### PR TITLE
MQE-685: References to ENV file must be done at test run-time

### DIFF
--- a/dev/tests/verification/Resources/PageReplacementTest.txt
+++ b/dev/tests/verification/Resources/PageReplacementTest.txt
@@ -39,8 +39,8 @@ class PageReplacementTestCest
 		$I->amOnPage("/John/StringLiteral2.html");
 		$I->amOnPage("/John/" . $datakey->getCreatedDataByName('firstname') . ".html");
 		$I->amOnPage("/" . $datakey->getCreatedDataByName('firstname') . "/StringLiteral2.html");
-		$I->amOnPage("/" . getenv("MAGENTO_BASE_URL") . "//backend");
-		$I->amOnPage("/" . getenv("MAGENTO_BASE_URL") . "//StringLiteral/page.html");
+		$I->amOnPage("/" . getenv("BACKEND_NAME") . "//backend");
+		$I->amOnPage("/" . getenv("BACKEND_NAME") . "//StringLiteral/page.html");
 		$I->amOnUrl("http://myFullUrl.com/");
 	}
 }

--- a/dev/tests/verification/Resources/PageReplacementTest.txt
+++ b/dev/tests/verification/Resources/PageReplacementTest.txt
@@ -39,8 +39,8 @@ class PageReplacementTestCest
 		$I->amOnPage("/John/StringLiteral2.html");
 		$I->amOnPage("/John/" . $datakey->getCreatedDataByName('firstname') . ".html");
 		$I->amOnPage("/" . $datakey->getCreatedDataByName('firstname') . "/StringLiteral2.html");
-		$I->amOnPage("/" . getenv("BACKEND_NAME") . "//backend");
-		$I->amOnPage("/" . getenv("BACKEND_NAME") . "//StringLiteral/page.html");
+		$I->amOnPage("/" . getenv("MAGENTO_BACKEND_NAME") . "//backend");
+		$I->amOnPage("/" . getenv("MAGENTO_BACKEND_NAME") . "//StringLiteral/page.html");
 		$I->amOnUrl("http://myFullUrl.com/");
 	}
 }

--- a/dev/tests/verification/Resources/PageReplacementTest.txt
+++ b/dev/tests/verification/Resources/PageReplacementTest.txt
@@ -39,7 +39,8 @@ class PageReplacementTestCest
 		$I->amOnPage("/John/StringLiteral2.html");
 		$I->amOnPage("/John/" . $datakey->getCreatedDataByName('firstname') . ".html");
 		$I->amOnPage("/" . $datakey->getCreatedDataByName('firstname') . "/StringLiteral2.html");
-		$I->amOnPage("/admin/backend");
+		$I->amOnPage("/" . getenv("MAGENTO_BASE_URL") . "//backend");
+		$I->amOnPage("/" . getenv("MAGENTO_BASE_URL") . "//StringLiteral/page.html");
 		$I->amOnUrl("http://myFullUrl.com/");
 	}
 }

--- a/dev/tests/verification/TestModule/Page/SamplePage.xml
+++ b/dev/tests/verification/TestModule/Page/SamplePage.xml
@@ -23,6 +23,9 @@
     <page name="AdminPage" url="/backend" area="admin" module="SampleTests">
         <section name="SampleSection"/>
     </page>
+    <page name="AdminOneParamPage" url="/{{var1}}/page.html" area="admin" module="SampleTests" parameterized="true">
+        <section name="SampleSection"/>
+    </page>
     <page name="ExternalPage" url="http://myFullUrl.com/" area="external" module="SampleTests">
         <section name="SampleSection"/>
     </page>

--- a/dev/tests/verification/TestModule/Test/PageReplacementTest.xml
+++ b/dev/tests/verification/TestModule/Test/PageReplacementTest.xml
@@ -19,6 +19,7 @@
         <amOnPage stepKey="twoParamPageDataPersist" url="{{TwoParamPage.url(simpleData.firstname, $datakey.firstname$)}}"/>
         <amOnPage stepKey="twoParamPagePersistString" url="{{TwoParamPage.url($datakey.firstname$, 'StringLiteral2')}}"/>
         <amOnPage stepKey="onAdminPage" url="{{AdminPage.url}}"/>
+        <amOnPage stepKey="oneParamAdminPageString" url="{{AdminOneParamPage.url('StringLiteral')}}"/>
         <amOnUrl stepKey="onExternalPage" url="{{ExternalPage.url}}"/>
     </test>
     <test name="ExternalPageTestBadReference">

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/DataObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/DataObjectHandler.php
@@ -13,7 +13,6 @@ use Magento\FunctionalTestingFramework\ObjectManagerFactory;
 
 class DataObjectHandler implements ObjectHandlerInterface
 {
-    const __ENV = '_ENV';
     const _ENTITY = 'entity';
     const _NAME = 'name';
     const _TYPE = 'type';
@@ -56,7 +55,6 @@ class DataObjectHandler implements ObjectHandlerInterface
             return;
         }
         $this->entityDataObjects = $this->processParserOutput($parserOutput);
-        $this->entityDataObjects[self::__ENV] = $this->processEnvFile();
     }
 
     /**
@@ -98,37 +96,6 @@ class DataObjectHandler implements ObjectHandlerInterface
     public function getAllObjects()
     {
         return $this->entityDataObjects;
-    }
-
-    /**
-     * Convert the contents of the .env file into a single EntityDataObject so that the values can be accessed like
-     * normal data.
-     *
-     * @return EntityDataObject|null
-     */
-    private function processEnvFile()
-    {
-        // These constants are defined in the bootstrap file
-        $path = PROJECT_ROOT . DIRECTORY_SEPARATOR . '.env';
-
-        if (file_exists($path)) {
-            $vars = [];
-            $lines = file($path);
-
-            foreach ($lines as $line) {
-                $parts = explode("=", $line);
-                if (count($parts) != 2) {
-                    continue;
-                }
-                $key = strtolower(trim($parts[0]));
-                $value = trim($parts[1]);
-                $vars[$key] = $value;
-            }
-
-            return new EntityDataObject(self::__ENV, 'environment', $vars, null, null);
-        }
-
-        return null;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Page/Objects/PageObject.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Objects/PageObject.php
@@ -94,11 +94,6 @@ class PageObject
      */
     public function getUrl()
     {
-        if ($this->getArea() == self::ADMIN_AREA) {
-            $url = ltrim($this->url, '/');
-            return "/" . getenv('MAGENTO_BACKEND_NAME') . "/{$url}";
-        }
-
         return $this->url;
     }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -343,7 +343,7 @@ class ActionObject
                     $parameterized = $obj->isParameterized();
                     $replacement = $this->resolveParameterization($parameterized, $obj->getUrl(), $match);
                     if ($obj->getArea() == PageObject::ADMIN_AREA) {
-                        $replacement = "/{{_ENV.MAGENTO_BASE_URL}}/" . $replacement;
+                        $replacement = "/{{_ENV.BACKEND_NAME}}/" . $replacement;
                     }
                     break;
                 case SectionObject::class:

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -19,6 +19,7 @@ use Magento\FunctionalTestingFramework\Exceptions\TestReferenceException;
  */
 class ActionObject
 {
+    const __ENV = "_ENV";
     const DATA_ENABLED_ATTRIBUTES = ["userInput", "parameterArray", "expected", "actual"];
     const SELECTOR_ENABLED_ATTRIBUTES = ['selector', 'dependentSelector', "selector1", "selector2", "function"];
     const EXTERNAL_URL_AREA_INVALID_ACTIONS = ['amOnPage'];
@@ -329,6 +330,11 @@ class ActionObject
             list($objName) = $this->stripAndSplitReference($match);
 
             $obj = $objectHandler->getObject($objName);
+
+            // Leave {{_ENV.VARIABLE}} references to be replaced in TestGenerator with getenv("VARIABLE")
+            if ($objName === ActionObject::__ENV) {
+                continue;
+            }
 
             // specify behavior depending on field
             switch (get_class($obj)) {

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -366,7 +366,7 @@ class ActionObject
             $replacement = $this->resolveParameterization($parameterized, $replacement, $match);
 
             if (get_class($obj) == PageObject::class && $obj->getArea() == PageObject::ADMIN_AREA) {
-                $replacement = "/{{_ENV.BACKEND_NAME}}/" . $replacement;
+                $replacement = "/{{_ENV.MAGENTO_BACKEND_NAME}}/" . $replacement;
             }
 
             $outputString = str_replace($match, $replacement, $outputString);

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -340,11 +340,8 @@ class ActionObject
             switch (get_class($obj)) {
                 case PageObject::class:
                     $this->validateUrlAreaAgainstActionType($obj);
+                    $replacement = $obj->getUrl();
                     $parameterized = $obj->isParameterized();
-                    $replacement = $this->resolveParameterization($parameterized, $obj->getUrl(), $match);
-                    if ($obj->getArea() == PageObject::ADMIN_AREA) {
-                        $replacement = "/{{_ENV.BACKEND_NAME}}/" . $replacement;
-                    }
                     break;
                 case SectionObject::class:
                     list(,$objField) = $this->stripAndSplitReference($match);
@@ -354,11 +351,9 @@ class ActionObject
                     $parameterized = $obj->getElement($objField)->isParameterized();
                     $replacement = $obj->getElement($objField)->getPrioritizedSelector();
                     $this->setTimeout($obj->getElement($objField)->getTimeout());
-                    $replacement = $this->resolveParameterization($parameterized, $replacement, $match);
                     break;
                 case EntityDataObject::class:
                     $replacement = $this->resolveEntityDataObjectReference($obj, $match);
-                    $replacement = $this->resolveParameterization($parameterized, $replacement, $match);
                     break;
             }
 
@@ -367,6 +362,13 @@ class ActionObject
             } elseif ($replacement == null) {
                 throw new TestReferenceException("Could not resolve entity reference " . $inputString);
             }
+
+            $replacement = $this->resolveParameterization($parameterized, $replacement, $match);
+
+            if (get_class($obj) == PageObject::class && $obj->getArea() == PageObject::ADMIN_AREA) {
+                $replacement = "/{{_ENV.BACKEND_NAME}}/" . $replacement;
+            }
+
             $outputString = str_replace($match, $replacement, $outputString);
         }
         return $outputString;

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1519,6 +1519,12 @@ class TestGenerator
     }
     // @codingStandardsIgnoreEnd
 
+    /**
+     * Resolves {{_ENV.variable}} into getenv("variable") for test-runtime ENV referencing.
+     * @param string $inputString
+     * @param array $args
+     * @return string
+     */
     private function resolveEnvReferences($inputString, $args)
     {
         $envRegex = "/{{_ENV\.([\w]+)}}/";

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1482,6 +1482,8 @@ class TestGenerator
         }
         $output .= ");\n";
 
+        $output = $this->resolveEnvReferences($output, $args);
+
         return $this->resolveTestVariable($output, $args);
     }
 
@@ -1511,9 +1513,33 @@ class TestGenerator
         }
         $output .= ");\n";
 
+        $output = $this->resolveEnvReferences($output, $args);
+
         return $this->resolveTestVariable($output, $args);
     }
     // @codingStandardsIgnoreEnd
+
+    private function resolveEnvReferences($inputString, $args)
+    {
+        $envRegex = "/{{_ENV\.([\w]+)}}/";
+
+        $outputString = $inputString;
+
+        foreach ($args as $arg) {
+            preg_match_all($envRegex, $arg, $matches);
+            if (!empty($matches[0])) {
+                $fullMatch = $matches[0][0];
+                $envVariable = $matches[1][0];
+                unset($matches);
+                $replacement = "getenv(\"{$envVariable}\")";
+
+                $outputArg = $this->processQuoteBreaks($fullMatch, $arg, $replacement);
+                $outputString = str_replace($arg, $outputArg, $outputString);
+            }
+        }
+
+        return $outputString;
+    }
 
     /**
      * Validates parameter array format, making sure user has enclosed string with square brackets.


### PR DESCRIPTION
### Description
{{_ENV.value}} references are no longer done on generation; they are done in test runtime. This fixes the issue of Magento instances changing .env contents post generation in builds.

### Fixed Issues
1. magento/magento2-functional-testing-framework#<685>: References to ENV file must be done at test run-time

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests