### PR TITLE
MQE-970: Tests in Suites being omitted when line counts are exact match

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Util/Sorter/ParallelGroupSorter.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Sorter/ParallelGroupSorter.php
@@ -243,7 +243,7 @@ class ParallelGroupSorter
             $split_suites["{$suiteName}_${split_count}"] = $group;
             $this->addSuiteToConfig($suiteName, "{$suiteName}_${split_count}", $group);
 
-            $availableTests = array_diff($availableTests, $group);
+            $availableTests = array_diff_key($availableTests, $group);
             $split_count++;
         }
 


### PR DESCRIPTION
### Description
- array_diff to array_diff_key in ParallelGroupSorter.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#970: Tests in Suites being omitted when line counts are exact match

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests