### PR TITLE
MQE-1189: Suite Generation - Precondition body must always get and re…

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
@@ -129,9 +129,8 @@ class GroupClassGenerator
      */
     private function buildHookMustacheArray($hookObj)
     {
-        $mustacheHookArray = [];
         $actions = [];
-        $hasWebDriverActions = false;
+        $mustacheHookArray['actions'][] = ['webDriverInit' => true];
 
         foreach ($hookObj->getActions() as $action) {
             /** @var ActionObject $action */
@@ -139,10 +138,6 @@ class GroupClassGenerator
             //deleteData contains either url or createDataKey, if it contains the former it needs special formatting
             if ($action->getType() !== "createData"
                 && !array_key_exists(TestGenerator::REQUIRED_ENTITY_REFERENCE, $action->getCustomActionAttributes())) {
-                if (!$hasWebDriverActions) {
-                    $hasWebDriverActions = true;
-                }
-
                 $actions = $this->buildWebDriverActionsMustacheArray($action, $actions, $index);
                 continue;
             }
@@ -159,11 +154,8 @@ class GroupClassGenerator
             $entityArray = $this->buildPersistenceMustacheArray($action, $entityArray);
             $actions[$index] = $entityArray;
         }
-        $mustacheHookArray['actions'] = $actions;
-        if ($hasWebDriverActions) {
-            array_unshift($mustacheHookArray['actions'], ['webDriverInit' => true]);
-            $mustacheHookArray['actions'][] = ['webDriverReset' => true];
-        }
+        $mustacheHookArray['actions'] = array_merge($mustacheHookArray['actions'], $actions);
+        $mustacheHookArray['actions'][] = ['webDriverReset' => true];
 
         return $mustacheHookArray;
     }


### PR DESCRIPTION
### Description
Bug Fix

### Fixed Issues (if relevant)
MQE-1189: Suite Generation - Precondition body must always get and reset driver

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests