### PR TITLE
MQE-1068: Require Issue ID for Skipped Test

### DIFF
--- a/dev/tests/verification/Resources/ChildExtendedTestNoParent.txt
+++ b/dev/tests/verification/Resources/ChildExtendedTestNoParent.txt
@@ -34,6 +34,6 @@ class ChildExtendedTestNoParentCest
 	 */
 	public function ChildExtendedTestNoParent(AcceptanceTester $I, \Codeception\Scenario $scenario)
 	{
-		$scenario->skip("This test is skipped");
+		$scenario->skip("This test is skipped due to the following issues:\nNo issues have been specified.");
 	}
 }

--- a/dev/tests/verification/Resources/MergeSkip.txt
+++ b/dev/tests/verification/Resources/MergeSkip.txt
@@ -17,21 +17,17 @@ use Yandex\Allure\Adapter\Model\SeverityLevel;
 use Yandex\Allure\Adapter\Annotation\TestCaseId;
 
 /**
- * @Title("skippedTest")
- * @Description("")
  */
-class SkippedTestCest
+class MergeSkipCest
 {
 	/**
-	 * @Stories({"skipped"})
-	 * @Severity(level = SeverityLevel::MINOR)
 	 * @Features({"TestModule"})
 	 * @Parameter(name = "AcceptanceTester", value="$I")
 	 * @param AcceptanceTester $I
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function SkippedTest(AcceptanceTester $I, \Codeception\Scenario $scenario)
+	public function MergeSkip(AcceptanceTester $I, \Codeception\Scenario $scenario)
 	{
 		$scenario->skip("This test is skipped");
 	}

--- a/dev/tests/verification/Resources/MergeSkip.txt
+++ b/dev/tests/verification/Resources/MergeSkip.txt
@@ -29,6 +29,6 @@ class MergeSkipCest
 	 */
 	public function MergeSkip(AcceptanceTester $I, \Codeception\Scenario $scenario)
 	{
-		$scenario->skip("This test is skipped");
+		$scenario->skip("This test is skipped due to the following issues:\nIssue5");
 	}
 }

--- a/dev/tests/verification/Resources/SkippedTest.txt
+++ b/dev/tests/verification/Resources/SkippedTest.txt
@@ -1,0 +1,39 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Persist\DataPersistenceHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Objects\EntityDataObject;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ * @Title("skippedTest")
+ * @Description("")
+ * @skipIssueId SkippedValue
+ */
+class SkippedTestCest
+{
+	/**
+	 * @Stories({"skipped"})
+	 * @Severity(level = SeverityLevel::MINOR)
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function SkippedTest(AcceptanceTester $I, \Codeception\Scenario $scenario)
+	{
+		$scenario->skip("This test is skipped");
+	}
+}

--- a/dev/tests/verification/Resources/SkippedTestNoIssues.txt
+++ b/dev/tests/verification/Resources/SkippedTestNoIssues.txt
@@ -17,13 +17,14 @@ use Yandex\Allure\Adapter\Model\SeverityLevel;
 use Yandex\Allure\Adapter\Annotation\TestCaseId;
 
 /**
- * @Title("skippedTest")
+ * @Title("skippedNoIssuesTest")
  * @Description("")
+ * @group skip
  */
-class SkippedTestCest
+class SkippedTestNoIssuesCest
 {
 	/**
-	 * @Stories({"skipped"})
+	 * @Stories({"skippedNo"})
 	 * @Severity(level = SeverityLevel::MINOR)
 	 * @Features({"TestModule"})
 	 * @Parameter(name = "AcceptanceTester", value="$I")
@@ -31,8 +32,8 @@ class SkippedTestCest
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function SkippedTest(AcceptanceTester $I, \Codeception\Scenario $scenario)
+	public function SkippedTestNoIssues(AcceptanceTester $I, \Codeception\Scenario $scenario)
 	{
-		$scenario->skip("This test is skipped due to the following issues:\nSkippedValue");
+		$scenario->skip("This test is skipped due to the following issues:\nNo issues have been specified.");
 	}
 }

--- a/dev/tests/verification/Resources/SkippedTestTwoIssues.txt
+++ b/dev/tests/verification/Resources/SkippedTestTwoIssues.txt
@@ -33,6 +33,6 @@ class SkippedTestTwoIssuesCest
 	 */
 	public function SkippedTestTwoIssues(AcceptanceTester $I, \Codeception\Scenario $scenario)
 	{
-		$scenario->skip("This test is skipped");
+		$scenario->skip("This test is skipped due to the following issues:\nSkippedValue\nSecondSkippedValue");
 	}
 }

--- a/dev/tests/verification/Resources/SkippedTestTwoIssues.txt
+++ b/dev/tests/verification/Resources/SkippedTestTwoIssues.txt
@@ -19,8 +19,6 @@ use Yandex\Allure\Adapter\Annotation\TestCaseId;
 /**
  * @Title("skippedMultipleIssuesTest")
  * @Description("")
- * @skipIssueId SkippedValue
- * @skipIssueId SecondSkippedValue
  */
 class SkippedTestTwoIssuesCest
 {

--- a/dev/tests/verification/Resources/SkippedTestTwoIssues.txt
+++ b/dev/tests/verification/Resources/SkippedTestTwoIssues.txt
@@ -1,0 +1,40 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Persist\DataPersistenceHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Objects\EntityDataObject;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ * @Title("skippedMultipleIssuesTest")
+ * @Description("")
+ * @skipIssueId SkippedValue
+ * @skipIssueId SecondSkippedValue
+ */
+class SkippedTestTwoIssuesCest
+{
+	/**
+	 * @Stories({"skippedMultiple"})
+	 * @Severity(level = SeverityLevel::MINOR)
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function SkippedTestTwoIssues(AcceptanceTester $I, \Codeception\Scenario $scenario)
+	{
+		$scenario->skip("This test is skipped");
+	}
+}

--- a/dev/tests/verification/TestModule/Test/MergeFunctionalTest.xml
+++ b/dev/tests/verification/TestModule/Test/MergeFunctionalTest.xml
@@ -55,4 +55,7 @@
         <click stepKey="clickTwo" selector="#mergeTwo"/>
         <click stepKey="clickThree" selector="#mergeThree"/>
     </test>
+    <test name="MergeSkip">
+        <comment userInput="ThisTestShouldBeSkipped" stepKey="skipComment"/>
+    </test>
 </tests>

--- a/dev/tests/verification/TestModule/Test/SkippedTest.xml
+++ b/dev/tests/verification/TestModule/Test/SkippedTest.xml
@@ -31,4 +31,13 @@
             </skip>
         </annotations>
     </test>
+    <test name="SkippedTestNoIssues">
+        <annotations>
+            <stories value="skippedNo"/>
+            <title value="skippedNoIssuesTest"/>
+            <description value=""/>
+            <severity value="AVERAGE"/>
+            <group value="skip"/>
+        </annotations>
+    </test>
 </tests>

--- a/dev/tests/verification/TestModule/Test/SkippedTest.xml
+++ b/dev/tests/verification/TestModule/Test/SkippedTest.xml
@@ -14,7 +14,7 @@
             <title value="skippedTest"/>
             <description value=""/>
             <severity value="AVERAGE"/>
-            <skip>
+            <skip reason="CORE_ISSUE" description="Information">
                 <issueId value="SkippedValue"/>
             </skip>
         </annotations>
@@ -25,7 +25,7 @@
             <title value="skippedMultipleIssuesTest"/>
             <description value=""/>
             <severity value="AVERAGE"/>
-            <skip>
+            <skip reason="MFTF_ISSUE">
                 <issueId value="SkippedValue"/>
                 <issueId value="SecondSkippedValue"/>
             </skip>

--- a/dev/tests/verification/TestModule/Test/SkippedTest.xml
+++ b/dev/tests/verification/TestModule/Test/SkippedTest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="SkippedTest">
+        <annotations>
+            <stories value="skipped"/>
+            <title value="skippedTest"/>
+            <description value=""/>
+            <severity value="AVERAGE"/>
+            <skip>
+                <issueId value="SkippedValue"/>
+            </skip>
+        </annotations>
+    </test>
+    <test name="SkippedTestTwoIssues">
+        <annotations>
+            <stories value="skippedMultiple"/>
+            <title value="skippedMultipleIssuesTest"/>
+            <description value=""/>
+            <severity value="AVERAGE"/>
+            <skip>
+                <issueId value="SkippedValue"/>
+                <issueId value="SecondSkippedValue"/>
+            </skip>
+        </annotations>
+    </test>
+</tests>

--- a/dev/tests/verification/TestModule/Test/SkippedTest.xml
+++ b/dev/tests/verification/TestModule/Test/SkippedTest.xml
@@ -14,7 +14,7 @@
             <title value="skippedTest"/>
             <description value=""/>
             <severity value="AVERAGE"/>
-            <skip reason="CORE_ISSUE" description="Information">
+            <skip>
                 <issueId value="SkippedValue"/>
             </skip>
         </annotations>
@@ -25,7 +25,7 @@
             <title value="skippedMultipleIssuesTest"/>
             <description value=""/>
             <severity value="AVERAGE"/>
-            <skip reason="MFTF_ISSUE">
+            <skip>
                 <issueId value="SkippedValue"/>
                 <issueId value="SecondSkippedValue"/>
             </skip>

--- a/dev/tests/verification/TestModuleMerged/Test/MergeFunctionalTest.xml
+++ b/dev/tests/verification/TestModuleMerged/Test/MergeFunctionalTest.xml
@@ -28,7 +28,7 @@
     </test>
     <test name="MergeSkip">
         <annotations>
-            <skip reason="UNKNOWN" description="Short Explanation">
+            <skip>
                 <issueId value="Issue5"/>
             </skip>
         </annotations>

--- a/dev/tests/verification/TestModuleMerged/Test/MergeFunctionalTest.xml
+++ b/dev/tests/verification/TestModuleMerged/Test/MergeFunctionalTest.xml
@@ -26,4 +26,11 @@
         <click stepKey="step10" selector="#step10MergedInResult"/>
         <actionGroup ref="FunctionalActionGroupWithData" stepKey="step8Merge" after="step7Merge"/>
     </test>
+    <test name="MergeSkip">
+        <annotations>
+            <skip>
+                <issueId value="Issue5"/>
+            </skip>
+        </annotations>
+    </test>
 </tests>

--- a/dev/tests/verification/TestModuleMerged/Test/MergeFunctionalTest.xml
+++ b/dev/tests/verification/TestModuleMerged/Test/MergeFunctionalTest.xml
@@ -28,7 +28,7 @@
     </test>
     <test name="MergeSkip">
         <annotations>
-            <skip>
+            <skip reason="UNKNOWN" description="Short Explanation">
                 <issueId value="Issue5"/>
             </skip>
         </annotations>

--- a/dev/tests/verification/Tests/MergedGenerationTest.php
+++ b/dev/tests/verification/Tests/MergedGenerationTest.php
@@ -62,4 +62,15 @@ class MergedGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('MergeMassViaInsertAfter');
     }
+
+    /**
+     * Tests generation of a test skipped in merge.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testMergeSkipGeneration()
+    {
+        $this->generateAndCompareTest('MergeSkip');
+    }
 }

--- a/dev/tests/verification/Tests/SkippedGenerationTest.php
+++ b/dev/tests/verification/Tests/SkippedGenerationTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace tests\verification\Tests;
+
+use tests\util\MftfTestCase;
+
+class SkippedGenerationTest extends MftfTestCase
+{
+    /**
+     * Tests skipped test generation.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testSkippedGeneration()
+    {
+        $this->generateAndCompareTest('SkippedTest');
+    }
+
+    /**
+     * Tests skipped test with multiple issues generation.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testMultipleSkippedIssuesGeneration()
+    {
+        $this->generateAndCompareTest('SkippedTestTwoIssues');
+    }
+}

--- a/dev/tests/verification/Tests/SkippedGenerationTest.php
+++ b/dev/tests/verification/Tests/SkippedGenerationTest.php
@@ -30,4 +30,15 @@ class SkippedGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('SkippedTestTwoIssues');
     }
+
+    /**
+     * Tests skipped test generation with no specified issues. Will be deprecated after MFTF 3.0.0
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testSkippedNoIssueGeneration()
+    {
+        $this->generateAndCompareTest('SkippedTestNoIssues');
+    }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -258,6 +258,7 @@
                 <item name="/tests/test/annotations/group" xsi:type="string">/tests/test/annotations/group</item>
                 <item name="/tests/test/annotations/env" xsi:type="string">/tests/test/annotations/env</item>
                 <item name="/tests/test/annotations/return" xsi:type="string">/tests/test/annotations/return</item>
+                <item name="/tests/test/annotations/skip/issueId" xsi:type="string">/tests/test/annotations/skip/issueId</item>
             </argument>
         </arguments>
     </virtualType>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -126,7 +126,7 @@ class TestObject
      */
     public function isSkipped()
     {
-        // TODO remove elseif when group skip is no longer allowed
+        // TODO deprecation|deprecate MFTF 3.0.0 remove elseif when group skip is no longer allowed
         if (array_key_exists('skip', $this->annotations)) {
             return true;
         } elseif (array_key_exists('group', $this->annotations) && (in_array("skip", $this->annotations['group']))) {

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -130,7 +130,6 @@ class TestObject
         if (array_key_exists('skip', $this->annotations)) {
             return true;
         } elseif (array_key_exists('group', $this->annotations) && (in_array("skip", $this->annotations['group']))) {
-            print("Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags.");
             return true;
         }
         return false;

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -126,7 +126,11 @@ class TestObject
      */
     public function isSkipped()
     {
-        if (array_key_exists('group', $this->annotations) && (in_array("skip", $this->annotations['group']))) {
+        // TODO remove elseif when group skip is no longer allowed
+        if (array_key_exists('skip', $this->annotations)) {
+            return true;
+        } elseif (array_key_exists('group', $this->annotations) && (in_array("skip", $this->annotations['group']))) {
+            print("Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags.");
             return true;
         }
         return false;

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -138,10 +138,11 @@ class AnnotationExtractor extends BaseObjectExtractor
      */
     public function validateSkippedIssues($issues, $filename)
     {
-        foreach ($issues as $issueId)
-        if (empty($issueId['value'])) {
-            $message = "issueId for skipped tests cannot be empty. Test: $filename";
-            throw new XmlException($message);
+        foreach ($issues as $issueId) {
+            if (empty($issueId['value'])) {
+                $message = "issueId for skipped tests cannot be empty. Test: $filename";
+                throw new XmlException($message);
+            }
         }
     }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -71,7 +71,7 @@ class AnnotationExtractor extends BaseObjectExtractor
             foreach ($annotationData as $annotationValue) {
                 $annotationValues[] = $annotationValue[self::ANNOTATION_VALUE];
             }
-
+            // TODO deprecation|deprecate MFTF 3.0.0
             if ($annotationKey == "group" && in_array("skip", $annotationValues)) {
                 print(
                     "Test: $filename" .

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -44,6 +44,7 @@ class AnnotationExtractor extends BaseObjectExtractor
      * @param array $testAnnotations
      * @param string $filename
      * @return array
+     * @throws XmlException
      */
     public function extractAnnotations($testAnnotations, $filename)
     {
@@ -61,10 +62,14 @@ class AnnotationExtractor extends BaseObjectExtractor
                 );
                 continue;
             }
-
+            if ($annotationKey == "skip") {
+                $annotationData = $annotationData['issueId'];
+                $this->validateSkippedIssues($annotationData, $filename);
+            }
             foreach ($annotationData as $annotationValue) {
                 $annotationValues[] = $annotationValue[self::ANNOTATION_VALUE];
             }
+
             $annotationObjects[$annotationKey] = $annotationValues;
         }
         $this->addStoryTitleToMap($annotationObjects, $filename);
@@ -109,6 +114,22 @@ class AnnotationExtractor extends BaseObjectExtractor
                 $message .= "Story: '{$story}' Title: '{$title}' in Tests {$tests}\n\n";
 
             }
+            throw new XmlException($message);
+        }
+    }
+
+    /**
+     * Validates that all issueId tags contain a non-empty value
+     * @param array $issues
+     * @param string $filename
+     * @throws XmlException
+     * @return void
+     */
+    public function validateSkippedIssues($issues, $filename)
+    {
+        foreach ($issues as $issueId)
+        if (empty($issueId['value'])) {
+            $message = "issueId for skipped tests cannot be empty. Test: $filename";
             throw new XmlException($message);
         }
     }

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -75,12 +75,10 @@ class AnnotationExtractor extends BaseObjectExtractor
             }
             // TODO deprecation|deprecate MFTF 3.0.0
             if ($annotationKey == "group" && in_array("skip", $annotationValues)) {
-                if (MftfApplicationConfig::getConfig()->verboseEnabled()) {
-                    LoggingUtil::getInstance()->getLogger(AnnotationExtractor::class)->warning(
-                        "Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags.",
-                        ["test" => $filename]
-                    );
-                }
+                LoggingUtil::getInstance()->getLogger(AnnotationExtractor::class)->warning(
+                    "Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags.",
+                    ["test" => $filename]
+                );
             }
 
             $annotationObjects[$annotationKey] = $annotationValues;

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -6,7 +6,9 @@
 
 namespace Magento\FunctionalTestingFramework\Test\Util;
 
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Exceptions\XmlException;
+use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
 
 /**
  * Class AnnotationExtractor
@@ -73,12 +75,12 @@ class AnnotationExtractor extends BaseObjectExtractor
             }
             // TODO deprecation|deprecate MFTF 3.0.0
             if ($annotationKey == "group" && in_array("skip", $annotationValues)) {
-                print(
-                    "Test: $filename" .
-                    PHP_EOL .
-                    "Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags." .
-                    PHP_EOL
-                );
+                if (MftfApplicationConfig::getConfig()->verboseEnabled()) {
+                    LoggingUtil::getInstance()->getLogger(AnnotationExtractor::class)->warning(
+                        "Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags.",
+                        ["test" => $filename]
+                    );
+                }
             }
 
             $annotationObjects[$annotationKey] = $annotationValues;

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -62,12 +62,23 @@ class AnnotationExtractor extends BaseObjectExtractor
                 );
                 continue;
             }
+
             if ($annotationKey == "skip") {
                 $annotationData = $annotationData['issueId'];
                 $this->validateSkippedIssues($annotationData, $filename);
             }
+
             foreach ($annotationData as $annotationValue) {
                 $annotationValues[] = $annotationValue[self::ANNOTATION_VALUE];
+            }
+
+            if ($annotationKey == "group" && in_array("skip", $annotationValues)) {
+                print(
+                    "Test: $filename" .
+                    PHP_EOL .
+                    "Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags." .
+                    PHP_EOL
+                );
             }
 
             $annotationObjects[$annotationKey] = $annotationValues;

--- a/src/Magento/FunctionalTestingFramework/Test/etc/mergedTestSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/mergedTestSchema.xsd
@@ -29,6 +29,7 @@
             <xs:element type="annotationType" name="testCaseId" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="annotationType" name="useCaseId" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="annotationType" name="group" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element type="skipType" name="skip" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element type="annotationType" name="return" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
     </xs:complexType>
@@ -52,6 +53,18 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute type="severityEnum" name="value" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="skipType">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element type="issueType" name="issueId" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="issueType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute type="xs:string" name="value" use="required"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/src/Magento/FunctionalTestingFramework/Test/etc/mergedTestSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/mergedTestSchema.xsd
@@ -42,15 +42,6 @@
             <xs:enumeration value="CRITICAL"/>
         </xs:restriction>
     </xs:simpleType>
-    <xs:simpleType name="skippedReasonEnum" final="restriction">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="CORE_ISSUE"/>
-            <xs:enumeration value="MFTF_ISSUE"/>
-            <xs:enumeration value="UNKNOWN"/>
-            <xs:enumeration value="OTHER"/>
-            <xs:enumeration value="NONE"/>
-        </xs:restriction>
-    </xs:simpleType>
     <xs:complexType name="annotationType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -69,8 +60,6 @@
         <xs:sequence maxOccurs="unbounded">
             <xs:element type="issueType" name="issueId" maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:attribute type="skippedReasonEnum" name="reason" use="required"/>
-        <xs:attribute type="xs:string" name="description"/>
     </xs:complexType>
     <xs:complexType name="issueType">
         <xs:simpleContent>

--- a/src/Magento/FunctionalTestingFramework/Test/etc/mergedTestSchema.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/mergedTestSchema.xsd
@@ -42,6 +42,15 @@
             <xs:enumeration value="CRITICAL"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="skippedReasonEnum" final="restriction">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CORE_ISSUE"/>
+            <xs:enumeration value="MFTF_ISSUE"/>
+            <xs:enumeration value="UNKNOWN"/>
+            <xs:enumeration value="OTHER"/>
+            <xs:enumeration value="NONE"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="annotationType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -60,6 +69,8 @@
         <xs:sequence maxOccurs="unbounded">
             <xs:element type="issueType" name="issueId" maxOccurs="unbounded"/>
         </xs:sequence>
+        <xs:attribute type="skippedReasonEnum" name="reason" use="required"/>
+        <xs:attribute type="xs:string" name="description"/>
     </xs:complexType>
     <xs:complexType name="issueType">
         <xs:simpleContent>

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -437,12 +437,6 @@ class TestGenerator
                     $annotationToAppend .= sprintf(" * @group %s\n", $group);
                 }
                 break;
-
-            case "skip":
-                foreach ($annotationName as $issue) {
-                    $annotationToAppend .= sprintf(" * @skipIssueId %s\n", $issue);
-                }
-                break;
         }
 
         return $annotationToAppend;

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1529,7 +1529,14 @@ class TestGenerator
         $testAnnotations = $this->generateAnnotationsPhp($test->getAnnotations(), true);
         $dependencies = 'AcceptanceTester $I';
         if ($test->isSkipped()) {
-            $steps = "\t\t" . '$scenario->skip("This test is skipped");' . "\n";
+            $skipString = "This test is skipped due to the following issues:\\n";
+            $issues = $test->getAnnotations()['skip'] ?? null;
+            if (isset($issues)) {
+                $skipString .= implode("\\n", $issues);
+            } else {
+                $skipString .= "No issues have been specified.";
+            }
+            $steps = "\t\t" . '$scenario->skip("' . $skipString . '");' . "\n";
             $dependencies .= ', \Codeception\Scenario $scenario';
         } else {
             try {

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -437,6 +437,12 @@ class TestGenerator
                     $annotationToAppend .= sprintf(" * @group %s\n", $group);
                 }
                 break;
+
+            case "skip":
+                foreach ($annotationName as $issue) {
+                    $annotationToAppend .= sprintf(" * @skipIssueId %s\n", $issue);
+                }
+                break;
         }
 
         return $annotationToAppend;


### PR DESCRIPTION
Skip tags will now be required instead of using `<group value="skip"/>`

Tests still using `<group value="skip"/>` will cause deprecation warning on generation.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests