### PR TITLE
MQE-740: Duplicates in test hook cause errors when merging

### DIFF
--- a/dev/tests/verification/TestModule/Test/XmlDuplicateTest.xml
+++ b/dev/tests/verification/TestModule/Test/XmlDuplicateTest.xml
@@ -650,4 +650,26 @@
         <waitForText stepKey="waittext1"/>
         <waitForText stepKey="waittext12"/>
     </test>
+
+    <test name="BasicDupedActionTest">
+        <before>
+            <createData entity="simpleData" stepKey="cb1">
+                <requiredEntity createDataKey="simpleData2"/>
+            </createData>
+            <amOnPage stepKey="aopb1" url="1"/>
+            <amOnPage stepKey="aopb2" url="2"/>
+        </before>
+        <after>
+            <createData entity="simpleData" stepKey="ca1">
+                <requiredEntity createDataKey="simpleData2"/>
+            </createData>
+            <amOnPage stepKey="aopf1" url="1"/>
+            <amOnPage stepKey="aopf2" url="2"/>
+        </after>
+        <createData entity="simpleData" stepKey="c1">
+            <requiredEntity createDataKey="simpleData2"/>
+        </createData>
+        <amOnPage stepKey="aop1" url="1"/>
+        <amOnPage stepKey="aop2" url="2"/>
+    </test>
 </tests>

--- a/dev/tests/verification/TestModuleMerged/Test/MergeXmlDuplicateTest.xml
+++ b/dev/tests/verification/TestModuleMerged/Test/MergeXmlDuplicateTest.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="BasicDupedActionTest">
+        <before>
+            <createData entity="simpleData" stepKey="cb3">
+                <requiredEntity createDataKey="simpleData2"/>
+            </createData>
+            <createData entity="simpleData" stepKey="cb4">
+                <requiredEntity createDataKey="simpleData2"/>
+            </createData>
+            <amOnPage stepKey="aopb3" url="3"/>
+            <amOnPage stepKey="aopb4" url="4"/>
+        </before>
+        <after>
+            <createData entity="simpleData" stepKey="ca3">
+                <requiredEntity createDataKey="simpleData2"/>
+            </createData>
+            <createData entity="simpleData" stepKey="c4">
+                <requiredEntity createDataKey="simpleData2"/>
+            </createData>
+            <amOnPage stepKey="aopf3" url="3"/>
+            <amOnPage stepKey="aopf4" url="4"/>
+        </after>
+        <createData entity="simpleData" stepKey="c3">
+            <requiredEntity createDataKey="simpleData2"/>
+        </createData>
+        <createData entity="simpleData" stepKey="c4">
+            <requiredEntity createDataKey="simpleData2"/>
+        </createData>
+        <amOnPage stepKey="aop3" url="3"/>
+        <amOnPage stepKey="aop4" url="4"/>
+    </test>
+</tests>

--- a/dev/tests/verification/Tests/XmlDuplicateGenerationTest.php
+++ b/dev/tests/verification/Tests/XmlDuplicateGenerationTest.php
@@ -14,6 +14,7 @@ class XmlDuplicateGerationTest extends TestCase
 {
     const XML_DUPLICATE_TEST = 'XmlDuplicateTest';
     const XML_DUPLICATE_ACTIONGROUP = 'xmlDuplicateActionGroup';
+    const XML_DUPLICATE_MERGE_TEST = 'BasicDupedActionTest';
     const RESOURCES_PATH = __DIR__ . '/../Resources';
 
     /**
@@ -28,6 +29,15 @@ class XmlDuplicateGerationTest extends TestCase
     public function testDuplicatesInActionGroup()
     {
         $actionGroup = ActionGroupObjectHandler::getInstance()->getObject(self::XML_DUPLICATE_ACTIONGROUP);
+        $this->addToAssertionCount(1); // No exception thrown thus far, can assert dupes didn't cause an error.
+    }
+
+    /**
+     * Parser testing, makes sure test action nodes are marked as array.
+     */
+    public function testDuplicatesInMergeTest()
+    {
+        $testObject = TestObjectHandler::getInstance()->getObject(self::XML_DUPLICATE_MERGE_TEST);
         $this->addToAssertionCount(1); // No exception thrown thus far, can assert dupes didn't cause an error.
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -214,13 +214,10 @@
                 <item name="/tests/test/updateData/required-entity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/getData/required-entity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
-                <item name="/tests/test/before/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
-                <item name="/tests/test/after/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
+                <item name="/tests/test/(before|after)/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
                 <item name="/tests/test/remove" xsi:type="string">keyForRemoval</item>
-                <item name="/tests/test/before/remove" xsi:type="string">keyForRemoval</item>
-                <item name="/tests/test/after/remove" xsi:type="string">keyForRemoval</item>
-                <item name="/tests/test/before/createData/required-entity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/after/updateData/required-entity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(before|after)/remove" xsi:type="string">keyForRemoval</item>
+                <item name="/tests/test/(before|after)/createData/required-entity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/annotations(/group)+" xsi:type="string">value</item>
             </argument>
             <argument name="fileName" xsi:type="string">*.xml</argument>
@@ -232,21 +229,16 @@
         <arguments>
             <argument name="assocArrayAttributes" xsi:type="array">
                 <item name="/tests/test/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
-                <item name="/tests/test/before/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
-                <item name="/tests/test/after/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
+                <item name="/tests/test/(before|after)/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
                 <item name="/tests/test/remove" xsi:type="string">keyForRemoval</item>
-                <item name="/tests/test/before/remove" xsi:type="string">keyForRemoval</item>
-                <item name="/tests/test/after/remove" xsi:type="string">keyForRemoval</item>
+                <item name="/tests/test/(before|after)/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/tests/test" xsi:type="string">name</item>
                 <item name="/tests/test/createData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/before/createData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/after/createData/requiredEntity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(before|after)/createData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/updateData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/before/updateData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/after/updateData/requiredEntity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(before|after)/updateData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/getData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/before/getData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/after/getData/requiredEntity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(before|after)/getData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/actionGroup/argument" xsi:type="string">name</item>
             </argument>
             <argument name="numericArrays" xsi:type="array">
@@ -373,10 +365,8 @@
         <arguments>
             <argument name="assocArrayAttributes" xsi:type="array">
                 <item name="/suites/suite" xsi:type="string">name</item>
-                <item name="/suites/suite/before/(createData|deleteData)" xsi:type="string">stepKey</item>
-                <item name="/suites/suite/after/(createData|deleteData)" xsi:type="string">stepKey</item>
-                <item name="/suites/suite/before/createData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/suites/suite/after/createData/requiredEntity" xsi:type="string">createDataKey</item>
+                <item name="/suites/suite/(before|after)/(createData|deleteData)" xsi:type="string">stepKey</item>
+                <item name="/suites/suite/(before|after)/createData/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/suites/suite/include/group" xsi:type="string">name</item>
                 <item name="/suites/suite/include/test" xsi:type="string">name</item>
                 <item name="/suites/suite/include/module" xsi:type="string">name</item>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -214,9 +214,13 @@
                 <item name="/tests/test/updateData/required-entity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/getData/required-entity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
+                <item name="/tests/test/before/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
+                <item name="/tests/test/after/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
                 <item name="/tests/test/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/tests/test/before/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/tests/test/after/remove" xsi:type="string">keyForRemoval</item>
+                <item name="/tests/test/before/createData/required-entity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/after/updateData/required-entity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/annotations(/group)+" xsi:type="string">value</item>
             </argument>
             <argument name="fileName" xsi:type="string">*.xml</argument>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -210,14 +210,12 @@
             <argument name="idAttributes" xsi:type="array">
                 <item name="/tests/test" xsi:type="string">name</item>
                 <item name="/tests/test/actionGroup/argument" xsi:type="string">name</item>
-                <item name="/tests/test/createData/required-entity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/updateData/required-entity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/getData/required-entity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(createData|updateData|getData)/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
                 <item name="/tests/test/(before|after)/(actionGroup|&commonTestActions;)" xsi:type="string">stepKey</item>
                 <item name="/tests/test/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/tests/test/(before|after)/remove" xsi:type="string">keyForRemoval</item>
-                <item name="/tests/test/(before|after)/createData/required-entity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(before|after)/(createData|updateData|getData)/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/annotations(/group)+" xsi:type="string">value</item>
             </argument>
             <argument name="fileName" xsi:type="string">*.xml</argument>
@@ -233,12 +231,8 @@
                 <item name="/tests/test/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/tests/test/(before|after)/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/tests/test" xsi:type="string">name</item>
-                <item name="/tests/test/createData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/(before|after)/createData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/updateData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/(before|after)/updateData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/getData/requiredEntity" xsi:type="string">createDataKey</item>
-                <item name="/tests/test/(before|after)/getData/requiredEntity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(createData|updateData|getData)/requiredEntity" xsi:type="string">createDataKey</item>
+                <item name="/tests/test/(before|after)/(createData|updateData|getData)/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/tests/test/actionGroup/argument" xsi:type="string">name</item>
             </argument>
             <argument name="numericArrays" xsi:type="array">
@@ -290,6 +284,7 @@
                 <item name="/actionGroups/actionGroup" xsi:type="string">name</item>
                 <item name="/actionGroups/actionGroup/arguments/argument" xsi:type="string">name</item>
                 <item name="/actionGroups/actionGroup/(&commonTestActions;)" xsi:type="string">stepKey</item>
+                <item name="/actionGroups/actionGroup/(createData|updateData|getData)/requiredEntity" xsi:type="string">createDataKey</item>
                 <item name="/actionGroups/actionGroup/remove" xsi:type="string">keyForRemoval</item>
             </argument>
             <argument name="fileName" xsi:type="string">*ActionGroup.xml</argument>
@@ -304,6 +299,7 @@
                 <item name="/actionGroups/actionGroup/remove" xsi:type="string">keyForRemoval</item>
                 <item name="/actionGroups/actionGroup" xsi:type="string">name</item>
                 <item name="/actionGroups/actionGroup/arguments/argument" xsi:type="string">name</item>
+                <item name="/actionGroups/actionGroup/(createData|updateData|getData)/requiredEntity" xsi:type="string">createDataKey</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
### Description
di.xml fixes to make sure hooks have all data actions, as well as overall review of di.xml configurationf or other missing actions.

### Fixed Issues
1. magento/magento2-functional-testing-framework#<740>: Duplicates in test hook cause errors when merging

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests