### PR TITLE
MQE-1151: Extending a skipped test fails to generate the parent before and after actions

### DIFF
--- a/dev/tests/verification/Resources/ExtendingSkippedTest.txt
+++ b/dev/tests/verification/Resources/ExtendingSkippedTest.txt
@@ -1,0 +1,66 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Persist\DataPersistenceHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Objects\EntityDataObject;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ * @Title("ChildExtendedTestSkippedParent")
+ * @group Child
+ */
+class ExtendingSkippedTestCest
+{
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->amOnPage("/beforeUrl");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _after(AcceptanceTester $I)
+	{
+		$I->amOnPage("/afterUrl");
+	}
+
+	/**
+	  * @param AcceptanceTester $I
+	  * @throws \Exception
+	  */
+	public function _failed(AcceptanceTester $I)
+	{
+		$I->saveScreenshot();
+	}
+
+	/**
+	 * @Severity(level = SeverityLevel::CRITICAL)
+	 * @Features({"TestModule"})
+	 * @Stories({"Child"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function ExtendingSkippedTest(AcceptanceTester $I)
+	{
+		$I->comment("text");
+		$I->comment("child");
+	}
+}

--- a/dev/tests/verification/Resources/SkippedTestWithHooks.txt
+++ b/dev/tests/verification/Resources/SkippedTestWithHooks.txt
@@ -1,0 +1,38 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Persist\DataPersistenceHandler;
+use Magento\FunctionalTestingFramework\DataGenerator\Objects\EntityDataObject;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ * @Title("skippedTestWithHooks")
+ * @Description("")
+ */
+class SkippedTestWithHooksCest
+{
+	/**
+	 * @Stories({"skippedWithHooks"})
+	 * @Severity(level = SeverityLevel::MINOR)
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function SkippedTestWithHooks(AcceptanceTester $I, \Codeception\Scenario $scenario)
+	{
+		$scenario->skip("This test is skipped due to the following issues:\nSkippedValue");
+	}
+}

--- a/dev/tests/verification/TestModule/Test/ExtendedFunctionalTest.xml
+++ b/dev/tests/verification/TestModule/Test/ExtendedFunctionalTest.xml
@@ -116,7 +116,6 @@
             <remove keyForRemoval="beforeAmOnPageKey"/>
         </before>
     </test>
-
     <test name="ChildExtendedTestNoParent" extends="ThisTestDoesNotExist">
         <annotations>
             <severity value="CRITICAL"/>
@@ -128,5 +127,35 @@
         <before>
             <remove keyForRemoval="beforeAmOnPageKey"/>
         </before>
+    </test>
+    <test name="SkippedParent">
+        <annotations>
+            <severity value="CRITICAL"/>
+            <title value="PARENTSKIPPED"/>
+            <group value="Parent"/>
+            <features value="Parent"/>
+            <stories value="Parent"/>
+            <skip>
+                <issueId value="NONE"/>
+            </skip>
+        </annotations>
+        <before>
+            <amOnPage url="/beforeUrl" stepKey="beforeAmOnPageKey"/>
+        </before>
+        <after>
+            <amOnPage url="/afterUrl" stepKey="afterAmOnPageKey"/>
+        </after>
+        <comment userInput="text" stepKey="keepMe"/>
+        <comment userInput="text" stepKey="replaceMe"/>
+    </test>
+    <test name="ExtendingSkippedTest" extends="SkippedParent">
+        <annotations>
+            <severity value="CRITICAL"/>
+            <title value="ChildExtendedTestSkippedParent"/>
+            <group value="Child"/>
+            <features value="Child"/>
+            <stories value="Child"/>
+        </annotations>
+        <comment userInput="child" stepKey="replaceMe"/>
     </test>
 </tests>

--- a/dev/tests/verification/TestModule/Test/SkippedTest.xml
+++ b/dev/tests/verification/TestModule/Test/SkippedTest.xml
@@ -19,6 +19,23 @@
             </skip>
         </annotations>
     </test>
+    <test name="SkippedTestWithHooks">
+        <annotations>
+            <stories value="skippedWithHooks"/>
+            <title value="skippedTestWithHooks"/>
+            <description value=""/>
+            <severity value="AVERAGE"/>
+            <skip>
+                <issueId value="SkippedValue"/>
+            </skip>
+        </annotations>
+        <before>
+            <comment userInput="skippedComment" stepKey="beforeComment"/>
+        </before>
+        <after>
+            <comment userInput="skippedComment" stepKey="afterComment"/>
+        </after>
+    </test>
     <test name="SkippedTestTwoIssues">
         <annotations>
             <stories value="skippedMultiple"/>

--- a/dev/tests/verification/Tests/ExtendedGenerationTest.php
+++ b/dev/tests/verification/Tests/ExtendedGenerationTest.php
@@ -96,4 +96,15 @@ class ExtendedGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('ChildExtendedTestNoParent');
     }
+
+    /**
+     * Tests extending a skipped test generation.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testExtendingSkippedGeneration()
+    {
+        $this->generateAndCompareTest('ExtendingSkippedTest');
+    }
 }

--- a/dev/tests/verification/Tests/SkippedGenerationTest.php
+++ b/dev/tests/verification/Tests/SkippedGenerationTest.php
@@ -21,6 +21,17 @@ class SkippedGenerationTest extends MftfTestCase
     }
 
     /**
+     * Tests skipped test generation does not generate hooks.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testSkippedWithHooksGeneration()
+    {
+        $this->generateAndCompareTest('SkippedTestWithHooks');
+    }
+
+    /**
      * Tests skipped test with multiple issues generation.
      *
      * @throws \Exception

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -164,15 +164,10 @@ class TestObject
     /**
      * Returns hooks.
      *
-     * @param boolean $isExtended
      * @return TestHookObject[]
      */
-    public function getHooks($isExtended = false)
+    public function getHooks()
     {
-        // if this test is skipped we do not want any before/after actions to generate as the tests will not run
-        if ($this->isSkipped() && !$isExtended) {
-            return [];
-        }
         return $this->hooks;
     }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -164,12 +164,13 @@ class TestObject
     /**
      * Returns hooks.
      *
+     * @param boolean $isExtended
      * @return TestHookObject[]
      */
-    public function getHooks()
+    public function getHooks($isExtended = false)
     {
         // if this test is skipped we do not want any before/after actions to generate as the tests will not run
-        if ($this->isSkipped()) {
+        if ($this->isSkipped() && !$isExtended) {
             return [];
         }
         return $this->hooks;

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ObjectExtensionUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ObjectExtensionUtil.php
@@ -146,7 +146,8 @@ class ObjectExtensionUtil
     private function resolveExtendedHooks($testObject, $parentTestObject)
     {
         $testHooks = $testObject->getHooks();
-        $parentHooks = $parentTestObject->getHooks();
+        // Send true to getHooks to return even if test is skipped
+        $parentHooks = $parentTestObject->getHooks(true);
 
         // Get the hooks for each Test merge changes from the child hooks to the parent hooks into the child hooks
         foreach ($testHooks as $key => $hook) {

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ObjectExtensionUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ObjectExtensionUtil.php
@@ -146,8 +146,7 @@ class ObjectExtensionUtil
     private function resolveExtendedHooks($testObject, $parentTestObject)
     {
         $testHooks = $testObject->getHooks();
-        // Send true to getHooks to return even if test is skipped
-        $parentHooks = $parentTestObject->getHooks(true);
+        $parentHooks = $parentTestObject->getHooks();
 
         // Get the hooks for each Test merge changes from the child hooks to the parent hooks into the child hooks
         foreach ($testHooks as $key => $hook) {

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -207,7 +207,11 @@ class TestGenerator
 
         $className = $testObject->getCodeceptionName();
         try {
-            $hookPhp = $this->generateHooksPhp($testObject->getHooks());
+            if (!$testObject->isSkipped()) {
+                $hookPhp = $this->generateHooksPhp($testObject->getHooks());
+            } else {
+                $hookPhp = null;
+            }
             $testsPhp = $this->generateTestPhp($testObject);
         } catch (TestReferenceException $e) {
             throw new TestReferenceException($e->getMessage() . "\n" . $testObject->getFilename());


### PR DESCRIPTION
This change will allow before and after hooks to be generated for an extended test when those hoooks live on the parent test and that parent test is skipped.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests