### PR TITLE
MQE-768: Framework cannot depend on relative file structure to execute tests

### DIFF
--- a/dev/tests/_bootstrap.php
+++ b/dev/tests/_bootstrap.php
@@ -42,6 +42,7 @@ $RELATIVE_TESTS_MODULE_PATH = DIRECTORY_SEPARATOR . 'verification';
 
 defined('TESTS_BP') || define('TESTS_BP', __DIR__);
 defined('TESTS_MODULE_PATH') || define('TESTS_MODULE_PATH', TESTS_BP . $RELATIVE_TESTS_MODULE_PATH);
+defined('MAGENTO_BP') || define('MAGENTO_BP', __DIR__);
 
 $utilDir = DIRECTORY_SEPARATOR . 'Util'. DIRECTORY_SEPARATOR . '*.php';
 

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -223,7 +223,6 @@ class ModuleResolver
     {
         $allModulePaths = [];
 
-        // TODO update these paths when we switch a composer based pathing
         // Define the Module paths from app/code
         $appCodePath = MAGENTO_BP
             . DIRECTORY_SEPARATOR

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -225,7 +225,7 @@ class ModuleResolver
 
         // TODO update these paths when we switch a composer based pathing
         // Define the Module paths from app/code
-        $appCodePath = dirname(dirname(dirname(PROJECT_ROOT)))
+        $appCodePath = MAGENTO_BP
             . DIRECTORY_SEPARATOR
             . 'app' . DIRECTORY_SEPARATOR
             . 'code' . DIRECTORY_SEPARATOR;
@@ -234,7 +234,7 @@ class ModuleResolver
         $modulePath = defined('TESTS_MODULE_PATH') ? TESTS_MODULE_PATH : TESTS_BP;
 
         // Define the Module paths from vendor modules
-        $vendorCodePath = dirname(dirname(dirname(PROJECT_ROOT)))
+        $vendorCodePath = MAGENTO_BP
             . DIRECTORY_SEPARATOR
             . 'vendor' . DIRECTORY_SEPARATOR;
 

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -233,7 +233,7 @@ class ModuleResolver
         $modulePath = defined('TESTS_MODULE_PATH') ? TESTS_MODULE_PATH : TESTS_BP;
 
         // Define the Module paths from vendor modules
-        $vendorCodePath = MAGENTO_BP
+        $vendorCodePath = PROJECT_ROOT
             . DIRECTORY_SEPARATOR
             . 'vendor' . DIRECTORY_SEPARATOR;
 


### PR DESCRIPTION
### Description
- MFTF and MFTF Tests can now interact with one another properly even if installed via composer. Pathing and anchoring is now done via composer autoload file checking.
- ModuleResolver now correctly refers to MAGENTO_BP instead of relative pathing.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#768: Framework cannot depend on relative file structure to execute tests

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests