### PR TITLE
magento/magento2-functional-testing-framework#61: Validate build:project was run before attempting to generate tests

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -52,9 +52,30 @@ class RoboFile extends \Robo\Tasks
             $GLOBALS['FORCE_PHP_GENERATE'] = true;
         }
 
-        require 'dev' . DIRECTORY_SEPARATOR . 'tests'. DIRECTORY_SEPARATOR . 'functional' . DIRECTORY_SEPARATOR . '_bootstrap.php';
+        require 'dev' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'functional' . DIRECTORY_SEPARATOR . '_bootstrap.php';
+
+        if (!$this->isProjectBuilt()) {
+            throw new Exception('Please run vendor/bin/robo build:project and configure your environment (.env) first.');
+        }
+
         \Magento\FunctionalTestingFramework\Util\TestGenerator::getInstance()->createAllTestFiles($opts['config'], $opts['nodes']);
         $this->say("Generate Tests Command Run");
+    }
+
+    /**
+     * Check if MFTF has been properly configured
+     * @return bool
+     */
+    private function isProjectBuilt()
+    {
+        $actorFile = __DIR__ . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Magento' . DIRECTORY_SEPARATOR . 'FunctionalTestingFramework' . DIRECTORY_SEPARATOR . '_generated' . DIRECTORY_SEPARATOR . 'AcceptanceTesterActions.php';
+
+        $login = getenv('MAGENTO_ADMIN_USERNAME');
+        $password = getenv('MAGENTO_ADMIN_PASSWORD');
+        $baseUrl = getenv('MAGENTO_BASE_URL');
+        $backendName = getenv('MAGENTO_BACKEND_NAME');
+
+        return (file_exists($actorFile) && $login && $password && $baseUrl && $backendName);
     }
 
     /**


### PR DESCRIPTION
### Description
Exception throwing has been added to test generation method in order to check if `vendor/bin/robo build:project` has been ran and .env configuration file has been filled in.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#61: Validate build:project was run before attempting to generate tests

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests