### PR TITLE
[Pangolin] Deliver changes to mainline framework repo

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Page/Handlers/SectionObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Handlers/SectionObjectHandler.php
@@ -20,7 +20,7 @@ class SectionObjectHandler implements ObjectHandlerInterface
     const TYPE = 'section';
     const SUB_TYPE = 'element';
     const ELEMENT_TYPE_ATTR = 'type';
-    const ELEMENT_LOCATOR_ATTR = 'locator';
+    const ELEMENT_SELECTOR_ATTR = 'selector';
     const ELEMENT_TIMEOUT_ATTR = 'timeout';
     const ELEMENT_PARAMETERIZED = 'parameterized';
 
@@ -102,14 +102,14 @@ class SectionObjectHandler implements ObjectHandlerInterface
             $elements = [];
             foreach ($sectionData[SectionObjectHandler::SUB_TYPE] as $elementName => $elementData) {
                 $elementType = $elementData[SectionObjectHandler::ELEMENT_TYPE_ATTR];
-                $elementLocator = $elementData[SectionObjectHandler::ELEMENT_LOCATOR_ATTR];
+                $elementSelector = $elementData[SectionObjectHandler::ELEMENT_SELECTOR_ATTR];
                 $elementTimeout = $elementData[SectionObjectHandler::ELEMENT_TIMEOUT_ATTR] ?? null;
                 $elementParameterized = $elementData[SectionObjectHandler::ELEMENT_PARAMETERIZED] ?? false;
 
                 $elements[$elementName] = new ElementObject(
                     $elementName,
                     $elementType,
-                    $elementLocator,
+                    $elementSelector,
                     $elementTimeout,
                     $elementParameterized
                 );

--- a/src/Magento/FunctionalTestingFramework/Page/Objects/ElementObject.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Objects/ElementObject.php
@@ -31,7 +31,7 @@ class ElementObject
      *
      * @var string
      */
-    private $locator;
+    private $selector;
 
     /**
      * Section element timeout
@@ -51,15 +51,15 @@ class ElementObject
      * ElementObject constructor.
      * @param string $name
      * @param string $type
-     * @param string $locator
+     * @param string $selector
      * @param string $timeout
      * @param bool $parameterized
      */
-    public function __construct($name, $type, $locator, $timeout, $parameterized)
+    public function __construct($name, $type, $selector, $timeout, $parameterized)
     {
         $this->name = $name;
         $this->type = $type;
-        $this->locator = $locator;
+        $this->selector = $selector;
         $this->timeout = $timeout;
         $this->parameterized = $parameterized;
     }
@@ -85,13 +85,13 @@ class ElementObject
     }
 
     /**
-     * Getter for the locator of an element
+     * Getter for the selector of an element
      *
      * @return string
      */
-    public function getLocator()
+    public function getSelector()
     {
-        return $this->locator;
+        return $this->selector;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd
+++ b/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd
@@ -58,17 +58,10 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute type="notEmptyType" name="locator" use="required">
+            <xs:attribute type="notEmptyType" name="selector" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                        Locator of the element. Use %s for placeholders for variables.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute type="notEmptyType" name="locatorVariables" use="optional">
-                <xs:annotation>
-                    <xs:documentation>
-                        Optional variable names separated by "," which are used to substitute %s in locator attribute.
+                        Selector of the element.
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -323,7 +323,7 @@ class ActionObject
                         throw new TestReferenceException("Could not resolve entity reference " . $inputString);
                     }
                     $parameterized = $obj->getElement($objField)->isParameterized();
-                    $replacement = $obj->getElement($objField)->getLocator();
+                    $replacement = $obj->getElement($objField)->getSelector();
                     $this->timeout = $obj->getElement($objField)->getTimeout();
                     break;
                 case (get_class($obj) == EntityDataObject::class):


### PR DESCRIPTION
# Scope

### Story

* [MQE-376](https://jira.corp.magento.com/browse/MQE-376) [Framework] Resolve selector1 and selector2 replacements in ActionObject
* [MQE-353](https://jira.corp.magento.com/browse/MQE-353) [Generator] Remove double curly braces from parameterized data references.
* [MQE-292](https://jira.corp.magento.com/browse/MQE-292) Use "selector" name consistently instead of "locator"

### Related Pull Request
https://github.com/magento-pangolin/magento2ce/pull/8 - internal
https://github.com/magento/magento2ce/pull/1531 - mainline