### PR TITLE
MQE-841: robo generate:tests --force should not require MAGENTO_BASE_URL

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -227,7 +227,9 @@ class ActionObject
         $oldAttributes = array_intersect($actionAttributeKeys, ActionObject::OLD_ASSERTION_ATTRIBUTES);
         if (!empty($oldAttributes)) {
             // @codingStandardsIgnoreStart
-            echo("WARNING: Use of one line Assertion actions will be deprecated in MFTF 3.0.0, please use nested syntax (Action: {$this->type} StepKey: {$this->stepKey})" . PHP_EOL);
+            if ($GLOBALS['GENERATE_TESTS'] ?? false == true) {
+                echo("WARNING: Use of one line Assertion actions will be deprecated in MFTF 3.0.0, please use nested syntax (Action: {$this->type} StepKey: {$this->stepKey})" . PHP_EOL);
+            }
             // @codingStandardsIgnoreEnd
             return;
         }
@@ -239,21 +241,7 @@ class ActionObject
             return;
         }
 
-        /** MQE-683 DEPRECATE OLD METHOD HERE
-         * Unnecessary validation, only needed for backwards compatibility
-         */
-        $singleChildTypes = ['assertEmpty', 'assertFalse', 'assertFileExists', 'assertFileNotExists',
-            'assertIsEmpty', 'assertNotEmpty', 'assertNotNull', 'assertNull', 'assertTrue',
-            'assertElementContainsAttribute'];
-
-        if (!in_array($this->type, $singleChildTypes)) {
-            if (!in_array('expectedResult', $relevantAssertionAttributes)
-                || !in_array('actualResult', $relevantAssertionAttributes)) {
-                // @codingStandardsIgnoreStart
-                throw new TestReferenceException("{$this->type} must have both an expectedResult and actualResult defined (stepKey: {$this->stepKey})");
-                // @codingStandardsIgnoreEnd
-            }
-        }
+        $this->validateAssertionSchema($relevantAssertionAttributes);
 
         // Flatten nested Elements's type and value into key=>value entries
         foreach ($this->actionAttributes as $key => $subAttributes) {
@@ -264,6 +252,31 @@ class ActionObject
                 $this->resolvedCustomAttributes[$prefix] =
                     $subAttributes[ActionObject::ASSERTION_VALUE_ATTRIBUTE];
                 unset($this->actionAttributes[$key]);
+            }
+        }
+    }
+
+    /**
+     * Validates that the given assertion attributes have valid schema according to nested assertion syntax.
+     * @param array $attributes
+     * @return void
+     * @throws TestReferenceException
+     */
+    private function validateAssertionSchema($attributes)
+    {
+        /** MQE-683 DEPRECATE OLD METHOD HERE
+         * Unnecessary validation, only needed for backwards compatibility
+         */
+        $singleChildTypes = ['assertEmpty', 'assertFalse', 'assertFileExists', 'assertFileNotExists',
+            'assertIsEmpty', 'assertNotEmpty', 'assertNotNull', 'assertNull', 'assertTrue',
+            'assertElementContainsAttribute'];
+
+        if (!in_array($this->type, $singleChildTypes)) {
+            if (!in_array('expectedResult', $attributes)
+                || !in_array('actualResult', $attributes)) {
+                // @codingStandardsIgnoreStart
+                throw new TestReferenceException("{$this->type} must have both an expectedResult and actualResult defined (stepKey: {$this->stepKey})");
+                // @codingStandardsIgnoreEnd
             }
         }
     }

--- a/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
@@ -86,8 +86,12 @@ class ConfigSanitizerUtil
      */
     public static function sanitizeUrl($url)
     {
+        $forceGenerate = $GLOBALS['FORCE_PHP_GENERATE'] ?? false;
         if ($url === "") {
-            trigger_error("MAGENTO_BASE_URL must be defined in .env", E_USER_ERROR);
+            if ($forceGenerate === false) {
+                trigger_error("MAGENTO_BASE_URL must be defined in .env", E_USER_ERROR);
+            }
+            return $url;
         }
 
         if (filter_var($url, FILTER_VALIDATE_URL) === true) {

--- a/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
@@ -87,11 +87,8 @@ class ConfigSanitizerUtil
     public static function sanitizeUrl($url)
     {
         $forceGenerate = $GLOBALS['FORCE_PHP_GENERATE'] ?? false;
-        if ($url === "") {
-            if ($forceGenerate === false) {
-                trigger_error("MAGENTO_BASE_URL must be defined in .env", E_USER_ERROR);
-            }
-            return $url;
+        if ($url === "" && $forceGenerate === false) {
+            trigger_error("MAGENTO_BASE_URL must be defined in .env", E_USER_ERROR);
         }
 
         if (filter_var($url, FILTER_VALIDATE_URL) === true) {

--- a/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
@@ -87,7 +87,7 @@ class ConfigSanitizerUtil
     public static function sanitizeUrl($url)
     {
         $forceGenerate = $GLOBALS['FORCE_PHP_GENERATE'] ?? false;
-        if (strlen($url) == 0  && $forceGenerate === false) {
+        if (strlen($url) == 0 && $forceGenerate === false) {
             trigger_error("MAGENTO_BASE_URL must be defined in .env", E_USER_ERROR);
         }
 

--- a/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
@@ -87,7 +87,7 @@ class ConfigSanitizerUtil
     public static function sanitizeUrl($url)
     {
         $forceGenerate = $GLOBALS['FORCE_PHP_GENERATE'] ?? false;
-        if ($url === "" && $forceGenerate === false) {
+        if (strlen($url) == 0  && $forceGenerate === false) {
             trigger_error("MAGENTO_BASE_URL must be defined in .env", E_USER_ERROR);
         }
 

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -126,11 +126,17 @@ class ModuleResolver
      */
     public function getEnabledModules()
     {
+        $testGenerationPhase = $GLOBALS['GENERATE_TESTS'] ?? false;
+
         if (isset($this->enabledModules)) {
             return $this->enabledModules;
+        } elseif (!isset($_ENV['MAGENTO_BASE_URL']) && $GLOBALS['FORCE_PHP_GENERATE'] ?? false == true) {
+            if ($testGenerationPhase) {
+                print "\nWARNING: No MAGENTO_BASE_URL defined in .env file, merging test files alphabetically.\n";
+            }
+            return null;
         }
 
-        $testGenerationPhase = $GLOBALS['GENERATE_TESTS'] ?? false;
         if ($testGenerationPhase) {
             $this->printMagentoVersionInfo();
         }

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -130,11 +130,6 @@ class ModuleResolver
 
         if (isset($this->enabledModules)) {
             return $this->enabledModules;
-        } elseif (!isset($_ENV['MAGENTO_BASE_URL']) && $GLOBALS['FORCE_PHP_GENERATE'] ?? false == true) {
-            if ($testGenerationPhase) {
-                print "\nWARNING: No MAGENTO_BASE_URL defined in .env file, merging test files alphabetically.\n";
-            }
-            return null;
         }
 
         if ($testGenerationPhase) {
@@ -147,7 +142,7 @@ class ModuleResolver
             return $this->enabledModules;
         }
 
-        $url = ConfigSanitizerUtil::sanitizeUrl($_ENV['MAGENTO_BASE_URL']) . $this->moduleUrl;
+        $url = ConfigSanitizerUtil::sanitizeUrl(getenv('MAGENTO_BASE_URL')) . $this->moduleUrl;
 
         $headers = [
             'Authorization: Bearer ' . $token,
@@ -258,6 +253,11 @@ class ModuleResolver
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $response = curl_exec($ch);
+
+        if (!$response) {
+            $response = "No version information available.";
+        }
+
         print "\nVersion Information: {$response}\n";
     }
 


### PR DESCRIPTION
### Description
Using --force flag now allows users to generate tests regardless if their .env has MAGENTO_BASE_URL defined, or defined as ''.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#841: robo generate:tests --force should not require MAGENTO_BASE_URL

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests