### PR TITLE
MQE-559: Use more descriptive assertion syntax

### DIFF
--- a/dev/tests/verification/Resources/AssertTest.txt
+++ b/dev/tests/verification/Resources/AssertTest.txt
@@ -82,7 +82,7 @@ class AssertTestCest
 		$I->assertTrue(true, "pass");
 		$I->comment("string type that use created data");
 		$I->assertStringStartsWith("D", $this->createData1->getCreatedDataByName('lastname') . ", " . $this->createData1->getCreatedDataByName('firstname'), "fail");
-		$I->assertStringStartsNotWith("W", $createData2->getCreatedDataByName('firstname') . " " . $createData2->getCreatedDataByName('lastname'), "pass");
+		$I->assertStringStartsNotWith("W", $createData2->getCreatedDataByName('firstname') . ", " . $createData2->getCreatedDataByName('lastname'), "pass");
 		$I->assertEquals($this->createData1->getCreatedDataByName('lastname'), $this->createData1->getCreatedDataByName('lastname'), "pass");
 		$I->comment("array type that use created data");
 		$I->assertArraySubset([$this->createData1->getCreatedDataByName('lastname'), $this->createData1->getCreatedDataByName('firstname')], [$this->createData1->getCreatedDataByName('lastname'), $this->createData1->getCreatedDataByName('firstname'), "1"], "pass");
@@ -101,7 +101,7 @@ class AssertTestCest
 		$I->fail($this->createData1->getCreatedDataByName('firstname') . " " . $this->createData1->getCreatedDataByName('lastname'));
 		$I->assertElementContainsAttribute("#username", "class", "admin__control-text");
 		$I->assertElementContainsAttribute("#username", "name", "login[username]");
-		$I->assertElementContainsAttribute("#username", "autofocus", "");
+		$I->assertElementContainsAttribute("#username", "autofocus", "true");
 		$I->assertElementContainsAttribute("#username", "data-validate", "{required:true}");
 		$I->assertElementContainsAttribute(".admin__menu-overlay", "style", "display: none;");
 		$I->assertElementContainsAttribute(".admin__menu-overlay", "border", "0");

--- a/dev/tests/verification/TestModule/Test/AssertTest.xml
+++ b/dev/tests/verification/TestModule/Test/AssertTest.xml
@@ -16,74 +16,221 @@
         <grabTextFrom selector=".copyright>span" stepKey="grabTextFrom1"/>
         <!-- asserts without variable replacement -->
         <comment stepKey="c1" userInput="asserts without variable replacement"/>
-        <assertArrayHasKey stepKey="assertArrayHasKey" expected="apple" expectedType="string" actual="['orange' => 2, 'apple' => 1]" actualType="const" message="pass"/>
-        <assertArrayNotHasKey stepKey="assertArrayNotHasKey" expected="kiwi" expectedType="string" actual="['orange' => 2, 'apple' => 1]" message="pass"/>
-        <assertArraySubset stepKey="assertArraySubset" expected="[1, 2]" actual="[1, 2, 3, 5]" message="pass"/>
-        <assertContains stepKey="assertContains" expected="ab" expectedType="string" actual="['item1' => 'a', 'item2' => 'ab']" message="pass"/>
-        <assertCount stepKey="assertCount" expected="2" expectedType="int" actual="['a', 'b']" message="pass"/>
-        <assertEmpty stepKey="assertEmpty" actual="[]" message="pass"/>
-        <assertEquals stepKey="assertEquals1" expected="text" expectedType="variable" actual="Copyright © 2013-2017 Magento, Inc. All rights reserved." actualType="string" message="pass"/>
-        <assertEquals stepKey="assertEquals2" expected="Copyright © 2013-2017 Magento, Inc. All rights reserved." expectedType="string" actual="text" actualType="variable" message="pass"/>
-        <assertFalse stepKey="assertFalse1" actual="0" actualType="bool" message="pass"/>
-        <assertFileNotExists stepKey="assertFileNotExists1" actual="/out.txt" actualType="string" message="pass"/>
-        <assertFileNotExists stepKey="assertFileNotExists2" actual="$text" actualType="variable" message="pass"/>
-        <assertGreaterOrEquals stepKey="assertGreaterOrEquals" expected="2" expectedType="int" actual="5" actualType="int" message="pass"/>
-        <assertGreaterThan stepKey="assertGreaterThan" expected="2" expectedType="int" actual="5" actualType="int" message="pass"/>
-        <assertGreaterThanOrEqual stepKey="assertGreaterThanOrEqual" expected="2" expectedType="int" actual="5" actualType="int" message="pass"/>
-        <assertInternalType stepKey="assertInternalType1" expected="string" expectedType="string" actual="xyz" actualType="string" message="pass"/>
-        <assertInternalType stepKey="assertInternalType2" expected="int" expectedType="string" actual="21" actualType="int" message="pass"/>
-        <assertInternalType stepKey="assertInternalType3" expected="string" expectedType="string" actual="$text" actualType="variable" message="pass"/>
-        <assertLessOrEquals stepKey="assertLessOrEquals" expected="5" expectedType="int" actual="2" actualType="int" message="pass"/>
-        <assertLessThan stepKey="assertLessThan" expected="5" expectedType="int" actual="2" actualType="int" message="pass"/>
-        <assertLessThanOrEqual stepKey="assertLessThanOrEqual" expected="5" expectedType="int" actual="2" actualType="int" message="pass"/>
-        <assertNotContains stepKey="assertNotContains1" expected="bc" expectedType="string" actual="['item1' => 'a', 'item2' => 'ab']" message="pass"/>
-        <assertNotContains stepKey="assertNotContains2" expected="bc" expectedType="string" actual="text" actualType="variable" message="pass"/>
-        <assertNotEmpty stepKey="assertNotEmpty1" actual="[1, 2]" message="pass"/>
-        <assertNotEmpty stepKey="assertNotEmpty2" actual="text" actualType="variable" message="pass"/>
-        <assertNotEquals stepKey="assertNotEquals" expected="2" expectedType="int" actual="5" actualType="int" message="pass" delta=""/>
-        <assertNotNull stepKey="assertNotNull1" actual="abc" actualType="string" message="pass"/>
-        <assertNotNull stepKey="assertNotNull2" actual="text" actualType="variable" message="pass"/>
-        <assertNotRegExp stepKey="assertNotRegExp" expected="/foo/" expectedType="string" actual="bar" actualType="string" message="pass"/>
-        <assertNotSame stepKey="assertNotSame" expected="log" expectedType="string" actual="tag" actualType="string" message="pass"/>
-        <assertRegExp stepKey="assertRegExp" expected="/foo/" expectedType="string" actual="foo" actualType="string" message="pass"/>
-        <assertSame stepKey="assertSame" expected="bar" expectedType="string" actual="bar" actualType="string" message="pass"/>
-        <assertStringStartsNotWith stepKey="assertStringStartsNotWith" expected="a" expectedType="string" actual="banana" actualType="string" message="pass"/>
-        <assertStringStartsWith stepKey="assertStringStartsWith" expected="a" expectedType="string" actual="apple" actualType="string" message="pass"/>
-        <assertTrue stepKey="assertTrue" actual="1" actualType="bool" message="pass"/>
+        <assertArrayHasKey stepKey="assertArrayHasKey" message="pass">
+            <expectedResult type="string">apple</expectedResult>
+            <actualResult type="const">['orange' => 2, 'apple' => 1]</actualResult>
+        </assertArrayHasKey>
+        <assertArrayNotHasKey stepKey="assertArrayNotHasKey" message="pass">
+            <expectedResult type="string">kiwi</expectedResult>
+            <actualResult type="const">['orange' => 2, 'apple' => 1]</actualResult>
+        </assertArrayNotHasKey>
+        <assertArraySubset stepKey="assertArraySubset" message="pass">
+            <expectedResult type="const">[1, 2]</expectedResult>
+            <actualResult type="const">[1, 2, 3, 5]</actualResult>
+        </assertArraySubset>
+        <assertContains stepKey="assertContains" message="pass">
+            <expectedResult type="string">ab</expectedResult>
+            <actualResult type="const">['item1' => 'a', 'item2' => 'ab']</actualResult>
+        </assertContains>
+        <assertCount stepKey="assertCount" message="pass">
+            <expectedResult type="int">2</expectedResult>
+            <actualResult type="const">['a', 'b']</actualResult>
+        </assertCount>
+        <assertEmpty stepKey="assertEmpty" message="pass">
+            <actualResult type="const">[]</actualResult>
+        </assertEmpty>
+        <assertEquals stepKey="assertEquals1" message="pass">
+            <expectedResult type="variable">text</expectedResult>
+            <actualResult type="string">Copyright © 2013-2017 Magento, Inc. All rights reserved.</actualResult>
+        </assertEquals>
+        <assertEquals stepKey="assertEquals2" message="pass">
+            <expectedResult type="string">Copyright © 2013-2017 Magento, Inc. All rights reserved.</expectedResult>
+            <actualResult type="variable">text</actualResult>
+        </assertEquals>
+        <assertFalse stepKey="assertFalse1" message="pass">
+            <actualResult type="bool">0</actualResult>
+        </assertFalse>
+        <assertFileNotExists stepKey="assertFileNotExists1" message="pass">
+            <actualResult type="string">/out.txt</actualResult>
+        </assertFileNotExists>
+        <assertFileNotExists stepKey="assertFileNotExists2" message="pass">
+            <actualResult type="variable">text</actualResult>
+        </assertFileNotExists>
+        <assertGreaterOrEquals stepKey="assertGreaterOrEquals" message="pass">
+            <expectedResult type="int">2</expectedResult>
+            <actualResult type="int">5</actualResult>
+        </assertGreaterOrEquals>
+        <assertGreaterThan stepKey="assertGreaterthan" message="pass">
+            <expectedResult type="int">2</expectedResult>
+            <actualResult type="int">5</actualResult>
+        </assertGreaterThan>
+        <assertGreaterThanOrEqual stepKey="assertGreaterThanOrEqual" message="pass">
+            <expectedResult type="int">2</expectedResult>
+            <actualResult type="int">5</actualResult>
+        </assertGreaterThanOrEqual>
+        <assertInternalType stepKey="assertInternalType1" message="pass">
+            <expectedResult type="string">string</expectedResult>
+            <actualResult type="string">xyz</actualResult>
+        </assertInternalType>
+        <assertInternalType stepKey="assertInternalType2" message="pass">
+            <expectedResult type="string">int</expectedResult>
+            <actualResult type="int">21</actualResult>
+        </assertInternalType>
+        <assertInternalType stepKey="assertInternalType3" message="pass">
+            <expectedResult type="string">string</expectedResult>
+            <actualResult type="variable">text</actualResult>
+        </assertInternalType>
+        <assertLessOrEquals stepKey="assertLessOrEquals" message="pass">
+            <expectedResult type="int">5</expectedResult>
+            <actualResult type="int">2</actualResult>
+        </assertLessOrEquals>
+        <assertLessThan stepKey="assertLessThan" message="pass">
+            <expectedResult type="int">5</expectedResult>
+            <actualResult type="int">2</actualResult>
+        </assertLessThan>
+        <assertLessThanOrEqual stepKey="assertLessThanOrEquals" message="pass">
+            <expectedResult type="int">5</expectedResult>
+            <actualResult type="int">2</actualResult>
+        </assertLessThanOrEqual>
+        <assertNotContains stepKey="assertNotContains1" message="pass">
+            <expectedResult type="string">bc</expectedResult>
+            <actualResult type="const">['item1' => 'a', 'item2' => 'ab']</actualResult>
+        </assertNotContains>
+        <assertNotContains stepKey="assertNotContains2" message="pass">
+            <expectedResult type="string">bc</expectedResult>
+            <actualResult type="variable">text</actualResult>
+        </assertNotContains>
+        <assertNotEmpty stepKey="assertNotEmpty1" message="pass">
+            <actualResult type="const">[1, 2]</actualResult>
+        </assertNotEmpty>
+        <assertNotEmpty stepKey="assertNotEmpty2" message="pass">
+            <actualResult type="variable">text</actualResult>
+        </assertNotEmpty>
+        <assertNotEquals stepKey="assertNotEquals" message="pass" delta="">
+            <expectedResult type="int">2</expectedResult>
+            <actualResult type="int">5</actualResult>
+        </assertNotEquals>
+        <assertNotNull stepKey="assertNotNull1" message="pass">
+            <actualResult type="string">abc</actualResult>
+        </assertNotNull>
+        <assertNotNull stepKey="assertNotNull2" message="pass">
+            <actualResult type="variable">text</actualResult>
+        </assertNotNull>
+        <assertNotRegExp stepKey="assertNotRegExp" message="pass">
+            <expectedResult type="string">/foo/</expectedResult>
+            <actualResult type="string">bar</actualResult>
+        </assertNotRegExp>
+        <assertNotSame stepKey="assertNotSame" message="pass">
+            <expectedResult type="string">log</expectedResult>
+            <actualResult type="string">tag</actualResult>
+        </assertNotSame>
+        <assertRegExp stepKey="assertRegExp" message="pass">
+            <expectedResult type="string">/foo/</expectedResult>
+            <actualResult type="string">foo</actualResult>
+        </assertRegExp>
+        <assertSame stepKey="assertSame" message="pass">
+            <expectedResult type="string">bar</expectedResult>
+            <actualResult type="string">bar</actualResult>
+        </assertSame>
+        <assertStringStartsNotWith stepKey="assertStringStartsNotWith" message="pass">
+            <expectedResult type="string">a</expectedResult>
+            <actualResult type="string">banana</actualResult>
+        </assertStringStartsNotWith>
+        <assertStringStartsWith stepKey="assertStringStartsWith" message="pass">
+            <expectedResult type="string">a</expectedResult>
+            <actualResult type="string">apple</actualResult>
+        </assertStringStartsWith>
+        <assertTrue stepKey="assertTrue" message="pass">
+            <actualResult type="bool">1</actualResult>
+        </assertTrue>
 
         <!-- string type that use created data -->
         <comment stepKey="c2" userInput="string type that use created data"/>
-        <assertStringStartsWith stepKey="assert1" expected="D" expectedType="string" actual="$$createData1.lastname$$, $$createData1.firstname$$" actualType="string" message="fail"/>
-        <assertStringStartsNotWith stepKey="assert2" expected="W" expectedType="string" actual="$createData2.firstname$ $createData2.lastname$" actualType="string" message="pass"/>
-        <assertEquals stepKey="assert5" expected="$$createData1.lastname$$" expectedType="string" actual="$$createData1.lastname$$" actualType="string" message="pass"/>
+        <assertStringStartsWith stepKey="assert1" message="fail">
+            <expectedResult type="string">D</expectedResult>
+            <actualResult type="string">$$createData1.lastname$$, $$createData1.firstname$$</actualResult>
+        </assertStringStartsWith>
+        <assertStringStartsNotWith stepKey="assert2" message="pass">
+            <expectedResult type="string">W</expectedResult>
+            <actualResult type="string">$createData2.firstname$, $createData2.lastname$</actualResult>
+        </assertStringStartsNotWith>
+        <assertEquals stepKey="assert5" message="pass">
+            <expectedResult type="string">$$createData1.lastname$$</expectedResult>
+            <actualResult type="string">$$createData1.lastname$$</actualResult>
+        </assertEquals>
 
         <!-- array type that use created data -->
         <comment stepKey="c3" userInput="array type that use created data"/>
-        <assertArraySubset stepKey="assert9" expected="[$$createData1.lastname$$, $$createData1.firstname$$]" expectedType="array" actual="[$$createData1.lastname$$, $$createData1.firstname$$, 1]" actualType="array" message="pass"/>
-        <assertArraySubset stepKey="assert10" expected="[$createData2.firstname$, $createData2.lastname$]" expectedType="array" actual="[$createData2.firstname$, $createData2.lastname$, 1]" actualType="array" message="pass"/>
-        <assertArrayHasKey stepKey="assert3" expected="lastname" expectedType="string" actual="['lastname' => $$createData1.lastname$$, 'firstname' => $$createData1.firstname$$]" actualType="array" message="pass"/>
-        <assertArrayHasKey stepKey="assert4" expected="lastname" expectedType="string" actual="['lastname' => $createData2.lastname$, 'firstname' => $createData2.firstname$]" actualType="array" message="pass"/>
+        <assertArraySubset stepKey="assert9" message="pass">
+            <expectedResult type="array">[$$createData1.lastname$$, $$createData1.firstname$$]</expectedResult>
+            <actualResult type="array">[$$createData1.lastname$$, $$createData1.firstname$$, 1]</actualResult>
+        </assertArraySubset>
+        <assertArraySubset stepKey="assert10" message="pass">
+            <expectedResult type="array">[$createData2.firstname$, $createData2.lastname$]</expectedResult>
+            <actualResult type="array">[$createData2.firstname$, $createData2.lastname$, 1]</actualResult>
+        </assertArraySubset>
+        <assertArrayHasKey stepKey="assert3" message="pass">
+            <expectedResult type="string">lastname</expectedResult>
+            <actualResult type="array">['lastname' => $$createData1.lastname$$, 'firstname' => $$createData1.firstname$$]</actualResult>
+        </assertArrayHasKey>
+        <assertArrayHasKey stepKey="assert4" message="pass">
+            <expectedResult type="string">lastname</expectedResult>
+            <actualResult type="array">['lastname' => $createData2.lastname$, 'firstname' => $createData2.firstname$]</actualResult>
+        </assertArrayHasKey>
 
         <!-- this section can only be generated and cannot run -->
-        <assertInstanceOf stepKey="assertInstanceOf" expected="User::class" actual="text" actualType="variable" message="pass"/>
-        <assertNotInstanceOf stepKey="assertNotInstanceOf" expected="User::class" actual="21" actualType="int" message="pass"/>
-        <assertFileExists stepKey="assertFileExists2" actual="text" actualType="variable" message="pass"/>
-        <assertFileExists stepKey="assert6" actual="AssertCest.php" actualType="string" message="pass"/>
-        <assertIsEmpty stepKey="assertIsEmpty" actual="text" actualType="variable" message="pass"/>
-        <assertNull stepKey="assertNull" actual="text" actualType="variable" message="pass"/>
-        <expectException stepKey="expectException" expected="new MyException('exception msg')" actual="function() {$this->doSomethingBad();}"/>
+        <assertInstanceOf stepKey="assertInstanceOf" message="pass">
+            <expectedResult type="const">User::class</expectedResult>
+            <actualResult type="variable">text</actualResult>
+        </assertInstanceOf>
+        <assertNotInstanceOf stepKey="assertNotInstanceOf" message="pass">
+            <expectedResult type="const">User::class</expectedResult>
+            <actualResult type="int">21</actualResult>
+        </assertNotInstanceOf>
+        <assertFileExists stepKey="assertFileExists2" message="pass">
+            <actualResult type="variable">text</actualResult>
+        </assertFileExists>
+        <assertFileExists stepKey="assertFileExists3" message="pass">
+            <actualResult type="string">AssertCest.php</actualResult>
+        </assertFileExists>
+        <assertIsEmpty stepKey="assertIsEmpty" message="pass">
+            <actualResult type="variable">text</actualResult>
+        </assertIsEmpty>
+        <assertNull stepKey="assertNull" message="pass">
+            <actualResult type="variable">text</actualResult>
+        </assertNull>
+        <expectException stepKey="expectException">
+            <expectedResult type="const">new MyException('exception msg')</expectedResult>
+            <actualResult type="const">function() {$this->doSomethingBad();}</actualResult>
+        </expectException>
         <fail stepKey="fail" message="fail"/>
         <fail stepKey="assert7" message="$createData2.firstname$ $createData2.lastname$"/>
         <fail stepKey="assert8" message="$$createData1.firstname$$ $$createData1.lastname$$"/>
 
         <!-- assertElementContainsAttribute examples -->
-        <assertElementContainsAttribute selector="#username" attribute="class" expectedValue="admin__control-text" stepKey="assertElementContainsAttribute1"/>
-        <assertElementContainsAttribute selector="#username" attribute="name" expectedValue="login[username]" stepKey="assertElementContainsAttribute2"/>
-        <assertElementContainsAttribute selector="#username" attribute="autofocus" expectedValue="" stepKey="assertElementContainsAttribute3"/>
-        <assertElementContainsAttribute selector="#username" attribute="data-validate" expectedValue="{required:true}" stepKey="assertElementContainsAttribute4"/>
-        <assertElementContainsAttribute selector=".admin__menu-overlay" attribute="style" expectedValue="display: none;" stepKey="assertElementContainsAttribute5"/>
-        <assertElementContainsAttribute selector=".admin__menu-overlay" attribute="border" expectedValue="0" stepKey="assertElementContainsAttribute6"/>
-        <assertElementContainsAttribute selector="#username" attribute="value" expectedValue="$createData2.firstname$" stepKey="assertElementContainsAttribute7"/>
-        <assertElementContainsAttribute selector="#username" attribute="value" expectedValue="$$createData1.firstname$$" stepKey="assertElementContainsAttribute8"/>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute1" selector="#username" attribute="class">
+            <expectedResult type="const">admin__control-text</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute2" selector="#username" attribute="name">
+            <expectedResult type="const">login[username]</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute3" selector="#username" attribute="autofocus">
+            <expectedResult type="const">true</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute4" selector="#username" attribute="data-validate">
+            <expectedResult type="const">{required:true}</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute5" selector=".admin__menu-overlay" attribute="style">
+            <expectedResult type="const">display: none;</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute6" selector=".admin__menu-overlay" attribute="border">
+            <expectedResult type="const">0</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute7" selector="#username" attribute="value">
+            <expectedResult type="const">$createData2.firstname$</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertElementContainsAttribute8" selector="#username" attribute="value">
+            <expectedResult type="const">$$createData1.firstname$$</expectedResult>
+        </assertElementContainsAttribute>
     </test>
 </tests>

--- a/dev/tests/verification/TestModule/Test/AssertTest.xml
+++ b/dev/tests/verification/TestModule/Test/AssertTest.xml
@@ -209,22 +209,22 @@
 
         <!-- assertElementContainsAttribute examples -->
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute1" selector="#username" attribute="class">
-            <expectedResult type="const">admin__control-text</expectedResult>
+            <expectedResult type="string">admin__control-text</expectedResult>
         </assertElementContainsAttribute>
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute2" selector="#username" attribute="name">
-            <expectedResult type="const">login[username]</expectedResult>
+            <expectedResult type="string">login[username]</expectedResult>
         </assertElementContainsAttribute>
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute3" selector="#username" attribute="autofocus">
-            <expectedResult type="const">true</expectedResult>
+            <expectedResult type="string">true</expectedResult>
         </assertElementContainsAttribute>
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute4" selector="#username" attribute="data-validate">
-            <expectedResult type="const">{required:true}</expectedResult>
+            <expectedResult type="string">{required:true}</expectedResult>
         </assertElementContainsAttribute>
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute5" selector=".admin__menu-overlay" attribute="style">
-            <expectedResult type="const">display: none;</expectedResult>
+            <expectedResult type="string">display: none;</expectedResult>
         </assertElementContainsAttribute>
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute6" selector=".admin__menu-overlay" attribute="border">
-            <expectedResult type="const">0</expectedResult>
+            <expectedResult type="string">0</expectedResult>
         </assertElementContainsAttribute>
         <assertElementContainsAttribute stepKey="assertElementContainsAttribute7" selector="#username" attribute="value">
             <expectedResult type="const">$createData2.firstname$</expectedResult>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -204,7 +204,8 @@ class ActionObject
     }
 
     /**
-     * Trims actionAttributes and flattens expectedResult/actualResults, if necessary.
+     * Flattens expectedResult/actualResults nested elements, if necessary.
+     * e.g. expectedResults[] -> ["expectedType" => "string", "expected" => "value"]
      * Warns user if they are using old Assertion syntax.
      *
      * @return void
@@ -213,7 +214,10 @@ class ActionObject
     {
         $actionAttributeKeys = array_keys($this->actionAttributes);
 
-        /** MQE-683 DEPRECATE OLD METHOD HERE */
+        /** MQE-683 DEPRECATE OLD METHOD HERE
+         * Checks if action has any of the old, single line attributes
+         * Throws a warning and returns, assuming old syntax is used.
+         */
         $oldAttributes = array_intersect($actionAttributeKeys, ActionObject::OLD_ASSERTION_ATTRIBUTES);
         if (!empty($oldAttributes)) {
             // @codingStandardsIgnoreStart
@@ -229,7 +233,7 @@ class ActionObject
             return;
         }
 
-        // Flatten subArray into resolvedCustomAttributes as "prefixType" = type, "prefix" = value
+        // Flatten nested Elements's type and value into key=>value entries
         foreach ($this->actionAttributes as $key => $subAttributes) {
             if (in_array($key, $relevantKeys)) {
                 $prefix = ActionObject::ASSERTION_ATTRIBUTES[$key];

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -21,6 +21,9 @@ class ActionObject
 {
     const DATA_ENABLED_ATTRIBUTES = ["userInput", "parameterArray", "expected", "actual"];
     const SELECTOR_ENABLED_ATTRIBUTES = ['selector', 'dependentSelector', "selector1", "selector2", "function"];
+    const ASSERTION_ATTRIBUTES = ["expectedResult" => "expected", "actualResult" => "actual"];
+    const ASSERTION_TYPE_ATTRIBUTE = "type";
+    const ASSERTION_VALUE_ATTRIBUTE = "value";
     const EXTERNAL_URL_AREA_INVALID_ACTIONS = ['amOnPage'];
     const MERGE_ACTION_ORDER_AFTER = 'after';
     const MERGE_ACTION_ORDER_BEFORE = 'before';
@@ -196,6 +199,32 @@ class ActionObject
             $this->resolveSelectorReferenceAndTimeout();
             $this->resolveUrlReference();
             $this->resolveDataInputReferences();
+        }
+    }
+
+    /**
+     * Trims actionAttributes and flattens expectedResult/actualResults, if necessary.
+     *
+     * @return void
+     */
+    public function trimAssertionAttributes()
+    {
+        $actionAttributeKeys = array_keys($this->actionAttributes);
+        $relevantKeys = array_keys(ActionObject::ASSERTION_ATTRIBUTES);
+        $relevantAssertionAttributes = array_intersect($actionAttributeKeys, $relevantKeys);
+
+        if (empty($relevantAssertionAttributes)) {
+            return;
+        }
+
+        // Flatten subArray into resolvedCustomAttributes as "prefixType" = given type, "prefixValue" = given value
+        foreach ($this->actionAttributes as $key => $subAttributes) {
+            $prefix = ActionObject::ASSERTION_ATTRIBUTES[$key];
+            $this->resolvedCustomAttributes[$prefix . ucfirst(ActionObject::ASSERTION_TYPE_ATTRIBUTE)] =
+                $subAttributes[ActionObject::ASSERTION_TYPE_ATTRIBUTE];
+            $this->resolvedCustomAttributes[$prefix . ucfirst(ActionObject::ASSERTION_VALUE_ATTRIBUTE)] =
+                $subAttributes[ActionObject::ASSERTION_VALUE_ATTRIBUTE];
+            unset($this->actionAttributes[$key]);
         }
     }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionMergeUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionMergeUtil.php
@@ -166,6 +166,7 @@ class ActionMergeUtil
     {
         foreach ($parsedSteps as $parsedStep) {
             $parsedStep->resolveReferences();
+            $parsedStep->trimAssertionAttributes();
             if ($parsedStep->getLinkedAction()) {
                 $this->stepsToMerge[$parsedStep->getStepKey()] = $parsedStep;
             } else {

--- a/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
@@ -1435,10 +1435,7 @@
         <xs:sequence>
             <xs:element name="expectedResult" type="expectedResultType"/>
         </xs:sequence>
-        <xs:attribute type="xs:string" name="expected" use="optional"/>
-        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
-        <xs:attribute type="xs:string" name="actual" use="optional"/>
-        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="expectedValue" use="optional"/>
         <xs:attribute type="xs:string" name="stepKey" use="required"/>
         <xs:attribute type="xs:string" name="selector" use="required"/>
         <xs:attribute type="xs:string" name="attribute" use="required"/>

--- a/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
@@ -184,44 +184,38 @@
                         maxOccurs="unbounded"/>
             <xs:element type="waitForPageLoadType" name="waitForPageLoad" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="waitForTextType" name="waitForText" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertArrayHasKeyType" name="assertArrayHasKey" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertArrayNotHasKeyType" name="assertArrayNotHasKey" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element type="assertArraySubsetType" name="assertArraySubset" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertContainsType" name="assertContains" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertCountType" name="assertCount" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertEmptyType" name="assertEmpty" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertEqualsType" name="assertEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertFalseType" name="assertFalse" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertFileExistsType" name="assertFileExists" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertFileNotExistsType" name="assertFileNotExists" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertGreaterOrEqualsType" name="assertGreaterOrEquals" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element type="assertGreaterThanType" name="assertGreaterThan" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertGreaterThanOrEqualType" name="assertGreaterThanOrEqual" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element type="assertInstanceOfType" name="assertInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertInternalTypeType" name="assertInternalType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertIsEmptyType" name="assertIsEmpty" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertLessOrEqualsType" name="assertLessOrEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertLessThanType" name="assertLessThan" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertLessThanOrEqualType" name="assertLessThanOrEqual" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element type="assertNotContainsType" name="assertNotContains" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNotEmptyType" name="assertNotEmpty" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNotEqualsType" name="assertNotEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNotInstanceOfType" name="assertNotInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNotNullType" name="assertNotNull" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNotRegExpType" name="assertNotRegExp" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNotSameType" name="assertNotSame" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertNullType" name="assertNull" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertRegExpType" name="assertRegExp" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertSameType" name="assertSame" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertStringStartsNotWithType" name="assertStringStartsNotWith" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element type="assertStringStartsWithType" name="assertStringStartsWith" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element type="assertTrueType" name="assertTrue" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertArrayHasKey" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertArrayNotHasKey" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertArraySubset" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertContains" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertCount" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertEmpty" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertFalse" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertFileExists" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertFileNotExists" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertGreaterOrEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertGreaterThan" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertGreaterThanOrEqual" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertInternalType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertIsEmpty" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertLessOrEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertLessThan" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertLessThanOrEqual" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotContains" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotEmpty" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotNull" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotRegExp" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNotSame" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertNull" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertRegExp" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertSame" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertStringStartsNotWith" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertStringStartsWith" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertionType" name="assertTrue" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="expectExceptionType" name="expectException" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="failType" name="fail" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
@@ -1410,439 +1404,6 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
-    <xs:complexType name="assertArrayHasKeyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertArrayNotHasKeyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertArraySubsetType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:boolean" name="strict"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertContainsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertCountType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertEmptyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertEqualsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="delta"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertFalseType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertFileExistsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertFileNotExistsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertGreaterOrEqualsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertGreaterThanType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertGreaterThanOrEqualType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertInstanceOfType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertInternalTypeType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertIsEmptyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertLessOrEqualsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertLessThanType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertLessThanOrEqualType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotContainsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotEmptyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotEqualsType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="delta"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotInstanceOfType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotNullType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotRegExpType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNotSameType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertNullType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertRegExpType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertSameType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertStringStartsNotWithType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertStringStartsWithType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertTrueType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="message"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
     <xs:complexType name="expectExceptionType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -1877,4 +1438,25 @@
             <xs:enumeration value="const"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="assertionType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="expectedResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="expectedResultType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute type="assertEnum" name="type" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="actualResultType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute type="assertEnum" name="type" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 </xs:schema>

--- a/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd
@@ -184,38 +184,38 @@
                         maxOccurs="unbounded"/>
             <xs:element type="waitForPageLoadType" name="waitForPageLoad" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="waitForTextType" name="waitForText" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertArrayHasKey" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertArrayNotHasKey" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertArraySubset" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertContains" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertCount" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertEmpty" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertFalse" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertFileExists" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertFileNotExists" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertGreaterOrEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertGreaterThan" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertGreaterThanOrEqual" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertInternalType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertIsEmpty" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertLessOrEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertLessThan" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertLessThanOrEqual" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotContains" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotEmpty" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotEquals" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotNull" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotRegExp" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNotSame" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertNull" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertRegExp" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertSame" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertStringStartsNotWith" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertStringStartsWith" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element type="assertionType" name="assertTrue" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertArrayHasKeyType" name="assertArrayHasKey" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertArrayNotHasKeyType" name="assertArrayNotHasKey" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertArraySubsetType" name="assertArraySubset" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertContainsType" name="assertContains" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertCountType" name="assertCount" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertEmptyType" name="assertEmpty" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertEqualsType" name="assertEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertFalseType" name="assertFalse" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertFileExistsType" name="assertFileExists" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertFileNotExistsType" name="assertFileNotExists" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertGreaterOrEqualsType" name="assertGreaterOrEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertGreaterThanType" name="assertGreaterThan" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertGreaterThanOrEqualType" name="assertGreaterThanOrEqual" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertInstanceOfType" name="assertInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertInternalTypeType" name="assertInternalType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertIsEmptyType" name="assertIsEmpty" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertLessOrEqualsType" name="assertLessOrEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertLessThanType" name="assertLessThan" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertLessThanOrEqualType" name="assertLessThanOrEqual" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotContainsType" name="assertNotContains" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotEmptyType" name="assertNotEmpty" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotEqualsType" name="assertNotEquals" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotInstanceOfType" name="assertNotInstanceOf" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotNullType" name="assertNotNull" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotRegExpType" name="assertNotRegExp" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNotSameType" name="assertNotSame" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertNullType" name="assertNull" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertRegExpType" name="assertRegExp" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertSameType" name="assertSame" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertStringStartsNotWithType" name="assertStringStartsNotWith" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertStringStartsWithType" name="assertStringStartsWith" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="assertTrueType" name="assertTrue" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="expectExceptionType" name="expectException" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="failType" name="fail" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
@@ -300,18 +300,6 @@
             <xs:extension base="xs:string">
                 <xs:attribute type="xs:string" name="selector" use="required"/>
                 <xs:attribute type="xs:string" name="userInput"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="assertElementContainsAttributeType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="selector" use="required"/>
-                <xs:attribute type="xs:string" name="expectedValue"/>
-                <xs:attribute type="xs:string" name="attribute" use="required"/>
                 <xs:attribute type="xs:string" name="stepKey" use="required"/>
                 <xs:attribute type="xs:string" name="before"/>
                 <xs:attribute type="xs:string" name="after"/>
@@ -1404,19 +1392,6 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
-    <xs:complexType name="expectExceptionType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute type="xs:string" name="expected" use="required"/>
-                <xs:attribute type="assertEnum" name="expectedType" default="const"/>
-                <xs:attribute type="xs:string" name="actual" use="required"/>
-                <xs:attribute type="assertEnum" name="actualType" default="const"/>
-                <xs:attribute type="xs:string" name="stepKey" use="required"/>
-                <xs:attribute type="xs:string" name="before"/>
-                <xs:attribute type="xs:string" name="after"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
     <xs:complexType name="failType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -1438,13 +1413,494 @@
             <xs:enumeration value="const"/>
         </xs:restriction>
     </xs:simpleType>
+    <!-- ASSERTION TYPES -->
+    <!-- REMOVE expected/expectedType and actual/actualType in MQE-683-->
     <xs:complexType name="assertionType">
         <xs:sequence>
             <xs:element name="expectedResult" type="expectedResultType"/>
-            <xs:element name="actualResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
         </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
         <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="delta" use="optional"/>
+        <xs:attribute type="xs:boolean" name="strict" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
     </xs:complexType>
+    <xs:complexType name="assertElementContainsAttributeType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="selector" use="required"/>
+        <xs:attribute type="xs:string" name="attribute" use="required"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertArrayHasKeyType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertArrayNotHasKeyType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertArraySubsetType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:boolean" name="strict" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertContainsType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertCountType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertEmptyType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertEqualsType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="delta" use="optional"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertFalseType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertFileExistsType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertFileNotExistsType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertGreaterOrEqualsType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertGreaterThanType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertGreaterThanOrEqualType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertInstanceOfType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertInternalTypeType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertIsEmptyType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertLessOrEqualsType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertLessThanType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertLessThanOrEqualType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotContainsType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotEmptyType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotEqualsType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="delta" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotInstanceOfType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotNullType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotRegExpType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNotSameType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertNullType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertRegExpType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertSameType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertStringStartsNotWithType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertStringStartsWithType">
+        <xs:sequence>
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="assertTrueType">
+        <xs:sequence>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="message" use="optional"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <xs:complexType name="expectExceptionType">
+        <xs:sequence minOccurs="0">
+            <xs:element name="expectedResult" type="expectedResultType"/>
+            <xs:element name="actualResult" type="actualResultType"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="expected" use="optional"/>
+        <xs:attribute type="assertEnum" name="expectedType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="actual" use="optional"/>
+        <xs:attribute type="assertEnum" name="actualType" default="const" use="optional"/>
+        <xs:attribute type="xs:string" name="stepKey" use="required"/>
+        <xs:attribute type="xs:string" name="before"/>
+        <xs:attribute type="xs:string" name="after"/>
+    </xs:complexType>
+    <!-- END ASSERT TYPES -->
     <xs:complexType name="expectedResultType">
         <xs:simpleContent>
             <xs:extension base="xs:string">

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -436,21 +436,21 @@ class TestGenerator
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['userInput']);
             } elseif (isset($customActionAttributes['url'])) {
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['url']);
-            } elseif (isset($customActionAttributes['expectedValue'])) {
-                $input = $this->addUniquenessFunctionCall($customActionAttributes['expectedValue']);
+            } elseif (isset($customActionAttributes['expected'])) {
+                $input = $this->addUniquenessFunctionCall($customActionAttributes['expected']);
             } elseif (isset($customActionAttributes['regex'])) {
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['regex']);
             }
 
-            if (isset($customActionAttributes['expectedValue'])) {
+            if (isset($customActionAttributes['expected'])) {
                 $assertExpected = $this->resolveValueByType(
-                    $customActionAttributes['expectedValue'],
+                    $customActionAttributes['expected'],
                     isset($customActionAttributes['expectedType']) ? $customActionAttributes['expectedType'] : null
                 );
             }
-            if (isset($customActionAttributes['actualValue'])) {
+            if (isset($customActionAttributes['actual'])) {
                 $assertActual = $this->resolveValueByType(
-                    $customActionAttributes['actualValue'],
+                    $customActionAttributes['actual'],
                     isset($customActionAttributes['actualType']) ? $customActionAttributes['actualType'] : null
                 );
             }

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -442,15 +442,15 @@ class TestGenerator
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['regex']);
             }
 
-            if (isset($customActionAttributes['expected'])) {
+            if (isset($customActionAttributes['expectedValue'])) {
                 $assertExpected = $this->resolveValueByType(
-                    $customActionAttributes['expected'],
+                    $customActionAttributes['expectedValue'],
                     isset($customActionAttributes['expectedType']) ? $customActionAttributes['expectedType'] : null
                 );
             }
-            if (isset($customActionAttributes['actual'])) {
+            if (isset($customActionAttributes['actualValue'])) {
                 $assertActual = $this->resolveValueByType(
-                    $customActionAttributes['actual'],
+                    $customActionAttributes['actualValue'],
                     isset($customActionAttributes['actualType']) ? $customActionAttributes['actualType'] : null
                 );
             }

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -436,8 +436,9 @@ class TestGenerator
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['userInput']);
             } elseif (isset($customActionAttributes['url'])) {
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['url']);
-            } elseif (isset($customActionAttributes['expected'])) {
-                $input = $this->addUniquenessFunctionCall($customActionAttributes['expected']);
+            } elseif (isset($customActionAttributes['expectedValue'])) {
+                //For old Assert backwards Compatibility, remove when deprecating
+                $assertExpected = $this->addUniquenessFunctionCall($customActionAttributes['expectedValue']);
             } elseif (isset($customActionAttributes['regex'])) {
                 $input = $this->addUniquenessFunctionCall($customActionAttributes['regex']);
             }
@@ -1019,8 +1020,8 @@ class TestGenerator
                     break;
                 case "assertElementContainsAttribute":
                     // If a blank string or null is passed in we need to pass a blank string to the function.
-                    if (empty($input)) {
-                        $input = '""';
+                    if (empty($assertExpected)) {
+                        $assertExpected = '""';
                     }
 
                     $testSteps .= $this->wrapFunctionCall(
@@ -1028,7 +1029,7 @@ class TestGenerator
                         $actionName,
                         $selector,
                         $this->wrapWithDoubleQuotes($attribute),
-                        $input
+                        $assertExpected
                     );
                     break;
                 case "assertEmpty":


### PR DESCRIPTION
### Description
Schema now uses the nested assertion action syntax. Old syntax (single line) is still supported, but documentation has been changed to point users to use the new syntax.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#MQE-559: Use more descriptive assertion syntax

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests