### PR TITLE
MQE-672: Generate failed hook with after hook

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Handlers/TestObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Handlers/TestObjectHandlerTest.php
@@ -24,7 +24,9 @@ use tests\unit\Util\TestDataArrayBuilder;
 class TestObjectHandlerTest extends TestCase
 {
     /**
-     * Basic test to validate array => test object conversion
+     * Basic test to validate array => test object conversion.
+     *
+     * @throws \Exception
      */
     public function testGetTestObject()
     {
@@ -57,14 +59,12 @@ class TestObjectHandlerTest extends TestCase
         $expectedBeforeHookObject = new TestHookObject(
             TestObjectExtractor::TEST_BEFORE_HOOK,
             $testDataArrayBuilder->testName,
-            [$expectedBeforeActionObject],
-            []
+            [$expectedBeforeActionObject]
         );
         $expectedAfterHookObject = new TestHookObject(
             TestObjectExtractor::TEST_AFTER_HOOK,
             $testDataArrayBuilder->testName,
-            [$expectedAfterActionObject],
-            []
+            [$expectedAfterActionObject]
         );
 
         $expectedTestActionObject = new ActionObject(
@@ -89,7 +89,9 @@ class TestObjectHandlerTest extends TestCase
     }
 
     /**
-     * Tests the function used to get a series of relevant tests by group
+     * Tests the function used to get a series of relevant tests by group.
+     *
+     * @throws \Exception
      */
     public function testGetTestsByGroup()
     {
@@ -120,6 +122,7 @@ class TestObjectHandlerTest extends TestCase
      * Function used to set mock for parser return and force init method to run between tests.
      *
      * @param array $data
+     * @throws \Exception
      */
     private function setMockParserOutput($data)
     {

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Handlers/TestObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Handlers/TestObjectHandlerTest.php
@@ -34,6 +34,7 @@ class TestObjectHandlerTest extends TestCase
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockData = $testDataArrayBuilder
             ->withAnnotations()
+            ->withFailedHook()
             ->withAfterHook()
             ->withBeforeHook()
             ->withTestActions()
@@ -56,6 +57,12 @@ class TestObjectHandlerTest extends TestCase
             $testDataArrayBuilder->testActionType,
             []
         );
+        $expectedFailedActionObject = new ActionObject(
+            $testDataArrayBuilder->testActionAfterName,
+            $testDataArrayBuilder->testActionType,
+            []
+        );
+
         $expectedBeforeHookObject = new TestHookObject(
             TestObjectExtractor::TEST_BEFORE_HOOK,
             $testDataArrayBuilder->testName,
@@ -65,6 +72,11 @@ class TestObjectHandlerTest extends TestCase
             TestObjectExtractor::TEST_AFTER_HOOK,
             $testDataArrayBuilder->testName,
             [$expectedAfterActionObject]
+        );
+        $expectedFailedHookObject = new TestHookObject(
+            TestObjectExtractor::TEST_FAILED_HOOK,
+            $testDataArrayBuilder->testName,
+            [$expectedFailedActionObject]
         );
 
         $expectedTestActionObject = new ActionObject(
@@ -80,7 +92,8 @@ class TestObjectHandlerTest extends TestCase
             ],
             [
                 TestObjectExtractor::TEST_BEFORE_HOOK => $expectedBeforeHookObject,
-                TestObjectExtractor::TEST_AFTER_HOOK => $expectedAfterHookObject
+                TestObjectExtractor::TEST_AFTER_HOOK => $expectedAfterHookObject,
+                TestObjectExtractor::TEST_FAILED_HOOK => $expectedFailedHookObject
             ],
             []
         );

--- a/dev/tests/unit/Util/TestDataArrayBuilder.php
+++ b/dev/tests/unit/Util/TestDataArrayBuilder.php
@@ -33,6 +33,13 @@ class TestDataArrayBuilder
     public $testActionAfterName = 'testActionAfter';
 
     /**
+     * Mock failed action name
+     *
+     * @var string
+     */
+    public $testActionFailedName = 'testActionFailed';
+
+    /**
      * Mock test action in test name
      *
      * @var string
@@ -60,6 +67,11 @@ class TestDataArrayBuilder
      * @var array
      */
     private $afterHook = [];
+
+    /**
+     * @var array
+     */
+    private $failedHook = [];
 
     /**
      * @var array
@@ -135,6 +147,27 @@ class TestDataArrayBuilder
     }
 
     /**
+     * Add a failed hook passed in by arg (or default if no arg)
+     *
+     * @param null $failedHook
+     * @return $this
+     */
+    public function withFailedHook($failedHook = null)
+    {
+        if ($failedHook == null) {
+            $this->failedHook = [$this->testActionFailedName => [
+                ActionObjectExtractor::NODE_NAME => $this->testActionType,
+                ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testActionFailedName
+
+            ]];
+        } else {
+            $this->failedHook = $failedHook;
+        }
+
+        return $this;
+    }
+
+    /**
      * Add test actions passed in by arg (or default if no arg)
      *
      * @param array $actions
@@ -167,7 +200,8 @@ class TestDataArrayBuilder
                 TestObjectExtractor::NAME => $this->testName,
                 TestObjectExtractor::TEST_ANNOTATIONS => $this->annotations,
                 TestObjectExtractor::TEST_BEFORE_HOOK => $this->beforeHook,
-                TestObjectExtractor::TEST_AFTER_HOOK => $this->afterHook
+                TestObjectExtractor::TEST_AFTER_HOOK => $this->afterHook,
+                TestObjectExtractor::TEST_FAILED_HOOK => $this->failedHook
             ],
             $this->testActions
         )];

--- a/dev/tests/verification/Resources/ActionGroupWithDataOverrideTest.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithDataOverrideTest.txt
@@ -25,9 +25,13 @@ class ActionGroupWithDataOverrideTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class ActionGroupWithDataOverrideTestCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/ActionGroupWithDataTest.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithDataTest.txt
@@ -25,9 +25,13 @@ class ActionGroupWithDataTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class ActionGroupWithDataTestCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/ActionGroupWithNoDefaultTest.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithNoDefaultTest.txt
@@ -25,9 +25,13 @@ class ActionGroupWithNoDefaultTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class ActionGroupWithNoDefaultTestCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/ActionGroupWithPersistedData.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithPersistedData.txt
@@ -25,9 +25,13 @@ class ActionGroupWithPersistedDataCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class ActionGroupWithPersistedDataCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/ActionGroupWithTopLevelPersistedData.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithTopLevelPersistedData.txt
@@ -25,9 +25,13 @@ class ActionGroupWithTopLevelPersistedDataCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class ActionGroupWithTopLevelPersistedDataCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/ArgumentWithSameNameAsElement.txt
+++ b/dev/tests/verification/Resources/ArgumentWithSameNameAsElement.txt
@@ -25,9 +25,13 @@ class ArgumentWithSameNameAsElementCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class ArgumentWithSameNameAsElementCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/AssertTest.txt
+++ b/dev/tests/verification/Resources/AssertTest.txt
@@ -21,9 +21,13 @@ class AssertTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createData1;
-	 */
+	  */
 	protected $createData1;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createData1");

--- a/dev/tests/verification/Resources/BasicActionGroupTest.txt
+++ b/dev/tests/verification/Resources/BasicActionGroupTest.txt
@@ -25,9 +25,13 @@ class BasicActionGroupTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");

--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -23,12 +23,29 @@ use Yandex\Allure\Adapter\Annotation\TestCaseId;
  */
 class BasicFunctionalTestCest
 {
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amOnPage("/beforeUrl");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->amOnPage("/afterUrl");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->amOnPage("/afterUrl");
 	}

--- a/dev/tests/verification/Resources/MergeFunctionalTest.txt
+++ b/dev/tests/verification/Resources/MergeFunctionalTest.txt
@@ -23,13 +23,30 @@ use Yandex\Allure\Adapter\Annotation\TestCaseId;
  */
 class MergeFunctionalTestCest
 {
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amOnPage("/beforeUrl");
 		$I->see("#before2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->amOnPage("/afterUrl1");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->amOnPage("/afterUrl1");
 	}

--- a/dev/tests/verification/Resources/MergedActionGroupTest.txt
+++ b/dev/tests/verification/Resources/MergedActionGroupTest.txt
@@ -25,9 +25,13 @@ class MergedActionGroupTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class MergedActionGroupTestCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/MultipleActionGroupsTest.txt
+++ b/dev/tests/verification/Resources/MultipleActionGroupsTest.txt
@@ -25,9 +25,13 @@ class MultipleActionGroupsTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createPersonParam;
-	 */
+	  */
 	protected $createPersonParam;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createPersonParam");
@@ -38,7 +42,21 @@ class MultipleActionGroupsTestCest
 		$I->fillField("#bar", "myData2");
 	}
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _after(AcceptanceTester $I)
+	{
+		$I->fillField("#foo", "myData1");
+		$I->fillField("#bar", "myData2");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
 	{
 		$I->fillField("#foo", "myData1");
 		$I->fillField("#bar", "myData2");

--- a/dev/tests/verification/Resources/PersistedReplacementTest.txt
+++ b/dev/tests/verification/Resources/PersistedReplacementTest.txt
@@ -21,9 +21,13 @@ class PersistedReplacementTestCest
 {
 	/**
 	  * @var DataPersistenceHandler $createData1;
-	 */
+	  */
 	protected $createData1;
 
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
 	public function _before(AcceptanceTester $I)
 	{
 		$I->amGoingTo("create entity that has the stepKey: createData1");

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -37,7 +37,7 @@ class TestObject
     private $annotations = [];
 
     /**
-     * Array which contains before and after actions to be excuted in scope of a single test.
+     * Array which contains before and after actions to be executed in scope of a single test.
      *
      * @var array
      */

--- a/src/Magento/FunctionalTestingFramework/Test/Util/TestObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/TestObjectExtractor.php
@@ -16,6 +16,7 @@ class TestObjectExtractor extends BaseObjectExtractor
     const TEST_ANNOTATIONS = 'annotations';
     const TEST_BEFORE_HOOK = 'before';
     const TEST_AFTER_HOOK = 'after';
+    const TEST_FAILED_HOOK = 'failed';
 
     /**
      * Action Object Extractor object
@@ -62,6 +63,7 @@ class TestObjectExtractor extends BaseObjectExtractor
      *
      * @param array $testData
      * @return TestObject
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\XmlException
      */
     public function extractTestData($testData)
     {
@@ -99,6 +101,15 @@ class TestObjectExtractor extends BaseObjectExtractor
             $testHooks[self::TEST_AFTER_HOOK] = $this->testHookObjectExtractor->extractHook(
                 $testData[self::NAME],
                 'after',
+                $testData[self::TEST_AFTER_HOOK]
+            );
+        }
+
+        // extract failed
+        if (array_key_exists(self::TEST_AFTER_HOOK, $testData)) {
+            $testHooks[self::TEST_FAILED_HOOK] = $this->testHookObjectExtractor->extractHook(
+                $testData[self::NAME],
+                'failed',
                 $testData[self::TEST_AFTER_HOOK]
             );
         }

--- a/src/Magento/FunctionalTestingFramework/Test/Util/TestObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/TestObjectExtractor.php
@@ -97,17 +97,15 @@ class TestObjectExtractor extends BaseObjectExtractor
             );
         }
 
-        // extract after
         if (array_key_exists(self::TEST_AFTER_HOOK, $testData)) {
+            // extract after
             $testHooks[self::TEST_AFTER_HOOK] = $this->testHookObjectExtractor->extractHook(
                 $testData[self::NAME],
                 'after',
                 $testData[self::TEST_AFTER_HOOK]
             );
-        }
 
-        // extract failed
-        if (array_key_exists(self::TEST_AFTER_HOOK, $testData)) {
+            // extract failed
             $testHooks[self::TEST_FAILED_HOOK] = $this->testHookObjectExtractor->extractHook(
                 $testData[self::NAME],
                 'failed',

--- a/src/Magento/FunctionalTestingFramework/Test/Util/TestObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/TestObjectExtractor.php
@@ -80,6 +80,7 @@ class TestObjectExtractor extends BaseObjectExtractor
             self::TEST_ANNOTATIONS,
             self::TEST_BEFORE_HOOK,
             self::TEST_AFTER_HOOK,
+            self::TEST_FAILED_HOOK,
             'filename'
         );
 
@@ -115,7 +116,6 @@ class TestObjectExtractor extends BaseObjectExtractor
         }
 
         // TODO extract filename info and store
-
         return new TestObject(
             $testData[self::NAME],
             $this->actionObjectExtractor->extractActions($testActions),

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -20,7 +20,6 @@ use Magento\FunctionalTestingFramework\Util\Filesystem\DirSetupUtil;
  */
 class TestGenerator
 {
-
     const REQUIRED_ENTITY_REFERENCE = 'createDataKey';
     const GENERATED_DIR = '_generated';
 
@@ -242,6 +241,7 @@ class TestGenerator
 
     /**
      * Generates Annotations PHP for given object, using given scope to determine indentation and additional output.
+     *
      * @param array $annotationsObject
      * @param boolean $isMethod
      * @return string
@@ -374,6 +374,7 @@ class TestGenerator
      * Since nearly half of all Codeception methods don't share the same signature I had to setup a massive Case
      * statement to handle each unique action. At the bottom of the case statement there is a generic function that can
      * construct the PHP string for nearly half of all Codeception actions.
+     *
      * @param array $stepsObject
      * @param array|bool $hookObject
      * @return string
@@ -1092,6 +1093,7 @@ class TestGenerator
 
     /**
      * Resolves Locator:: in given $attribute if it is found.
+     *
      * @param string $attribute
      * @return string
      */
@@ -1107,6 +1109,7 @@ class TestGenerator
     /**
      * Resolves replacement of $input$ and $$input$$ in given function, recursing and replacing individual arguments
      * Also determines if each argument requires any quote replacement.
+     *
      * @param string $inputString
      * @param array $args
      * @return string
@@ -1138,6 +1141,7 @@ class TestGenerator
 
     /**
      * Trims given $input of "{$var}" to $var if needed. Returns $input if format fails.
+     *
      * @param string $input
      * @return string
      */
@@ -1152,7 +1156,8 @@ class TestGenerator
     }
 
     /**
-     * Replaces all matches into given outputArg with. Variable scope determined by delimiter given
+     * Replaces all matches into given outputArg with. Variable scope determined by delimiter given.
+     *
      * @param array $matches
      * @param string &$outputArg
      * @param string $delimiter
@@ -1190,6 +1195,7 @@ class TestGenerator
     /**
      * Processes an argument for $data.key$ and determines if it needs quote breaks on either ends.
      * Returns an output with quote breaks and replacement already done.
+     *
      * @param string $match
      * @param string $argument
      * @param string $replacement
@@ -1207,7 +1213,8 @@ class TestGenerator
     }
 
     /**
-     * Wraps all args inside function give with double quotes. Uses regex to locate arguments of function
+     * Wraps all args inside function give with double quotes. Uses regex to locate arguments of function.
+     *
      * @param string $functionRegex
      * @param string $input
      * @return string
@@ -1244,6 +1251,7 @@ class TestGenerator
 
     /**
      * Performs str_replace on variable reference, dependent on delimiter and returns exploded array.
+     *
      * @param string $reference
      * @param string $delimiter
      * @return array
@@ -1256,6 +1264,7 @@ class TestGenerator
 
     /**
      * Creates a PHP string for the _before/_after methods if the Test contains an <before> or <after> block.
+     *
      * @param array $hookObjects
      * @return string
      * @throws TestReferenceException
@@ -1265,27 +1274,34 @@ class TestGenerator
     {
         $hooks = "";
         $createData = false;
+
         foreach ($hookObjects as $hookObject) {
             $type = $hookObject->getType();
             $dependencies = 'AcceptanceTester $I';
 
             foreach ($hookObject->getActions() as $step) {
+
                 if (($step->getType() == "createData")
                     || ($step->getType() == "updateData")
                     || ($step->getType() == "getData")
                 ) {
                     $hooks .= "\t/**\n";
                     $hooks .= sprintf("\t  * @var DataPersistenceHandler $%s;\n", $step->getStepKey());
-                    $hooks .= "\t */\n";
+                    $hooks .= "\t  */\n";
                     $hooks .= sprintf("\tprotected $%s;\n\n", $step->getStepKey());
                     $createData = true;
                 } elseif ($step->getType() == "entity") {
                     $hooks .= "\t/**\n";
                     $hooks .= sprintf("\t  * @var EntityDataObject $%s;\n", $step->getStepKey());
-                    $hooks .= "\t */\n";
+                    $hooks .= "\t  */\n";
                     $hooks .= sprintf("\tprotected $%s;\n\n", $step->getCustomActionAttributes()['name']);
                 }
             }
+
+            $hooks .= "\t/**\n";
+            $hooks .= "\t  * @param AcceptanceTester \$I\n";
+            $hooks .= "\t  * @throws \Exception\n";
+            $hooks .= "\t  */\n";
 
             try {
                 $steps = $this->generateStepsPhp(
@@ -1308,6 +1324,7 @@ class TestGenerator
     /**
      * Creates a PHP string based on a <test> block.
      * Concatenates the Test Annotations PHP and Test PHP for a single Test.
+     *
      * @param TestObject $test
      * @return string
      * @throws TestReferenceException
@@ -1338,6 +1355,7 @@ class TestGenerator
 
     /**
      * Detects uniqueness function calls on given attribute, and calls addUniquenessFunctionCall on matches.
+     *
      * @param string $input
      * @return string
      */


### PR DESCRIPTION
### Description
- Test Object Handler/Extractor now generates a _failed hook, with contents identical to _after hook.

### Fixed Issues
1. magento/magento2-functional-testing-framework#672: [SETUP/TEARDOWN] "_after" logic does not execute if the Test fails.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests