### PR TITLE
The property of the parent element is used first when making a request

### DIFF
--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
@@ -200,13 +200,31 @@ class CurlHandler
 
         if (!empty($matchedParams)) {
             foreach ($matchedParams[0] as $paramKey => $paramValue) {
+
+                $paramEntityParent = "";
+                $matchedParent = [];
+                $dataItem = $matchedParams[1][$paramKey];
+                preg_match_all("/(.+?)\./", $dataItem, $matchedParent);
+
+                if (!empty($matchedParent) && !empty($matchedParent[0]))
+                {
+                    $paramEntityParent = $matchedParent[1][0];
+                    $dataItem = preg_replace('/^'.$matchedParent[0][0].'/', '', $dataItem);
+                }
+
                 foreach ($entityObjects as $entityObject) {
-                    $param = $entityObject->getDataByName(
-                        $matchedParams[1][$paramKey],
-                        EntityDataObject::CEST_UNIQUE_VALUE
-                    );
+
+                    if ($paramEntityParent === "" || $entityObject->getType() == $paramEntityParent)
+                    {
+                        $param = $entityObject->getDataByName(
+                            $dataItem,
+                            EntityDataObject::CEST_UNIQUE_VALUE
+                        );
+                    }
+
                     if (null !== $param) {
                         $urlOut = str_replace($paramValue, $param, $urlOut);
+                        $param = null;
                         continue;
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

Whenever you want to make an API request to an URL that has a variable in it, e.g. deleting a product requires the sku of that product in the URL, you would go the a 'meta' file and add an operation that looks something like this:

`<operation name="deleteProduct" dataType="product" type="delete" auth="adminOauth" url="/V1/products/{sku}" method="DELETE">
<contentType>application/json</contentType>
</operation>`

Adding `{sku}` to the url works if the entity that you want to delete is the only entity that has a property of that name, and there are no child entities associated with it that also have the property. In other words, if you want to create, for example, a bundle product, and be able to pass it the category and it's child products, like so:

> <createData entity="_defaultCategory" stepKey="createCategory"/>
            <createData entity="SimpleProductForBundle1" stepKey="createSimpleProduct1">
                <requiredEntity createDataKey="createCategory"/>
            </createData>
            <createData entity="SimpleProductForBundle2" stepKey="createSimpleProduct2">
                <requiredEntity createDataKey="createCategory"/>
            </createData>
            <createData entity="SimpleProductForBundle3" stepKey="createSimpleProduct3">
                <requiredEntity createDataKey="createCategory"/>
            </createData>

            <createData entity="BundleProduct" stepKey="createBundleProduct">
                <requiredEntity createDataKey="createCategory"/>
                <requiredEntity createDataKey="createSimpleProduct1"/>
                <requiredEntity createDataKey="createSimpleProduct2"/>
                <requiredEntity createDataKey="createSimpleProduct3"/>
            </createData>

When you want to delete the product by calling `<deleteData createDataKey="createBundleProduct" stepKey="deleteBundleProduct"/>`, which refferences something like `<operation name="deleteProductBundle" dataType="product_bundle" type="delete" auth="adminOauth" url="/V1/products/{sku}" method="DELETE">
        <contentType>application/json</contentType>
    </operation>` , it will actually delete the last entity that was passed as a parameter which has the 'sku' property. In the example above that would be "createSimpleProduct3". This is not how it should work.

The changes that I've made allows you to pick the entity that you want to make a refference to, when you want to call its property in the url. In order to delete a bundle product, one would add something like this in the metadata file:

```
<operation name="deleteProductBundle" dataType="product_bundle" type="delete" auth="adminOauth" url="/V1/products/{product_bundle.sku}" method="DELETE">
        <contentType>application/json</contentType>
    </operation>
```

Basically, instead of adding `{sku}`, one would add `{product_bundle.sku}`, where `product_bundle` is the metadata entity type, to the url.

<!--- Provide a description of the changes proposed in the pull request -->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests