### PR TITLE
MQE-1021: Empty Action StepKey Attribute Issues

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionGroupObjectExtractorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionGroupObjectExtractorTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace tests\unit\Magento\FunctionalTestFramework\Test\Util;
+
+use Magento\FunctionalTestingFramework\Test\Util\ActionGroupObjectExtractor;
+use Magento\FunctionalTestingFramework\Util\MagentoTestCase;
+use tests\unit\Util\TestLoggingUtil;
+
+class ActionGroupObjectExtractorTest extends MagentoTestCase
+{
+    /** @var  ActionGroupObjectExtractor */
+    private $testActionGroupObjectExtractor;
+
+    /**
+     * Setup method
+     */
+    public function setUp()
+    {
+        $this->testActionGroupObjectExtractor = new ActionGroupObjectExtractor();
+        TestLoggingUtil::getInstance()->setMockLoggingUtil();
+    }
+
+    /**
+     * Tests basic action object extraction with an empty stepKey
+     */
+    public function testEmptyStepKey()
+    {
+        $this->expectExceptionMessage("StepKeys cannot be empty.	Action='sampleAction' in filename.xml");
+        $this->testActionGroupObjectExtractor->extractActionGroup($this->createBasicActionObjectArray(""));
+    }
+
+    /**
+     * Utility function to return mock parser output for testing extraction into ActionObjects.
+     *
+     * @param string $stepKey
+     * @param string $actionGroup
+     * @param string $filename
+     * @return array
+     */
+    private function createBasicActionObjectArray(
+        $stepKey = 'testAction1',
+        $actionGroup = "actionGroup",
+        $filename = "filename.xml"
+    ) {
+        $baseArray = [
+            'nodeName' => 'actionGroup',
+            'name' => $actionGroup,
+            'filename' => $filename,
+            $stepKey => [
+                "nodeName" => "sampleAction",
+                "stepKey" => $stepKey,
+                "someAttribute" => "someAttributeValue"
+            ]
+        ];
+        return $baseArray;
+    }
+
+    /**
+     * clean up function runs after all tests
+     */
+    public static function tearDownAfterClass()
+    {
+        TestLoggingUtil::getInstance()->clearMockLoggingUtil();
+    }
+}

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionGroupObjectExtractorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionGroupObjectExtractorTest.php
@@ -28,7 +28,9 @@ class ActionGroupObjectExtractorTest extends MagentoTestCase
      */
     public function testEmptyStepKey()
     {
-        $this->expectExceptionMessage("StepKeys cannot be empty.	Action='sampleAction' in filename.xml");
+        $this->expectExceptionMessage(
+            "StepKeys cannot be empty.	Action='sampleAction' in Action Group filename.xml"
+        );
         $this->testActionGroupObjectExtractor->extractActionGroup($this->createBasicActionObjectArray(""));
     }
 

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionObjectExtractorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionObjectExtractorTest.php
@@ -90,6 +90,15 @@ class ActionObjectExtractorTest extends MagentoTestCase
     }
 
     /**
+     * Tests basic action object extraction with an empty stepKey
+     */
+    public function testEmptyStepKey()
+    {
+        $this->expectExceptionMessage("StepKeys cannot be empty.	Action='sampleAction'");
+        $this->testActionObjectExtractor->extractActions($this->createBasicActionObjectArray(""));
+    }
+
+    /**
      * Utility function to return mock parser output for testing extraction into ActionObjects.
      *
      * @param string $stepKey

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionObjectExtractorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionObjectExtractorTest.php
@@ -50,7 +50,7 @@ class ActionObjectExtractorTest extends MagentoTestCase
         } catch (\Exception $e) {
             TestLoggingUtil::getInstance()->validateMockLogStatement(
                 'error',
-                'Line 103: Invalid ordering configuration in test',
+                'Line 108: Invalid ordering configuration in test',
                 [
                     'test' => 'TestWithSelfReferencingStepKey',
                     'stepKey' => ['invalidTestAction1']

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionGroupObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionGroupObjectExtractor.php
@@ -62,7 +62,11 @@ class ActionGroupObjectExtractor extends BaseObjectExtractor
         );
 
         // TODO filename is now available to the ActionGroupObject, integrate this into debug and error statements
-        $actions = $this->actionObjectExtractor->extractActions($actionData);
+        try {
+            $actions = $this->actionObjectExtractor->extractActions($actionData);
+        } catch (\Exception $error) {
+            throw new XmlException($error->getMessage() . " in " . $actionGroupData[self::FILENAME]);
+        }
 
         if (array_key_exists(self::ACTION_GROUP_ARGUMENTS, $actionGroupData)) {
             $arguments = $this->extractArguments($actionGroupData[self::ACTION_GROUP_ARGUMENTS]);

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionGroupObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionGroupObjectExtractor.php
@@ -65,7 +65,7 @@ class ActionGroupObjectExtractor extends BaseObjectExtractor
         try {
             $actions = $this->actionObjectExtractor->extractActions($actionData);
         } catch (\Exception $error) {
-            throw new XmlException($error->getMessage() . " in " . $actionGroupData[self::FILENAME]);
+            throw new XmlException($error->getMessage() . " in Action Group " . $actionGroupData[self::FILENAME]);
         }
 
         if (array_key_exists(self::ACTION_GROUP_ARGUMENTS, $actionGroupData)) {

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionObjectExtractor.php
@@ -27,6 +27,7 @@ class ActionObjectExtractor extends BaseObjectExtractor
     const ACTION_GROUP_ARG_VALUE = 'value';
     const BEFORE_AFTER_ERROR_MSG = "Merge Error - Steps cannot have both before and after attributes.\tStepKey='%s'";
     const STEP_KEY_BLACKLIST_ERROR_MSG = "StepKeys cannot contain non alphanumeric characters.\tStepKey='%s'";
+    const STEP_KEY_EMPTY_ERROR_MSG = "StepKeys cannot be empty.\tAction='%s'";
     const DATA_PERSISTENCE_CUSTOM_FIELD = 'field';
     const DATA_PERSISTENCE_CUSTOM_FIELD_KEY = 'key';
     const ACTION_OBJECT_PERSISTENCE_FIELDS = 'customFields';
@@ -58,6 +59,10 @@ class ActionObjectExtractor extends BaseObjectExtractor
 
         foreach ($testActions as $actionName => $actionData) {
             $stepKey = $actionData[self::TEST_STEP_MERGE_KEY];
+
+            if (empty($stepKey)) {
+                throw new XmlException(sprintf(self::STEP_KEY_EMPTY_ERROR_MSG, $actionData['nodeName']));
+            }
 
             if (preg_match('/[^a-zA-Z0-9_]/', $stepKey)) {
                 throw new XmlException(sprintf(self::STEP_KEY_BLACKLIST_ERROR_MSG, $actionName));


### PR DESCRIPTION
### Description
Actions with empty stepKeyswill now throw errors during generation instead of runtime.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests