### PR TITLE
MQE-1110: MFTF run:group does not work with a standalone configuration

### DIFF
--- a/dev/tests/_bootstrap.php
+++ b/dev/tests/_bootstrap.php
@@ -52,7 +52,7 @@ foreach ($TEST_ENVS as $key => $value) {
 putenv('MODULE_WHITELIST=Magento_TestModule');
 
 // Define our own set of paths for the tests
-define('FW_BP', PROJECT_ROOT);
+defined('FW_BP') || define('FW_BP', PROJECT_ROOT);
 
 $RELATIVE_TESTS_MODULE_PATH = DIRECTORY_SEPARATOR . 'verification';
 

--- a/dev/tests/_bootstrap.php
+++ b/dev/tests/_bootstrap.php
@@ -52,7 +52,7 @@ foreach ($TEST_ENVS as $key => $value) {
 putenv('MODULE_WHITELIST=Magento_TestModule');
 
 // Define our own set of paths for the tests
-defined('FW_BP') || define('FW_BP', PROJECT_ROOT);
+define('FW_BP', PROJECT_ROOT);
 
 $RELATIVE_TESTS_MODULE_PATH = DIRECTORY_SEPARATOR . 'verification';
 

--- a/dev/tests/functional/_bootstrap.php
+++ b/dev/tests/functional/_bootstrap.php
@@ -16,6 +16,14 @@ if (!(bool)$debug_mode && extension_loaded('xdebug')) {
     xdebug_disable();
 }
 
+// Force generation if standalone TODO remove when we manage to pass this onto symfony process in bin/mftf commands
+\Magento\FunctionalTestingFramework\Config\MftfApplicationConfig::create(
+    true,
+    \Magento\FunctionalTestingFramework\Config\MftfApplicationConfig::EXECUTION_PHASE,
+    false,
+    false
+);
+
 $RELATIVE_TESTS_MODULE_PATH = '/tests/functional/tests/MFTF';
 
 defined('MAGENTO_BP') || define('MAGENTO_BP', PROJECT_ROOT);

--- a/dev/tests/functional/_bootstrap.php
+++ b/dev/tests/functional/_bootstrap.php
@@ -7,6 +7,13 @@
 defined('PROJECT_ROOT') || define('PROJECT_ROOT', dirname(dirname(dirname(__DIR__))));
 require_once realpath(PROJECT_ROOT . '/vendor/autoload.php');
 
+//Do not continue running this bootstrap if PHPUnit is calling it
+$fullTrace = debug_backtrace();
+$rootFile = array_values(array_slice($fullTrace, -1))[0]['file'];
+if (strpos($rootFile, "phpunit") !== false) {
+    return;
+}
+
 //Load constants from .env file
 defined('FW_BP') || define('FW_BP', PROJECT_ROOT);
 
@@ -15,14 +22,6 @@ $debug_mode = $_ENV['MFTF_DEBUG'] ?? false;
 if (!(bool)$debug_mode && extension_loaded('xdebug')) {
     xdebug_disable();
 }
-
-// Force generation if standalone TODO remove when we manage to pass this onto symfony process in bin/mftf commands
-\Magento\FunctionalTestingFramework\Config\MftfApplicationConfig::create(
-    true,
-    \Magento\FunctionalTestingFramework\Config\MftfApplicationConfig::EXECUTION_PHASE,
-    false,
-    false
-);
 
 $RELATIVE_TESTS_MODULE_PATH = '/tests/functional/tests/MFTF';
 

--- a/dev/tests/functional/_bootstrap.php
+++ b/dev/tests/functional/_bootstrap.php
@@ -4,15 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-defined('PROJECT_ROOT') || define('PROJECT_ROOT', dirname(dirname(dirname(__DIR__))));
-require_once realpath(PROJECT_ROOT . '/vendor/autoload.php');
-
 //Do not continue running this bootstrap if PHPUnit is calling it
 $fullTrace = debug_backtrace();
 $rootFile = array_values(array_slice($fullTrace, -1))[0]['file'];
 if (strpos($rootFile, "phpunit") !== false) {
     return;
 }
+
+defined('PROJECT_ROOT') || define('PROJECT_ROOT', dirname(dirname(dirname(__DIR__))));
+require_once realpath(PROJECT_ROOT . '/vendor/autoload.php');
 
 //Load constants from .env file
 defined('FW_BP') || define('FW_BP', PROJECT_ROOT);

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -62,12 +62,9 @@ class RunTestCommand extends Command
                 '--tests' => json_encode([
                     'tests' => $tests,
                     'suites' => null
-                ])
+                ]),
+                '--force' => $force
             ];
-            if ($force) {
-                $args['--force'] = true;
-            }
-
             $command->run(new ArrayInput($args), $output);
         }
 

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -31,7 +31,13 @@ class RunTestCommand extends Command
                 'name',
                 InputArgument::REQUIRED | InputArgument::IS_ARRAY,
                 "name of tests to generate and execute"
-            )->addOption('skip-generate', 'k', InputOption::VALUE_NONE, "skip generation and execute existing test");
+            )->addOption('skip-generate', 'k', InputOption::VALUE_NONE, "skip generation and execute existing test")
+            ->addOption(
+                "force",
+                'f',
+                InputOption::VALUE_NONE,
+                'force generation of tests regardless of Magento Instance Configuration'
+            );
     }
 
     /**
@@ -48,6 +54,7 @@ class RunTestCommand extends Command
     {
         $tests = $input->getArgument('name');
         $skipGeneration = $input->getOption('skip-generate') ?? false;
+        $force = $input->getOption('force') ?? false;
 
         if (!$skipGeneration) {
             $command = $this->getApplication()->find('generate:tests');
@@ -57,6 +64,9 @@ class RunTestCommand extends Command
                     'suites' => null
                 ])
             ];
+            if ($force) {
+                $args['--force'] = true;
+            }
 
             $command->run(new ArrayInput($args), $output);
         }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -53,8 +53,8 @@ class RunTestCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $tests = $input->getArgument('name');
-        $skipGeneration = $input->getOption('skip-generate') ?? false;
-        $force = $input->getOption('force') ?? false;
+        $skipGeneration = $input->getOption('skip-generate');
+        $force = $input->getOption('force');
 
         if (!$skipGeneration) {
             $command = $this->getApplication()->find('generate:tests');

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -64,10 +64,10 @@ class RunTestGroupCommand extends Command
         if (!$skipGeneration) {
             $testConfiguration = $this->getGroupAndSuiteConfiguration($groups);
             $command = $this->getApplication()->find('generate:tests');
-            $args = ['--tests' => $testConfiguration];
-            if ($force) {
-                $args['--force'] = true;
-            }
+            $args = [
+                '--tests' => $testConfiguration,
+                '--force' => $force
+            ];
 
             $command->run(new ArrayInput($args), $output);
         }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace Magento\FunctionalTestingFramework\Console;
 
 use Magento\FunctionalTestingFramework\Suite\Handlers\SuiteObjectHandler;
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -60,6 +61,14 @@ class RunTestGroupCommand extends Command
         $skipGeneration = $input->getOption('skip-generate');
         $force = $input->getOption('force');
         $groups = $input->getArgument('groups');
+
+        // Create Mftf Configuration
+        MftfApplicationConfig::create(
+            $force,
+            MftfApplicationConfig::GENERATION_PHASE,
+            false,
+            false
+        );
 
         if (!$skipGeneration) {
             $testConfiguration = $this->getGroupAndSuiteConfiguration($groups);

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -57,8 +57,8 @@ class RunTestGroupCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $skipGeneration = $input->getOption('skip-generate') ?? false;
-        $force = $input->getOption('force') ?? false;
+        $skipGeneration = $input->getOption('skip-generate');
+        $force = $input->getOption('force');
         $groups = $input->getArgument('groups');
 
         if (!$skipGeneration) {

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -33,6 +33,11 @@ class RunTestGroupCommand extends Command
                 'k',
                 InputOption::VALUE_NONE,
                 "only execute a group of tests without generating from source xml"
+            )->addOption(
+                "force",
+                'f',
+                InputOption::VALUE_NONE,
+                'force generation of tests regardless of Magento Instance Configuration'
             )->addArgument(
                 'groups',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
@@ -53,12 +58,16 @@ class RunTestGroupCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $skipGeneration = $input->getOption('skip-generate') ?? false;
+        $force = $input->getOption('force') ?? false;
         $groups = $input->getArgument('groups');
 
         if (!$skipGeneration) {
             $testConfiguration = $this->getGroupAndSuiteConfiguration($groups);
             $command = $this->getApplication()->find('generate:tests');
             $args = ['--tests' => $testConfiguration];
+            if ($force) {
+                $args['--force'] = true;
+            }
 
             $command->run(new ArrayInput($args), $output);
         }

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -9,6 +9,7 @@ namespace Magento\FunctionalTestingFramework\Util;
 use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class ModuleResolver, resolve module path based on enabled modules of target Magento instance.
@@ -402,11 +403,19 @@ class ModuleResolver
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
         $response = curl_exec($ch);
+        $responseCode = curl_getinfo($ch)['http_code'];
 
-        if (!$response) {
-            $message = "Could not retrieve API token from Magento Instance.";
+        if ($responseCode !== 200) {
+            if ($responseCode == 0) {
+                $details = "Could not find Magento Instance at given MAGENTO_BASE_URL";
+            } else {
+                $details = $responseCode . " " . Response::$statusTexts[$responseCode];
+            }
+
+            $message = "Could not retrieve API token from Magento Instance ({$details})";
             $context = [
-                "Admin Integration Token Url" => $url,
+                "tokenUrl" => $url,
+                "responseCode" => $responseCode,
                 "MAGENTO_ADMIN_USERNAME" => getenv("MAGENTO_ADMIN_USERNAME"),
                 "MAGENTO_ADMIN_PASSWORD" => getenv("MAGENTO_ADMIN_PASSWORD"),
             ];

--- a/src/Magento/FunctionalTestingFramework/_bootstrap.php
+++ b/src/Magento/FunctionalTestingFramework/_bootstrap.php
@@ -12,7 +12,8 @@ defined('FW_BP') || define('FW_BP', realpath(__DIR__ . '/../../../'));
 $projectRootPath = substr(FW_BP, 0, strpos(FW_BP, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR));
 
 if (empty($projectRootPath)) {
-    // Currently we do not support global execution, so leave this script before pathing is set improperly
+    // If ProjectRootPath is empty, we are not under vendor and are executing standalone.
+    require_once (realpath(FW_BP . "/dev/tests/functional/_bootstrap.php"));
     return;
 }
 


### PR DESCRIPTION
### Description
- Overall bootstrap calls standalone bootstrap if instalation is detected to be standalone

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests