### PR TITLE
Added the ability to use entity properties in metadata

### DIFF
--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
@@ -134,6 +134,14 @@ class OperationDataArrayResolver
                     ));
                 }
             } else {
+
+                $operationElementProperty = null;
+                if(strpos($operationElementType, '.') !== false){
+                    $operationElementComponents = explode('.',$operationElementType);
+                    $operationElementType = $operationElementComponents[0];
+                    $operationElementProperty = $operationElementComponents[1];
+                }
+
                 $entityNamesOfType = $entityObject->getLinkedEntitiesOfType($operationElementType);
 
                 // If an element is required by metadata, but was not provided in the entity, throw an exception
@@ -146,12 +154,23 @@ class OperationDataArrayResolver
                     ));
                 }
                 foreach ($entityNamesOfType as $entityName) {
-                    $operationDataSubArray = $this->resolveNonPrimitiveElement(
-                        $entityName,
-                        $operationElement,
-                        $operation,
-                        $fromArray
-                    );
+
+                    if($operationElementProperty === null) {
+                        $operationDataSubArray = $this->resolveNonPrimitiveElement(
+                            $entityName,
+                            $operationElement,
+                            $operation,
+                            $fromArray
+                        );
+                    }else {
+                        $linkedEntityObj = $this->resolveLinkedEntityObject($entityName);
+                        $operationDataSubArray = $linkedEntityObj->getDataByName($operationElementProperty,0);
+
+                        if($operationDataSubArray === null)
+                            throw new \Exception(
+                                sprintf('Property %s not found in entity %s \n', $operationElementProperty, $entityName)
+                            );
+                    }
 
                     if ($operationElement->getType() == OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY) {
                         $operationDataArray[$operationElement->getKey()][] = $operationDataSubArray;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

Added the ability to use entity properties inside metadata entities for when you make API requests to create something that has to contain an array of properties from other entities, e.g. the request for creating a new tax rule has to contain an array of the ids of the tax rates that will be associated to it.

Now you can have a meta file that represents a tax rate, which would look something like this:

````
<?xml version="1.0" encoding="UTF-8"?>
<operations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd">
    <operation name="CreateTaxRate" dataType="tax_rate" type="create" auth="adminOauth" url="/V1/taxRates" method="POST">
        <contentType>application/json</contentType>
        <object dataType="tax_rate" key="taxRate">
            <field key="code">string</field>
            <field key="tax_country_id">string</field>
            <field key="tax_region_id">integer</field>
            <field key="tax_postcode">string</field>
            <field key="rate">integer</field>
        </object>
    </operation>
</operations>
````
And a meta file that represents a tax rule, which would look something like this:

````
<?xml version="1.0" encoding="UTF-8"?>
<operations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd">
    <operation name="CreateTaxRule" dataType="tax_rule" type="create" auth="adminOauth" url="/V1/taxRules" method="POST">
        <contentType>application/json</contentType>
        <object dataType="tax_rule" key="rule">
            <field key="code">string</field>
            <field key="priority">integer</field>
            <field key="position">integer</field>
            <array key="customer_tax_class_ids">
                <value>integer</value>
            </array>
            <array key="product_tax_class_ids">
                <value>integer</value>
            </array>
            <array key="tax_rate_ids">
                <value>tax_rate.id</value>
            </array>
        </object>
    </operation>
</operations>
````

Notice the `<value>tax_rate.id</value>` inside the `tax_rule` entity. Now a tax rule can be created successfully.

<!--- Provide a description of the changes proposed in the pull request -->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests