### PR TITLE
MQE-565: User are not able to use <actionGroup> after updating the la…

### DIFF
--- a/dev/tests/verification/Resources/ActionGroupFunctionalCest.txt
+++ b/dev/tests/verification/Resources/ActionGroupFunctionalCest.txt
@@ -35,6 +35,14 @@ class ActionGroupFunctionalCest
 		$ReplacementPerson = DataObjectHandler::getInstance()->getObject("ReplacementPerson");
 		$this->createPersonParam = new DataPersistenceHandler($ReplacementPerson);
 		$this->createPersonParam->createEntity();
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
 	}
 
 	/**

--- a/dev/tests/verification/TestModule/Cest/ActionGroupFunctionalCest.xml
+++ b/dev/tests/verification/TestModule/Cest/ActionGroupFunctionalCest.xml
@@ -18,6 +18,7 @@
         </annotations>
         <before>
             <createData entity="ReplacementPerson" mergeKey="createPersonParam"/>
+            <actionGroup ref="FunctionalActionGroup" mergeKey="beforeGroup"/>
         </before>
         <test name="BasicActionGroupTest">
             <amOnPage mergeKey="step1" url="/someUrl"/>
@@ -67,5 +68,8 @@
                 <argument name="myArg" value="DefaultPerson"/>
             </actionGroup>
         </test>
+        <after>
+            <actionGroup ref="FunctionalActionGroup" mergeKey="afterGroup"/>
+        </after>
     </cest>
 </config>

--- a/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
@@ -69,18 +69,24 @@
     </xs:complexType>
     <xs:complexType name="hookType">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:group ref="actionTypeTags"/>
+            <xs:group ref="testTypeTags"/>
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="testType">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:group ref="actionTypeTags" />
+            <xs:group ref="testTypeTags" />
             <xs:element type="annotationsType" name="annotations" minOccurs="0"/>
-            <xs:element type="actions" name="actionGroup" minOccurs="0"/>
         </xs:choice>
         <xs:attribute type="xs:string" name="name"/>
         <xs:attribute type="xs:boolean" name="remove" default="false"/>
     </xs:complexType>
+    <xs:group name="testTypeTags">
+        <xs:choice>
+            <xs:group ref="actionTypeTags"/>
+            <xs:element type="actions" name="actionGroup" minOccurs="0"/>
+        </xs:choice>
+    </xs:group>
+
     <xs:group name="actionTypeTags">
         <xs:choice>
             <xs:group ref="dataOperationTags"/>


### PR DESCRIPTION
## Scope

### Bug
* [MQE-565](https://jira.corp.magento.com/browse/MQE-565) User are not able to use <actionGroup> after updating the latest composer.json
  * add new test actions type
  * updated verification tests to include check for actionGroup in hook type

