### PR TITLE
 MQE-837: Assert sub-elements can't be declared out of sequence

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -239,11 +239,14 @@ class ActionObject
             return;
         }
 
-        $actualOnlyTypes = ['assertEmpty', 'assertFalse', 'assertFileExists', 'assertFileNotExists',
-            'assertIsEmpty', 'assertNotEmpty', 'assertNotNull', 'assertNull', 'assertTrue'];
-        $expectedOnlyTypes = ['assertElementContainsAttribute'];
+        /** MQE-683 DEPRECATE OLD METHOD HERE
+         * Unnecessary validation, only needed for backwards compatibility
+         */
+        $singleChildTypes = ['assertEmpty', 'assertFalse', 'assertFileExists', 'assertFileNotExists',
+            'assertIsEmpty', 'assertNotEmpty', 'assertNotNull', 'assertNull', 'assertTrue',
+            'assertElementContainsAttribute'];
 
-        if (!in_array($this->type, array_merge($actualOnlyTypes, $expectedOnlyTypes))) {
+        if (!in_array($this->type, $singleChildTypes)) {
             if (!in_array('expectedResult', $relevantAssertionAttributes)
                 || !in_array('actualResult', $relevantAssertionAttributes)) {
                 // @codingStandardsIgnoreStart

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -239,6 +239,19 @@ class ActionObject
             return;
         }
 
+        $actualOnlyTypes = ['assertEmpty', 'assertFalse', 'assertFileExists', 'assertFileNotExists',
+            'assertIsEmpty', 'assertNotEmpty', 'assertNotNull', 'assertNull', 'assertTrue'];
+        $expectedOnlyTypes = ['assertElementContainsAttribute'];
+
+        if (!in_array($this->type, array_merge($actualOnlyTypes, $expectedOnlyTypes))) {
+            if (!in_array('expectedResult', $relevantAssertionAttributes)
+                || !in_array('actualResult', $relevantAssertionAttributes)) {
+                // @codingStandardsIgnoreStart
+                throw new TestReferenceException("{$this->type} must have both an expectedResult and actualResult defined (stepKey: {$this->stepKey})");
+                // @codingStandardsIgnoreEnd
+            }
+        }
+
         // Flatten nested Elements's type and value into key=>value entries
         foreach ($this->actionAttributes as $key => $subAttributes) {
             if (in_array($key, $relevantKeys)) {

--- a/src/Magento/FunctionalTestingFramework/Test/etc/Actions/assertActions.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/Actions/assertActions.xsd
@@ -94,10 +94,10 @@
     <!-- ASSERTION TYPES -->
     <!-- REMOVE expected/expectedType and actual/actualType in MQE-683-->
     <xs:complexType name="assertionType">
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -114,9 +114,9 @@
                 Asserts that a given element contains a specific attribute.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute type="xs:string" name="expectedValue">
             <xs:annotation>
                 <xs:documentation>
@@ -141,10 +141,10 @@
                 Asserts that given array has a key.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -159,10 +159,10 @@
                 Asserts that given array does not contain a key.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -177,10 +177,10 @@
                 Asserts that given array contains a subset array.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -196,10 +196,10 @@
                 Asserts that given array contains a value.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -214,10 +214,10 @@
                 Asserts that expected count is equal to actual count.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -232,9 +232,9 @@
                 Asserts that given variable is empty.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -249,10 +249,10 @@
                 Asserts that two given variables are equal. Can be given a "delta" to allow precision tolerance in floating point comparison.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -268,9 +268,9 @@
                 Asserts that given condition is false.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -285,9 +285,9 @@
                 Asserts that given file exists.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -302,9 +302,9 @@
                 Asserts that given file does not exist.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -319,10 +319,10 @@
                 Asserts that given actual value is greater or equal to expected value.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -337,10 +337,10 @@
                 Asserts that given actual value is greater than expected value.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -355,10 +355,10 @@
                 Asserts that given actual value is greater than or equal to expected value.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -373,10 +373,10 @@
                 Asserts that given actual is an instance of expected class.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -391,10 +391,10 @@
                 Asserts that given actual is internal type.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -409,9 +409,9 @@
                 Asserts that given actual is empty.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -426,10 +426,10 @@
                 Asserts that given actual less than or equal to expected.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -444,10 +444,10 @@
                 Asserts that given actual less than expected.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -462,10 +462,10 @@
                 Asserts that given actual less than or equal to expected.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -480,10 +480,10 @@
                 Asserts that given array does not contain a value.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -498,9 +498,9 @@
                 Asserts that given actual variable is not empty.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -515,10 +515,10 @@
                 Asserts that actual and expected are not equal. Can be given a "delta" to allow precision tolerance in floating point comparison.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -534,10 +534,10 @@
                 Asserts that given actual is not an instance of a class.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -552,9 +552,9 @@
                 Asserts that given actual is not null.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -569,10 +569,10 @@
                 Asserts that given actual string does not match with expected pattern.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -587,10 +587,10 @@
                 Asserts that given actual and expected are not the same.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -605,9 +605,9 @@
                 Asserts that given actual is null.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -622,10 +622,10 @@
                 Asserts that given actual string matches with expected pattern.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -640,10 +640,10 @@
                 Asserts that actual and expected are the same.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -658,10 +658,10 @@
                 Asserts that actual string does not start with the expected prefix.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -676,10 +676,10 @@
                 Asserts that actual string starts with the expected prefix.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -694,9 +694,9 @@
                 Asserts that given actual is true.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence>
+        <xs:choice>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>
@@ -711,10 +711,10 @@
                 Handles and checks expected exception called inside actual callback function.
             </xs:documentation>
         </xs:annotation>
-        <xs:sequence minOccurs="0">
+        <xs:choice minOccurs="0">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
         <xs:attribute ref="expected"/>
         <xs:attribute type="assertEnum" name="expectedType" default="const"/>
         <xs:attribute ref="actual"/>

--- a/src/Magento/FunctionalTestingFramework/Test/etc/Actions/assertActions.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/Actions/assertActions.xsd
@@ -94,7 +94,7 @@
     <!-- ASSERTION TYPES -->
     <!-- REMOVE expected/expectedType and actual/actualType in MQE-683-->
     <xs:complexType name="assertionType">
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -114,7 +114,7 @@
                 Asserts that a given element contains a specific attribute.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute type="xs:string" name="expectedValue">
@@ -141,7 +141,7 @@
                 Asserts that given array has a key.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -159,7 +159,7 @@
                 Asserts that given array does not contain a key.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -177,7 +177,7 @@
                 Asserts that given array contains a subset array.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -214,7 +214,7 @@
                 Asserts that expected count is equal to actual count.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -232,7 +232,7 @@
                 Asserts that given variable is empty.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -249,7 +249,7 @@
                 Asserts that two given variables are equal. Can be given a "delta" to allow precision tolerance in floating point comparison.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -268,7 +268,7 @@
                 Asserts that given condition is false.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -285,7 +285,7 @@
                 Asserts that given file exists.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -302,7 +302,7 @@
                 Asserts that given file does not exist.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -319,7 +319,7 @@
                 Asserts that given actual value is greater or equal to expected value.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -337,7 +337,7 @@
                 Asserts that given actual value is greater than expected value.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -355,7 +355,7 @@
                 Asserts that given actual value is greater than or equal to expected value.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -373,7 +373,7 @@
                 Asserts that given actual is an instance of expected class.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -391,7 +391,7 @@
                 Asserts that given actual is internal type.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -409,7 +409,7 @@
                 Asserts that given actual is empty.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -426,7 +426,7 @@
                 Asserts that given actual less than or equal to expected.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -444,7 +444,7 @@
                 Asserts that given actual less than expected.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -462,7 +462,7 @@
                 Asserts that given actual less than or equal to expected.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -480,7 +480,7 @@
                 Asserts that given array does not contain a value.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -498,7 +498,7 @@
                 Asserts that given actual variable is not empty.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -515,7 +515,7 @@
                 Asserts that actual and expected are not equal. Can be given a "delta" to allow precision tolerance in floating point comparison.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -534,7 +534,7 @@
                 Asserts that given actual is not an instance of a class.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -552,7 +552,7 @@
                 Asserts that given actual is not null.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -569,7 +569,7 @@
                 Asserts that given actual string does not match with expected pattern.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -587,7 +587,7 @@
                 Asserts that given actual and expected are not the same.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -605,7 +605,7 @@
                 Asserts that given actual is null.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -622,7 +622,7 @@
                 Asserts that given actual string matches with expected pattern.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -640,7 +640,7 @@
                 Asserts that actual and expected are the same.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -658,7 +658,7 @@
                 Asserts that actual string does not start with the expected prefix.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -676,7 +676,7 @@
                 Asserts that actual string starts with the expected prefix.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
@@ -694,7 +694,7 @@
                 Asserts that given actual is true.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>
         <xs:attribute ref="expected"/>
@@ -711,7 +711,7 @@
                 Handles and checks expected exception called inside actual callback function.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice minOccurs="0">
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="expectedResult" type="expectedResultType" minOccurs="0"/>
             <xs:element name="actualResult" type="actualResultType" minOccurs="0"/>
         </xs:choice>


### PR DESCRIPTION
### Description
- Changed schema to allow for above
- Added validation in lieu of xsd validation.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#837: Assert sub-elements can't be declared out of sequence

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests