### PR TITLE
Support PHP-FPM in command.php

### DIFF
--- a/etc/config/command.php
+++ b/etc/config/command.php
@@ -11,7 +11,7 @@ if (isset($_POST['command'])) {
     } else {
         $arguments = null;
     }
-    $php = PHP_BINARY ?: (PHP_BINDIR ? PHP_BINDIR . '/php' : 'php');
+    $php = PHP_BINDIR ? PHP_BINDIR . '/php' : 'php';
     $valid = validateCommand($command);
     if ($valid) {
         exec(
@@ -60,7 +60,7 @@ function escapeCommand($command)
  */
 function validateCommand($command)
 {
-    $php = PHP_BINARY ?: (PHP_BINDIR ? PHP_BINDIR . '/php' : 'php');
+    $php = PHP_BINDIR ? PHP_BINDIR . '/php' : 'php';
     exec($php . ' -f ../../../../bin/magento list', $commandList);
     // Trim list of commands after first whitespace
     $commandList = array_map("trimAfterWhitespace", $commandList);


### PR DESCRIPTION
Remove assumption that `PHP_BINARY` will always be acceptable.

### Description
`command.php` assumes that if `PHP_BINARY` is set that it is always the PHP cli bin. When FPM is used, the bin will be `php-fpm` which isn't compatible with the PHP cli. This PR removes that constant and instead uses the already present `PHP_BINDIR` usage

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#216: command.php assumes that PHP_BINARY is always the PHP cli binary

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests