### PR TITLE
MQE-732: Unable to call action group with arguments in "after" block

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -244,6 +244,8 @@
                 <item name="/tests/test/before/getData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/after/getData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/actionGroup/argument" xsi:type="string">name</item>
+                <item name="/tests/test/before/actionGroup/argument" xsi:type="string">name</item>
+                <item name="/tests/test/after/actionGroup/argument" xsi:type="string">name</item>
             </argument>
             <argument name="numericArrays" xsi:type="array">
                 <item name="/tests/test/annotations/features" xsi:type="string">/tests/test/annotations/features</item>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -244,8 +244,7 @@
                 <item name="/tests/test/before/getData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/after/getData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/actionGroup/argument" xsi:type="string">name</item>
-                <item name="/tests/test/before/actionGroup/argument" xsi:type="string">name</item>
-                <item name="/tests/test/after/actionGroup/argument" xsi:type="string">name</item>
+                <item name="/tests/test/(before|after)/actionGroup/argument" xsi:type="string">name</item>
             </argument>
             <argument name="numericArrays" xsi:type="array">
                 <item name="/tests/test/annotations/features" xsi:type="string">/tests/test/annotations/features</item>


### PR DESCRIPTION
### Description
di.xml didn't have configuration for node path `<test><before|after><actionGroup><argument>`, which was causing the failure.

### Fixed Issues
1. magento/magento2-functional-testing-framework#<732>: Unable to call action group with arguments in "after" block

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests