### PR TITLE
MQE-820: MSI form posts use a single "/admin/" vs "/admin/admin/" URLs used in other areas of the Admin.

### DIFF
--- a/dev/tests/unit/Util/OperationDefinitionBuilder.php
+++ b/dev/tests/unit/Util/OperationDefinitionBuilder.php
@@ -38,6 +38,12 @@ class OperationDefinitionBuilder
     private $metadata = [];
 
     /**
+     * Determines if api URL should remove magento_backend_name.
+     * @var bool
+     */
+    private $removeBackend;
+
+    /**
      * Function which builds an operation defintions based on the fields set by the user.
      *
      * @return OperationDefinitionObject
@@ -54,7 +60,8 @@ class OperationDefinitionBuilder
             null,
             null,
             $this->metadata,
-            null
+            null,
+            false
         );
     }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/OperationDefinitionObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/OperationDefinitionObjectHandler.php
@@ -42,7 +42,7 @@ class OperationDefinitionObjectHandler implements ObjectHandlerInterface
     const ENTITY_OPERATION_OBJECT_KEY = 'key';
     const ENTITY_OPERATION_OBJECT_VALUE = 'value';
     const ENTITY_OPERATION_REQUIRED = 'required';
-    const ENTITY_OPERATION_BACKEND_REMOVE = 'removeBackendName';
+    const ENTITY_OPERATION_BACKEND_REMOVE = 'removeBackend';
 
     /**
      * The singleton instance of this class

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/OperationDefinitionObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/OperationDefinitionObjectHandler.php
@@ -42,6 +42,7 @@ class OperationDefinitionObjectHandler implements ObjectHandlerInterface
     const ENTITY_OPERATION_OBJECT_KEY = 'key';
     const ENTITY_OPERATION_OBJECT_VALUE = 'value';
     const ENTITY_OPERATION_REQUIRED = 'required';
+    const ENTITY_OPERATION_BACKEND_REMOVE = 'removeBackendName';
 
     /**
      * The singleton instance of this class
@@ -149,6 +150,7 @@ class OperationDefinitionObjectHandler implements ObjectHandlerInterface
             $headers = [];
             $params = [];
             $operationElements = [];
+            $removeBackend = $opDefArray[OperationDefinitionObjectHandler::ENTITY_OPERATION_BACKEND_REMOVE] ?? true;
 
             // TODO remove this warning with 2.1.0 release
             $backendName = getenv('MAGENTO_BACKEND_NAME');
@@ -238,6 +240,7 @@ class OperationDefinitionObjectHandler implements ObjectHandlerInterface
                 $params,
                 $operationElements,
                 $contentType,
+                $removeBackend,
                 $successRegex,
                 $returnRegex
             );

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/OperationDefinitionObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/OperationDefinitionObjectHandler.php
@@ -150,7 +150,7 @@ class OperationDefinitionObjectHandler implements ObjectHandlerInterface
             $headers = [];
             $params = [];
             $operationElements = [];
-            $removeBackend = $opDefArray[OperationDefinitionObjectHandler::ENTITY_OPERATION_BACKEND_REMOVE] ?? true;
+            $removeBackend = $opDefArray[OperationDefinitionObjectHandler::ENTITY_OPERATION_BACKEND_REMOVE] ?? false;
 
             // TODO remove this warning with 2.1.0 release
             $backendName = getenv('MAGENTO_BACKEND_NAME');

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Objects/OperationDefinitionObject.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Objects/OperationDefinitionObject.php
@@ -105,6 +105,12 @@ class OperationDefinitionObject
     private $returnRegex;
 
     /**
+     * Determines if operation should remove backend_name from URL.
+     * @var bool
+     */
+    private $removeBackend;
+
+    /**
      * OperationDefinitionObject constructor.
      * @param string $name
      * @param string $operation
@@ -116,6 +122,7 @@ class OperationDefinitionObject
      * @param array $params
      * @param array $metaData
      * @param string $contentType
+     * @param bool $removeBackend
      * @param string $successRegex
      * @param string $returnRegex
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -131,6 +138,7 @@ class OperationDefinitionObject
         $params,
         $metaData,
         $contentType,
+        $removeBackend,
         $successRegex = null,
         $returnRegex = null
     ) {
@@ -145,6 +153,7 @@ class OperationDefinitionObject
         $this->operationMetadata = $metaData;
         $this->successRegex = $successRegex;
         $this->returnRegex = $returnRegex;
+        $this->removeBackend = $removeBackend;
         $this->apiUrl = null;
 
         if (!empty($contentType)) {
@@ -152,6 +161,7 @@ class OperationDefinitionObject
         } else {
             $this->contentType = 'application/x-www-form-urlencoded';
         }
+
         // add content type as a header
         $this->headers[] = self::HTTP_CONTENT_TYPE_HEADER . ': ' . $this->contentType;
     }
@@ -229,6 +239,16 @@ class OperationDefinitionObject
     public function getHeaders()
     {
         return $this->headers;
+    }
+
+    /**
+     * Getter for removeBackend
+     *
+     * @return bool
+     */
+    public function removeUrlBackend()
+    {
+        return $this->removeBackend;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/AdminExecutor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/AdminExecutor.php
@@ -37,6 +37,12 @@ class AdminExecutor extends AbstractExecutor implements CurlInterface
     private $response;
 
     /**
+     * Should executor remove backend_name from api url
+     * @var bool
+     */
+    private $removeBackend;
+
+    /**
      * Backend url.
      *
      * @var string
@@ -45,15 +51,17 @@ class AdminExecutor extends AbstractExecutor implements CurlInterface
 
     /**
      * Constructor.
+     * @param bool $removeBackend
      *
      * @constructor
      */
-    public function __construct()
+    public function __construct($removeBackend)
     {
         if (!isset(parent::$baseUrl)) {
             parent::resolveBaseUrl();
         }
         self::$adminUrl = parent::$baseUrl . getenv('MAGENTO_BACKEND_NAME') . '/';
+        $this->removeBackend = $removeBackend;
         $this->transport = new CurlTransport();
         $this->authorize();
     }
@@ -110,6 +118,11 @@ class AdminExecutor extends AbstractExecutor implements CurlInterface
     public function write($url, $data = [], $method = CurlInterface::POST, $headers = [])
     {
         $apiUrl = self::$adminUrl . $url;
+
+        if (!$this->removeBackend) {
+            $apiUrl = parent::$baseUrl . ltrim($url, '/');
+        }
+
         if ($this->formKey) {
             $data['form_key'] = $this->formKey;
         } else {

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/AdminExecutor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/AdminExecutor.php
@@ -119,7 +119,7 @@ class AdminExecutor extends AbstractExecutor implements CurlInterface
     {
         $apiUrl = self::$adminUrl . $url;
 
-        if (!$this->removeBackend) {
+        if ($this->removeBackend) {
             $apiUrl = parent::$baseUrl . ltrim($url, '/');
         }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
@@ -131,7 +131,7 @@ class CurlHandler
             $this->isJson = true;
             $executor = new WebapiExecutor($this->storeCode);
         } elseif ($authorization === 'adminFormKey') {
-            $executor = new AdminExecutor();
+            $executor = new AdminExecutor($this->operationDefinition->removeUrlBackend());
         } elseif ($authorization === 'customerFormKey') {
             $executor = new FrontendExecutor(
                 $this->requestData['customer_email'],

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd
@@ -25,6 +25,7 @@
                         <xs:attribute type="operationEnum" name="type" use="required"/>
                         <xs:attribute type="xs:string" name="url"/>
                         <xs:attribute type="authEnum" name="auth"/>
+                        <xs:attribute type="xs:boolean" name="removeBackend" use="optional" default="true"/>
                         <xs:attribute type="xs:string" name="method"/>
                         <xs:attribute type="xs:string" name="successRegex"/>
                         <xs:attribute type="xs:string" name="returnRegex"/>


### PR DESCRIPTION
### Description
- added `removeBackend` attribute that removes addition of MAGENTO_BACKEND_NAME to metadata of type `adminFormKey`

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#820: MSI form posts use a single "/admin/" vs "/admin/admin/" URLs used in other areas of the Admin.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests