### PR TITLE
MQE-1043: MFTF force flag should ignore the magento base url even when valid

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Exceptions/TestFrameworkException.php
+++ b/src/Magento/FunctionalTestingFramework/Exceptions/TestFrameworkException.php
@@ -6,6 +6,8 @@
 
 namespace Magento\FunctionalTestingFramework\Exceptions;
 
+use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
+
 /**
  * Class TestFrameworkException
  */
@@ -14,9 +16,17 @@ class TestFrameworkException extends \Exception
     /**
      * TestFrameworkException constructor.
      * @param string $message
+     * @param array $context
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    public function __construct($message)
+    public function __construct($message, $context = [])
     {
+        list($childClass, $callingClass) = debug_backtrace(false, 2);
+        LoggingUtil::getInstance()->getLogger($callingClass['class'])->error(
+            $message,
+            $context
+        );
+
         parent::__construct($message);
     }
 }


### PR DESCRIPTION
### Description
- the flag `--force` now completely ignores magento modules when generating.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests