### PR TITLE
MQE-782: Fatal error is thrown when a group name conflicts with an existing suite name

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Suite/Util/SuiteObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Util/SuiteObjectExtractor.php
@@ -40,6 +40,8 @@ class SuiteObjectExtractor extends BaseObjectExtractor
      * @param array $parsedSuiteData
      * @return array
      * @throws XmlException
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function parseSuiteDataIntoObjects($parsedSuiteData)
     {
@@ -64,6 +66,19 @@ class SuiteObjectExtractor extends BaseObjectExtractor
             }
 
             $suiteHooks = [];
+
+            //Check for collisions between suite name and existing group name
+            $suiteName = $parsedSuite[self::NAME];
+            $testGroupConflicts = TestObjectHandler::getInstance()->getTestsByGroup($suiteName);
+            if (!empty($testGroupConflicts)) {
+                $testGroupConflictsFileNames = "";
+                foreach ($testGroupConflicts as $test) {
+                    $testGroupConflictsFileNames .= $test->getFilename() . "\n";
+                }
+                $exceptionmessage = "\"Suite names and Group names can not have the same value. \t\n" .
+                    "Suite: \"{$suiteName}\" also exists as a group annotation in: \n{$testGroupConflictsFileNames}";
+                throw new XmlException($exceptionmessage);
+            }
 
             //extract include and exclude references
             $groupTestsToInclude = $parsedSuite[self::INCLUDE_TAG_NAME] ?? [];

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -44,19 +44,28 @@ class TestObject
     private $hooks = [];
 
     /**
+     * String of filename of test
+     *
+     * @var String
+     */
+    private $filename;
+
+    /**
      * TestObject constructor.
      *
      * @param string $name
      * @param ActionObject[] $parsedSteps
      * @param array $annotations
      * @param TestHookObject[] $hooks
+     * @param String $filename
      */
-    public function __construct($name, $parsedSteps, $annotations, $hooks)
+    public function __construct($name, $parsedSteps, $annotations, $hooks, $filename = null)
     {
         $this->name = $name;
         $this->parsedSteps = $parsedSteps;
         $this->annotations = $annotations;
         $this->hooks = $hooks;
+        $this->filename = $filename;
     }
 
     /**
@@ -67,6 +76,16 @@ class TestObject
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Getter for the Test Filename
+     *
+     * @return string
+     */
+    public function getFilename()
+    {
+        return $this->filename;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
During generation, for the specified test set, if there is a conflict between a suite name and a group name, generation fails. An error is printed with the suite and test details of the conflict

### Fixed Issues (if relevant)
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests