### PR TITLE
MQE-1147: Turn Off Readiness Logging

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Extension/PageReadinessExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/PageReadinessExtension.php
@@ -251,6 +251,7 @@ class PageReadinessExtension extends Extension
      * @param string $message
      * @param array  $context
      * @return void
+     * @SuppressWarnings(PHPMD)
      */
     private function logDebug($message, $context = [])
     {
@@ -264,6 +265,7 @@ class PageReadinessExtension extends Extension
                 $logContext[$metric->getName() . '.failCount'] = $metric->getFailureCount();
             }
             $context = array_merge($logContext, $context);
+            //TODO REMOVE THIS LINE, UNCOMMENT LOGGER
             //$this->logger->info($message, $context);
         }
     }

--- a/src/Magento/FunctionalTestingFramework/Extension/PageReadinessExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/PageReadinessExtension.php
@@ -264,7 +264,7 @@ class PageReadinessExtension extends Extension
                 $logContext[$metric->getName() . '.failCount'] = $metric->getFailureCount();
             }
             $context = array_merge($logContext, $context);
-            $this->logger->info($message, $context);
+            //$this->logger->info($message, $context);
         }
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Extension/ReadinessMetrics/AbstractMetricCheck.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/ReadinessMetrics/AbstractMetricCheck.php
@@ -306,10 +306,12 @@ abstract class AbstractMetricCheck
      * @param string $message
      * @param array  $context
      * @return void
+     * @SuppressWarnings(PHPMD)
      */
     protected function errorLog($message, $context = [])
     {
         $context = array_merge($this->getLogContext(), $context);
+        //TODO REMOVE THIS LINE, UNCOMMENT LOGGER
         //$this->logger->error($message, $context);
     }
 
@@ -319,10 +321,12 @@ abstract class AbstractMetricCheck
      * @param string $message
      * @param array  $context
      * @return void
+     * @SuppressWarnings(PHPMD)
      */
     protected function infoLog($message, $context = [])
     {
         $context = array_merge($this->getLogContext(), $context);
+        //TODO REMOVE THIS LINE, UNCOMMENT LOGGER
         //$this->logger->info($message, $context);
     }
 
@@ -332,11 +336,13 @@ abstract class AbstractMetricCheck
      * @param string $message
      * @param array  $context
      * @return void
+     * @SuppressWarnings(PHPMD)
      */
     protected function debugLog($message, $context = [])
     {
         if ($this->verbose) {
             $context = array_merge($this->getLogContext(), $context);
+            //TODO REMOVE THIS LINE, UNCOMMENT LOGGER
             //$this->logger->debug($message, $context);
         }
     }

--- a/src/Magento/FunctionalTestingFramework/Extension/ReadinessMetrics/AbstractMetricCheck.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/ReadinessMetrics/AbstractMetricCheck.php
@@ -248,7 +248,7 @@ abstract class AbstractMetricCheck
      */
     public function getStoredValue()
     {
-        return $this->storedValue;
+        return $this->storedValue ?? null;
     }
 
     /**
@@ -310,7 +310,7 @@ abstract class AbstractMetricCheck
     protected function errorLog($message, $context = [])
     {
         $context = array_merge($this->getLogContext(), $context);
-        $this->logger->error($message, $context);
+        //$this->logger->error($message, $context);
     }
 
     /**
@@ -323,7 +323,7 @@ abstract class AbstractMetricCheck
     protected function infoLog($message, $context = [])
     {
         $context = array_merge($this->getLogContext(), $context);
-        $this->logger->info($message, $context);
+        //$this->logger->info($message, $context);
     }
 
     /**
@@ -337,7 +337,7 @@ abstract class AbstractMetricCheck
     {
         if ($this->verbose) {
             $context = array_merge($this->getLogContext(), $context);
-            $this->logger->debug($message, $context);
+            //$this->logger->debug($message, $context);
         }
     }
 


### PR DESCRIPTION
### Description
- Commented out all logging lines in Readiness Extension so it can be fixed in followup PR.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests