### PR TITLE
MQE-899: Excessive double quotes are being generated in WaitForElementChange method arguments

### DIFF
--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -112,6 +112,7 @@ class BasicFunctionalTestCest
 		$I->moveMouseOver(".functionalTestSelector");
 		$I->openNewTab();
 		$I->pauseExecution();
+		$I->performOn("#selector", function(\WebDriverElement $el) {return $el->isDisplayed();});
 		$I->pressKey("#page", "a");
 		$I->pressKey("#page", ['ctrl','a'],'new');
 		$I->pressKey("#page", ['shift','111'],'1','x');
@@ -150,6 +151,7 @@ class BasicFunctionalTestCest
 		$I->waitForElement(".functionalTestSelector", 30);
 		$I->waitForElementNotVisible(".functionalTestSelector", 30);
 		$I->waitForElementVisible(".functionalTestSelector", 30);
+		$I->waitForElementChange("#selector", function(\WebDriverElement $el) {return $el->isDisplayed();});
 		$I->waitForJS("someJsFunction", 30);
 		$I->waitForText("someInput", 30, ".functionalTestSelector");
 	}

--- a/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml
+++ b/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml
@@ -73,6 +73,7 @@
         <moveMouseOver selector=".functionalTestSelector" stepKey="moveMouseOverKey1"/>
         <openNewTab stepKey="openNewTabKey1"/>
         <pauseExecution stepKey="pauseExecutionKey1"/>
+        <performOn selector="#selector" function="function(\WebDriverElement $el) {return $el->isDisplayed();}" stepKey="performOnKey1"/>
         <pressKey selector="#page" userInput="a" stepKey="pressKey1"/>
         <pressKey selector="#page" parameterArray="[['ctrl','a'],'new']" stepKey="pressKey2"/>
         <pressKey selector="#page" parameterArray="[['shift','111'],'1','x']" stepKey="pressKey3"/>
@@ -113,6 +114,7 @@
         <waitForElement time="30" selector=".functionalTestSelector" stepKey="waitForElementKey1" />
         <waitForElementNotVisible selector=".functionalTestSelector" time="30" stepKey="waitForElementNotVisibleKey1" />
         <waitForElementVisible selector=".functionalTestSelector" time="30" stepKey="waitForElementVisibleKey1" />
+        <waitForElementChange selector="#selector" function="function(\WebDriverElement $el) {return $el->isDisplayed();}" stepKey="waitForElementChangeKey1"/>
         <waitForJS function="someJsFunction" time="30" stepKey="waitForJSKey1" />
         <waitForText selector=".functionalTestSelector" userInput="someInput" time="30" stepKey="waitForText1"/>
     </test>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -37,6 +37,7 @@ class ActionObject
     const ASSERTION_VALUE_ATTRIBUTE = "value";
     const DELETE_DATA_MUTUAL_EXCLUSIVE_ATTRIBUTES = ["url", "createDataKey"];
     const EXTERNAL_URL_AREA_INVALID_ACTIONS = ['amOnPage'];
+    const FUNCTION_CLOSURE_ACTIONS = ['waitForElementChange', 'performOn'];
     const MERGE_ACTION_ORDER_AFTER = 'after';
     const MERGE_ACTION_ORDER_BEFORE = 'before';
     const ACTION_ATTRIBUTE_URL = 'url';

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -590,6 +590,10 @@ class TestGenerator
 
             if (isset($customActionAttributes['function'])) {
                 $function = $this->addUniquenessFunctionCall($customActionAttributes['function']);
+                if (in_array($actionObject->getType(), ActionObject::FUNCTION_CLOSURE_ACTIONS)) {
+                    // Argument must be a closure function, not a string.
+                    $function = trim($function, '"');
+                }
             }
 
             if (isset($customActionAttributes['html'])) {


### PR DESCRIPTION
### Description
- Fixed quote issue in waitForElementChanged. Also included fix for performOn, as it's the only other codeception function that takes a closure as an argument.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#<899>: Excessive double quotes are being generated in WaitForElementChange method arguments

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests