### PR TITLE
MQE-852: Incorrect Magento Version URL

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -63,7 +63,7 @@ class ModuleResolver
      *
      * @var string
      */
-    protected $versionUrl = "magento_version ";
+    protected $versionUrl = "magento_version";
 
     /**
      * List of known directory that does not map to a Magento module.


### PR DESCRIPTION
### Description
- removed trailing space from $versionUrl

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#852: Incorrect  Magento Version URL

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests