### PR TITLE
MQE-818: Enable executeJS to save a variable

### DIFF
--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -88,7 +88,7 @@ class BasicFunctionalTestCest
 		$I->dontSeeOptionIsSelected(".functionalTestSelector", "someInput");
 		$I->doubleClick(".functionalTestSelector");
 		$I->dragAndDrop(".functionalTestSelector", ".functionalTestSelector2");
-		$I->executeJS("someJSFunction");
+		$executeJSKey1 = $I->executeJS("someJSFunction");
 		$I->fillField(".functionalTestSelector", "someInput");
 		$I->fillField(".functionalTestSelector", "0");
 		$grabAttributeFromKey1 = $I->grabAttributeFrom(".functionalTestSelector", "someInput");

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -913,7 +913,12 @@ class TestGenerator
                     $testSteps .= $this->wrapFunctionCall($actor, $actionObject, $function);
                     break;
                 case "executeJS":
-                    $testSteps .= $this->wrapFunctionCall($actor, $actionObject, $function);
+                    $testSteps .= $this->wrapFunctionCallWithReturnValue(
+                        $stepKey,
+                        $actor,
+                        $actionObject,
+                        $function
+                    );
                     break;
                 case "performOn":
                 case "waitForElementChange":


### PR DESCRIPTION

### Description
- executeJS now assigns a variable for storage.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#818: Enable executeJS to save a variable

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests