### PR TITLE
MQE-1047: magentoCLI command does not work if MAGENTO_BASE_URL uses index.php

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -457,12 +457,11 @@ class MagentoWebDriver extends WebDriver
      */
     public function magentoCLI($command, $arguments = null)
     {
-        // trim everything after first '/' in URL after http:// or https://
-        $apiURL = substr(
-            $this->config['url'],
-            0,
-            strpos($this->config['url'], "/", 8) + 1
-        );
+        // trim everything after first '/' in URL after (ex http://magento.instance/<index.php>)
+        preg_match("/.+\/\/[^\/]+\/?/", $this->config['url'], $trimmed);
+        $trimmedUrl = $trimmed[0];
+        $apiURL = $trimmedUrl . ltrim(getenv('MAGENTO_CLI_COMMAND_PATH'), '/');
+
         $executor = new CurlTransport();
         $executor->write(
             $apiURL,

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -457,8 +457,12 @@ class MagentoWebDriver extends WebDriver
      */
     public function magentoCLI($command, $arguments = null)
     {
-        // trim /index.php if baseURL includes it, will lead to bad path otherwise
-        $apiURL = str_replace("/index.php", "", $this->config['url']) . getenv('MAGENTO_CLI_COMMAND_PATH');
+        // trim everything after first '/' in URL after http:// or https://
+        $apiURL = substr(
+            $this->config['url'],
+            0,
+            strpos($this->config['url'], "/", 8) + 1
+        );
         $executor = new CurlTransport();
         $executor->write(
             $apiURL,

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -457,7 +457,8 @@ class MagentoWebDriver extends WebDriver
      */
     public function magentoCLI($command, $arguments = null)
     {
-        $apiURL = $this->config['url'] . getenv('MAGENTO_CLI_COMMAND_PATH');
+        // trim /index.php if baseURL includes it, will lead to bad path otherwise
+        $apiURL = str_replace("/index.php", "", $this->config['url']) . getenv('MAGENTO_CLI_COMMAND_PATH');
         $executor = new CurlTransport();
         $executor->write(
             $apiURL,


### PR DESCRIPTION
### Description
- apiURL now tries to trim index.php/ if present

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests