### PR TITLE
MQE-1037: Passing Multiple Element References In Selector Parameters Does Not Generate Correctly When Multiple Elements Are Parameterized

### DIFF
--- a/dev/tests/verification/Resources/SectionReplacementTest.txt
+++ b/dev/tests/verification/Resources/SectionReplacementTest.txt
@@ -64,5 +64,7 @@ class SectionReplacementTestCest
 		$I->click("#stringLiteral1-" . $createdData->getCreatedDataByName('firstname') . " .{$data}");
 		$I->click("#stringLiteral1-" . $createdData->getCreatedDataByName('firstname') . " ." . msq("uniqueData") . "John");
 		$I->click("#stringLiteral1-" . $createdData->getCreatedDataByName('firstname') . " .Doe" . msq("uniqueData"));
+		$I->click("#element .1#element .2");
+		$I->click("#element .1#element .{$data}");
 	}
 }

--- a/dev/tests/verification/TestModule/Test/SectionReplacementTest.xml
+++ b/dev/tests/verification/TestModule/Test/SectionReplacementTest.xml
@@ -43,10 +43,12 @@
         <click stepKey="selectorReplaceThreeParamVariable" selector="{{SampleSection.threeParamElement({$data1}, {$data2}, {$data3})}}"/>
         <click stepKey="selectorReplaceThreeParamVariableOneDupe" selector="{{SampleSection.threeOneDuplicateParamElement(simpleData.firstname, simpleData.lastname, simpleData.middlename)}}"/>
 
-
         <click stepKey="selectorReplaceThreeParamMixed1" selector="{{SampleSection.threeParamElement('stringLiteral1', $createdData.firstname$, simpleData.firstname)}}"/>
         <click stepKey="selectorReplaceThreeParamMixed2" selector="{{SampleSection.threeParamElement('stringLiteral1', $createdData.firstname$, {$data})}}"/>
         <click stepKey="selectorReplaceThreeParamMixedMSQPrefix" selector="{{SampleSection.threeParamElement('stringLiteral1', $createdData.firstname$, uniqueData.firstname)}}"/>
         <click stepKey="selectorReplaceThreeParamMixedMSQSuffix" selector="{{SampleSection.threeParamElement('stringLiteral1', $createdData.firstname$, uniqueData.lastname)}}"/>
+
+        <click stepKey="selectorReplaceTwoParamElements" selector="{{SampleSection.oneParamElement('1')}}{{SampleSection.oneParamElement('2')}}"/>
+        <click stepKey="selectorReplaceTwoParamMixedTypes" selector="{{SampleSection.oneParamElement('1')}}{{SampleSection.oneParamElement({$data})}}"/>
     </test>
 </tests>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -65,7 +65,7 @@ class ActionObject
     const ACTION_ATTRIBUTE_URL = 'url';
     const ACTION_ATTRIBUTE_SELECTOR = 'selector';
     const ACTION_ATTRIBUTE_VARIABLE_REGEX_PARAMETER = '/\(.+\)/';
-    const ACTION_ATTRIBUTE_VARIABLE_REGEX_PATTERN = '/({{[\w]+\.[\w\[\]]+}})|({{[\w]+\.[\w]+\(.+\)}})/';
+    const ACTION_ATTRIBUTE_VARIABLE_REGEX_PATTERN = '/({{[\w]+\.[\w\[\]]+}})|({{[\w]+\.[\w]+\((?(?!}}).)+\)}})/';
 
     /**
      * The unique identifier for the action


### PR DESCRIPTION
### Description
- Added negative lookahead for regex.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests