### PR TITLE
MQE-1038: bin/mftf commands which exceed 60 seconds timeout

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Console/BuildProjectCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/BuildProjectCommand.php
@@ -76,6 +76,8 @@ class BuildProjectCommand extends Command
         $codeceptBuildCommand = realpath(PROJECT_ROOT . '/vendor/bin/codecept') .  ' build';
         $process = new Process($codeceptBuildCommand);
         $process->setWorkingDirectory(TESTS_BP);
+        $process->setIdleTimeout(600);
+        $process->setTimeout(0);
         $process->run(
             function ($type, $buffer) use ($output) {
                 if ($output->isVerbose()) {

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -63,11 +63,12 @@ class RunTestCommand extends Command
 
         $process = new Process($codeceptionCommand);
         $process->setWorkingDirectory(TESTS_BP);
+        $process->setIdleTimeout(600);
+        $process->setTimeout(0);
         $process->run(
             function ($type, $buffer) use ($output) {
                 $output->write($buffer);
             }
         );
     }
-
 }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -68,6 +68,8 @@ class RunTestGroupCommand extends Command
 
         $process = new Process($codeceptionCommand);
         $process->setWorkingDirectory(TESTS_BP);
+        $process->setIdleTimeout(600);
+        $process->setTimeout(0);
         $process->run(
             function ($type, $buffer) use ($output) {
                 $output->write($buffer);


### PR DESCRIPTION
### Description
- added idletimeout/timeout to all $process calls in bin/mftf commands

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests