### PR TITLE
MQE-1153: ExecuteJS javascript escaping matches persisted data

### DIFF
--- a/dev/tests/verification/Resources/ExecuteJsEscapingTest.txt
+++ b/dev/tests/verification/Resources/ExecuteJsEscapingTest.txt
@@ -31,5 +31,7 @@ class ExecuteJsEscapingTestCest
 	{
 		$javaVariableEscape = $I->executeJS("return \$javascriptVariable");
 		$mftfVariableNotEscaped = $I->executeJS("return {$doNotEscape}");
+		$persistedDataNotEscaped = $I->executeJS("return " . $persisted->getCreatedDataByName('data'));
+		$hookPersistedDataNotEscaped = $I->executeJS("return " . $this->persisted->getCreatedDataByName('data'));
 	}
 }

--- a/dev/tests/verification/Resources/ExecuteJsEscapingTest.txt
+++ b/dev/tests/verification/Resources/ExecuteJsEscapingTest.txt
@@ -33,5 +33,6 @@ class ExecuteJsEscapingTestCest
 		$mftfVariableNotEscaped = $I->executeJS("return {$doNotEscape}");
 		$persistedDataNotEscaped = $I->executeJS("return " . $persisted->getCreatedDataByName('data'));
 		$hookPersistedDataNotEscaped = $I->executeJS("return " . $this->persisted->getCreatedDataByName('data'));
+		$addNewAttributeForRule = $I->executeJS("document.querySelector('entity option[value=" . $this->productAttribute->getCreatedDataByName('attribute_code') . "]').setAttribute('selected', 'selected')");
 	}
 }

--- a/dev/tests/verification/TestModule/Test/ExecuteJsTest.xml
+++ b/dev/tests/verification/TestModule/Test/ExecuteJsTest.xml
@@ -11,5 +11,7 @@
     <test name="ExecuteJsEscapingTest">
         <executeJS function="return $javascriptVariable" stepKey="javaVariableEscape"/>
         <executeJS function="return {$doNotEscape}" stepKey="mftfVariableNotEscaped"/>
+        <executeJS function="return $persisted.data$" stepKey="persistedDataNotEscaped"/>
+        <executeJS function="return $$persisted.data$$" stepKey="hookPersistedDataNotEscaped"/>
     </test>
 </tests>

--- a/dev/tests/verification/TestModule/Test/ExecuteJsTest.xml
+++ b/dev/tests/verification/TestModule/Test/ExecuteJsTest.xml
@@ -13,5 +13,6 @@
         <executeJS function="return {$doNotEscape}" stepKey="mftfVariableNotEscaped"/>
         <executeJS function="return $persisted.data$" stepKey="persistedDataNotEscaped"/>
         <executeJS function="return $$persisted.data$$" stepKey="hookPersistedDataNotEscaped"/>
+        <executeJS function="document.querySelector('entity option[value=$$productAttribute.attribute_code$$]').setAttribute('selected', 'selected')" stepKey="addNewAttributeForRule"/>
     </test>
 </tests>

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -620,7 +620,7 @@ class TestGenerator
                 }
                 // turn $javaVariable => \$javaVariable but not {$mftfVariable}
                 if ($actionObject->getType() == "executeJS") {
-                    $function = preg_replace('/(?<!{)(\$[\w\d_]+)/', '\\\\$1', $function);
+                    $function = preg_replace('/(?<!{)(\$[A-z._]+)(?![A-z.]*+\$)/', '\\\\$1', $function);
                 }
             }
 

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -620,7 +620,7 @@ class TestGenerator
                 }
                 // turn $javaVariable => \$javaVariable but not {$mftfVariable}
                 if ($actionObject->getType() == "executeJS") {
-                    $function = preg_replace('/(?<!{)(\$[A-z._]+)(?![A-z.]*+\$)/', '\\\\$1', $function);
+                    $function = preg_replace('/(?<!{)(\$[A-Za-z._]+)(?![A-z.]*+\$)/', '\\\\$1', $function);
                 }
             }
 


### PR DESCRIPTION
ExecuteJS should now properly escape sequences without involving persisted data

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests