### PR TITLE
MQE-693: Characters "[" and "]" must be allowed in selector/url parameters

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
@@ -105,7 +105,7 @@ class ActionGroupObject
         // $regexPattern match on:   $matches[0] {{section.element(arg.field)}}
         // $matches[1] = section.element
         // $matches[2] = arg.field
-        $regexPattern = '/{{([\w.\[\]]+)\(*([\w.$\',\s]+)*\)*}}/';
+        $regexPattern = '/{{([\w.\[\]]+)\(*([\w.$\',\s\[\]]+)*\)*}}/';
 
         foreach ($this->parsedActions as $action) {
             $varAttributes = array_intersect($this->varAttributes, array_keys($action->getCustomActionAttributes()));


### PR DESCRIPTION
### Description
- added [ and ] to regex in actionGroupObject.

### Fixed Issues
1. magento/magento2-functional-testing-framework#693: [ActionGroup] Characters "[" and "]" must be allowed in selector/url parameters 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests