### PR TITLE
MQE-699:  Exception message for "conditionalClick" failure uses '$selector' instead of '$dependentSelector'.

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -472,7 +472,7 @@ class MagentoWebDriver extends WebDriver
     {
         $el = $this->_findElements($dependentSelector);
         if (sizeof($el) > 1) {
-            throw new \Exception("more than one element matches selector " . $selector);
+            throw new \Exception("more than one element matches selector " . $dependentSelector);
         }
 
         $clickCondition = null;


### PR DESCRIPTION
### Description
- Fixed exception message for conditionalClick

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests