### PR TITLE
MQE-971: DeleteData using url is generated incorrectly in Suite hooks

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
@@ -132,6 +132,7 @@ class GroupClassGenerator
         foreach ($hookObj->getActions() as $action) {
             /** @var ActionObject $action */
             $index = count($actions);
+            //deleteData contains either url or createDataKey, if it contains the former it needs special formatting
             if ($action->getType() !== "createData"
                 && !array_key_exists(TestGenerator::REQUIRED_ENTITY_REFERENCE, $action->getCustomActionAttributes())) {
                 if (!$hasWebDriverActions) {

--- a/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
@@ -27,7 +27,6 @@ class GroupClassGenerator
     const LAST_REQUIRED_ENTITY_TAG = 'last';
     const MUSTACHE_VAR_TAG = 'var';
     const MAGENTO_CLI_COMMAND_COMMAND = 'command';
-    const DATA_PERSISTENCE_ACTIONS = ["createData", "deleteData"];
     const REPLACEMENT_ACTIONS = [
         'comment' => 'print'
     ];
@@ -133,7 +132,8 @@ class GroupClassGenerator
         foreach ($hookObj->getActions() as $action) {
             /** @var ActionObject $action */
             $index = count($actions);
-            if (!in_array($action->getType(), self::DATA_PERSISTENCE_ACTIONS)) {
+            if ($action->getType() !== "createData"
+                && !array_key_exists(TestGenerator::REQUIRED_ENTITY_REFERENCE, $action->getCustomActionAttributes())) {
                 if (!$hasWebDriverActions) {
                     $hasWebDriverActions = true;
                 }


### PR DESCRIPTION
### Description
- Changed conditional for actions to use TestGenerator to be based on "createDataKey" existance.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#971: DeleteData using url is generated incorrectly in Suite hooks

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests