### PR TITLE
MQE-1060: Allow magentoCLI Action To Run Without Manipulating Command That Is Sent To CLI

### DIFF
--- a/dev/tests/functional/_bootstrap.php
+++ b/dev/tests/functional/_bootstrap.php
@@ -29,4 +29,13 @@ if (file_exists(TESTS_BP . DIRECTORY_SEPARATOR . '.env')) {
     foreach ($_ENV as $key => $var) {
         defined($key) || define($key, $var);
     }
+
+    defined('MAGENTO_CLI_COMMAND_PATH') || define(
+        'MAGENTO_CLI_COMMAND_PATH',
+        'dev/tests/acceptance/utils/command.php'
+    );
+    $env->setEnvironmentVariable('MAGENTO_CLI_COMMAND_PATH', MAGENTO_CLI_COMMAND_PATH);
+
+    defined('MAGENTO_CLI_COMMAND_PARAMETER') || define('MAGENTO_CLI_COMMAND_PARAMETER', 'command');
+    $env->setEnvironmentVariable('MAGENTO_CLI_COMMAND_PARAMETER', MAGENTO_CLI_COMMAND_PARAMETER);
 }

--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -105,7 +105,7 @@ class BasicFunctionalTestCest
 		$grabMultipleKey1 = $I->grabMultiple(".functionalTestSelector");
 		$grabTextFromKey1 = $I->grabTextFrom(".functionalTestSelector");
 		$grabValueFromKey1 = $I->grabValueFrom(".functionalTestSelector");
-		$magentoCli1 = $I->magentoCLI("maintenance:enable");
+		$magentoCli1 = $I->magentoCLI("maintenance:enable", "\"stuffHere\"");
 		$I->comment($magentoCli1);
 		$I->makeScreenshot("screenShotInput");
 		$I->maximizeWindow();

--- a/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml
+++ b/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml
@@ -66,7 +66,7 @@
         <grabMultiple selector=".functionalTestSelector" stepKey="grabMultipleKey1" />
         <grabTextFrom selector=".functionalTestSelector" stepKey="grabTextFromKey1" />
         <grabValueFrom selector=".functionalTestSelector" stepKey="grabValueFromKey1" />
-        <magentoCLI command="maintenance:enable" stepKey="magentoCli1"/>
+        <magentoCLI command="maintenance:enable" arguments="&quot;stuffHere&quot;" stepKey="magentoCli1"/>
         <makeScreenshot userInput="screenShotInput" stepKey="makeScreenshotKey1"/>
         <maximizeWindow stepKey="maximizeWindowKey1"/>
         <moveBack stepKey="moveBackKey1"/>

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -435,13 +435,14 @@ class MagentoWebDriver extends WebDriver
     /**
      * Takes given $command and executes it against exposed MTF CLI entry point. Returns response from server.
      * @param string $command
-     * @returns string
+     * @param string $arguments
+     * @return string
      */
-    public function magentoCLI($command)
+    public function magentoCLI($command, $arguments)
     {
         $apiURL = $this->config['url'] . getenv('MAGENTO_CLI_COMMAND_PATH');
         $executor = new CurlTransport();
-        $executor->write($apiURL, [getenv('MAGENTO_CLI_COMMAND_PARAMETER') => $command], CurlInterface::POST, []);
+        $executor->write($apiURL, [getenv('MAGENTO_CLI_COMMAND_PARAMETER') => $command], CurlInterface::POST, [$arguments]);
         $response = $executor->read();
         $executor->close();
         return $response;

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -438,11 +438,19 @@ class MagentoWebDriver extends WebDriver
      * @param string $arguments
      * @return string
      */
-    public function magentoCLI($command, $arguments)
+    public function magentoCLI($command, $arguments = null)
     {
         $apiURL = $this->config['url'] . getenv('MAGENTO_CLI_COMMAND_PATH');
         $executor = new CurlTransport();
-        $executor->write($apiURL, [getenv('MAGENTO_CLI_COMMAND_PARAMETER') => $command], CurlInterface::POST, [$arguments]);
+        $executor->write(
+            $apiURL,
+            [
+                getenv('MAGENTO_CLI_COMMAND_PARAMETER') => $command,
+                'arguments' => $arguments
+            ],
+            CurlInterface::POST,
+            []
+        );
         $response = $executor->read();
         $executor->close();
         return $response;

--- a/src/Magento/FunctionalTestingFramework/Test/etc/Actions/customActions.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/Actions/customActions.xsd
@@ -42,6 +42,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute type="xs:string" name="arguments">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Arguments for Magento CLI command, will not be escaped.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
                 <xs:attributeGroup ref="commonActionAttributes"/>
             </xs:extension>
         </xs:simpleContent>

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -489,6 +489,7 @@ class TestGenerator
             $dependentSelector = null;
             $visible = null;
             $command = null;
+            $arguments = null;
             $sortOrder = null;
             $storeCode = null;
 
@@ -503,6 +504,9 @@ class TestGenerator
 
             if (isset($customActionAttributes['command'])) {
                 $command = $this->addUniquenessFunctionCall($customActionAttributes['command']);
+            }
+            if (isset($customActionAttributes['arguments'])) {
+                $arguments = $this->addUniquenessFunctionCall($customActionAttributes['arguments']);
             }
 
             if (isset($customActionAttributes['attribute'])) {
@@ -1219,7 +1223,8 @@ class TestGenerator
                         $stepKey,
                         $actor,
                         $actionObject,
-                        $command
+                        $command,
+                        $arguments
                     );
                     $testSteps .= sprintf(
                         "\t\t$%s->comment(\$%s);\n",


### PR DESCRIPTION

### Description
Added an `argument` attribute to magentoCLI to pass in unescaped arguments

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests