### PR TITLE
Add ability to use array entities as arguments.

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionObjectTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionObjectTest.php
@@ -256,6 +256,35 @@ class ActionObjectTest extends TestCase
     }
 
     /**
+     * {{EntityDataObject.values}} should be replaced with ["value1","value2"]
+     */
+    public function testResolveArrayData()
+    {
+        // Set up mocks
+        $actionObject = new ActionObject('merge123', 'fillField', [
+            'selector' => '#selector',
+            'userInput' => '{{EntityDataObject.values}}'
+        ]);
+        $entityDataObject = new EntityDataObject('EntityDataObject', 'test', [
+            'values' => [
+                'value1',
+                'value2'
+            ]
+        ], [], '', '');
+        $this->mockDataHandlerWithData($entityDataObject);
+
+        // Call the method under test
+        $actionObject->resolveReferences();
+
+        // Verify
+        $expected = [
+            'selector' => '#selector',
+            'userInput' => '["value1","value2"]'
+        ];
+        $this->assertEquals($expected, $actionObject->getCustomActionAttributes());
+    }
+
+    /**
      * Action object should throw an exception if a reference to a parameterized selector has too few given args.
      */
     public function testTooFewArgumentException()

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionObjectTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionObjectTest.php
@@ -268,7 +268,8 @@ class ActionObjectTest extends TestCase
         $entityDataObject = new EntityDataObject('EntityDataObject', 'test', [
             'values' => [
                 'value1',
-                'value2'
+                'value2',
+                '"My" Value'
             ]
         ], [], '', '');
         $this->mockDataHandlerWithData($entityDataObject);
@@ -279,7 +280,7 @@ class ActionObjectTest extends TestCase
         // Verify
         $expected = [
             'selector' => '#selector',
-            'userInput' => '["value1","value2"]'
+            'userInput' => '["value1","value2","\"My\" Value"]'
         ];
         $this->assertEquals($expected, $actionObject->getCustomActionAttributes());
     }

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -495,6 +495,10 @@ class ActionObject
                 $this->setTimeout($obj->getElement($objField)->getTimeout());
             } elseif (get_class($obj) == EntityDataObject::class) {
                 $replacement = $this->resolveEntityDataObjectReference($obj, $match);
+
+                if (is_array($replacement)) {
+                    $replacement = '["' . implode('","', array_map('addSlashes', $replacement)) . '"]';
+                }
             }
 
             if ($replacement === null) {
@@ -503,9 +507,6 @@ class ActionObject
                 } else {
                     throw new TestReferenceException("Could not resolve entity reference " . $inputString);
                 }
-            }
-            elseif (is_array($replacement)) {
-                $replacement = '["' . implode('","', array_map('addSlashes',$replacement)) . '"]';
             }
 
             $replacement = $this->resolveParameterization($parameterized, $replacement, $match, $obj);

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -496,6 +496,10 @@ class ActionObject
 
             $replacement = $this->resolveParameterization($parameterized, $replacement, $match, $obj);
 
+            if (is_array($replacement)) {
+                $replacement = '["' . implode('","', $replacement) . '"]';
+            }
+
             $outputString = str_replace($match, $replacement, $outputString);
         }
         return $outputString;

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -493,12 +493,11 @@ class ActionObject
                     throw new TestReferenceException("Could not resolve entity reference " . $inputString);
                 }
             }
+            elseif (is_array($replacement)) {
+                $replacement = '["' . implode('","', array_map('addSlashes',$replacement)) . '"]';
+            }
 
             $replacement = $this->resolveParameterization($parameterized, $replacement, $match, $obj);
-
-            if (is_array($replacement)) {
-                $replacement = '["' . implode('","', $replacement) . '"]';
-            }
 
             $outputString = str_replace($match, $replacement, $outputString);
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Added support for passing array entities as arguments.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
As a Test Engineer I want to pass data entity arrays as arguments so that I can not have to use hard-coded flat arrays.

For example:

**The Entity**

```xml
<entities>
    <entity name="DefaultCustomerGroup" type="customerGroup">
        <array key="group_names">
            <item>Default</item>
        </array>
    </entity>
</entities>
```

**The ActionGroup**

```xml
<actionGroups>
    <actionGroup name="searchAndMultiSelectActionGroup">
        <arguments>
            <argument name="options" />
        </arguments>
        <selectMultipleOptions filterSelector="foo" optionSelector="bar" stepKey="selectSpecifiedOptions">
            <array>{{options}}</array>
        </selectMultipleOptions>
    </actionGroup>
</actionGroups>
```

**The Test**

```xml
<tests>
    <test name="AdminCreateCustomerTest">
        <actionGroup ref="searchAndMultiSelectActionGroup" stepKey="searchAndSelectGroup">
            <argument name="options" value="DefaultCustomerGroup.group_names"/>
        </actionGroup>
    </test>
</tests>
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests