### PR TITLE
MQE-1016: Variable Substitution Does Not Work For Command Attribute In MagentoCLI Action

### DIFF
--- a/dev/tests/verification/Resources/DataReplacementTest.txt
+++ b/dev/tests/verification/Resources/DataReplacementTest.txt
@@ -51,5 +51,7 @@ class DataReplacementTestCest
 		$I->searchAndMultiSelectOption("#selector", [msq("uniqueData") . "John", "Doe" . msq("uniqueData")]);
 		$I->selectMultipleOptions("#Doe" . msq("uniqueData"), "#element", [msq("uniqueData") . "John", "Doe" . msq("uniqueData")]);
 		$I->fillField(".selector", "0");
+		$insertCommand = $I->magentoCLI("do something Doe" . msq("uniqueData") . " with uniqueness");
+		$I->comment($insertCommand);
 	}
 }

--- a/dev/tests/verification/TestModule/Test/DataReplacementTest.xml
+++ b/dev/tests/verification/TestModule/Test/DataReplacementTest.xml
@@ -37,5 +37,6 @@
         </selectMultipleOptions>
 
         <fillField stepKey="insertZero" selector=".selector" userInput="{{simpleData.favoriteIndex}}"/>
+        <magentoCLI stepKey="insertCommand" command="do something {{uniqueData.lastname}} with uniqueness"/>
     </test>
 </tests>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -31,7 +31,8 @@ class ActionObject
         "x",
         "y",
         "expectedResult",
-        "actualResult"
+        "actualResult",
+        "command"
     ];
     const SELECTOR_ENABLED_ATTRIBUTES = [
         'selector',
@@ -40,7 +41,8 @@ class ActionObject
         "selector2",
         "function",
         'filterSelector',
-        'optionSelector'
+        'optionSelector',
+        "command"
     ];
     const OLD_ASSERTION_ATTRIBUTES = ["expected", "expectedType", "actual", "actualType"];
     const ASSERTION_ATTRIBUTES = ["expectedResult" => "expected", "actualResult" => "actual"];

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -500,7 +500,7 @@ class TestGenerator
             $this->validateXmlAttributesMutuallyExclusive($stepKey, $actionObject->getType(), $customActionAttributes);
 
             if (isset($customActionAttributes['command'])) {
-                $command = $customActionAttributes['command'];
+                $command = $this->addUniquenessFunctionCall($customActionAttributes['command']);
             }
 
             if (isset($customActionAttributes['attribute'])) {
@@ -1217,7 +1217,7 @@ class TestGenerator
                         $stepKey,
                         $actor,
                         $actionObject,
-                        $this->wrapWithDoubleQuotes($command)
+                        $command
                     );
                     $testSteps .= sprintf(
                         "\t\t$%s->comment(\$%s);\n",


### PR DESCRIPTION
### Description
- added `command` to replacement enabled attributes

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests