### PR TITLE
MQE-1248: Expose MFTF DEFAULT_TIMEZONE configuration in .env

### DIFF
--- a/dev/tests/_bootstrap.php
+++ b/dev/tests/_bootstrap.php
@@ -40,7 +40,8 @@ $TEST_ENVS = [
     'MAGENTO_BASE_URL' => 'http://baseurl:8080',
     'MAGENTO_BACKEND_NAME' => 'admin',
     'MAGENTO_ADMIN_USERNAME' => 'admin',
-    'MAGENTO_ADMIN_PASSWORD' => 'admin123'
+    'MAGENTO_ADMIN_PASSWORD' => 'admin123',
+    'DEFAULT_TIMEZONE' => 'America/Los_Angeles'
 ];
 
 foreach ($TEST_ENVS as $key => $value) {

--- a/dev/tests/functional/_bootstrap.php
+++ b/dev/tests/functional/_bootstrap.php
@@ -45,4 +45,12 @@ if (file_exists(TESTS_BP . DIRECTORY_SEPARATOR . '.env')) {
 
     defined('MAGENTO_CLI_COMMAND_PARAMETER') || define('MAGENTO_CLI_COMMAND_PARAMETER', 'command');
     $env->setEnvironmentVariable('MAGENTO_CLI_COMMAND_PARAMETER', MAGENTO_CLI_COMMAND_PARAMETER);
+
+    defined('DEFAULT_TIMEZONE') || define('DEFAULT_TIMEZONE', 'America/Los_Angeles');
+    $env->setEnvironmentVariable('DEFAULT_TIMEZONE', DEFAULT_TIMEZONE);
+    
+    if (array_search(DEFAULT_TIMEZONE, timezone_identifiers_list()) === false) {
+        throw new \Exception("Invalid DEFAULT_TIMEZONE in .env: " . DEFAULT_TIMEZONE . PHP_EOL);
+    }
+
 }

--- a/dev/tests/functional/_bootstrap.php
+++ b/dev/tests/functional/_bootstrap.php
@@ -49,8 +49,10 @@ if (file_exists(TESTS_BP . DIRECTORY_SEPARATOR . '.env')) {
     defined('DEFAULT_TIMEZONE') || define('DEFAULT_TIMEZONE', 'America/Los_Angeles');
     $env->setEnvironmentVariable('DEFAULT_TIMEZONE', DEFAULT_TIMEZONE);
     
-    if (array_search(DEFAULT_TIMEZONE, timezone_identifiers_list()) === false) {
-        throw new \Exception("Invalid DEFAULT_TIMEZONE in .env: " . DEFAULT_TIMEZONE . PHP_EOL);
+    try {
+        new DateTimeZone(DEFAULT_TIMEZONE);
+    } catch (\Exception $e) {
+        throw new \Exception("Invalid DEFAULT_TIMEZONE in .env: " . DEFAULT_TIMEZONE . PHP_EOL);        
     }
 
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionObjectTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionObjectTest.php
@@ -370,6 +370,21 @@ class ActionObjectTest extends MagentoTestCase
         $actionObject->resolveReferences();
     }
 
+    /**
+     * Action object should throw an exception if the timezone provided is not valid.
+     */
+    public function testInvalidTimezoneException()
+    {
+        $this->expectException(TestReferenceException::class);
+
+        $actionObject = new ActionObject('key123', 'generateDate', [
+            'timezone' => "INVALID_TIMEZONE"
+        ]);
+
+        // Call the method under test
+        $actionObject->resolveReferences();
+    }
+
     private function mockSectionHandlerWithElement($elementObject)
     {
         $sectionObject = new SectionObject('SectionObject', ['elementObject' => $elementObject]);

--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -107,6 +107,10 @@ class BasicFunctionalTestCest
 		$date->setTimestamp(strtotime("Now"));
 		$date->setTimezone(new \DateTimeZone("America/Los_Angeles"));
 		$generateDateKey = $date->format("H:i:s");
+		$date = new \DateTime();
+		$date->setTimestamp(strtotime("Now"));
+		$date->setTimezone(new \DateTimeZone("UTC"));
+		$generateDateKey2 = $date->format("H:i:s");
 		$grabAttributeFromKey1 = $I->grabAttributeFrom(".functionalTestSelector", "someInput");
 		$grabCookieKey1 = $I->grabCookie("grabCookieInput", ['domain' => 'www.google.com']);
 		$grabFromCurrentUrlKey1 = $I->grabFromCurrentUrl("/grabCurrentUrl");

--- a/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml
+++ b/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml
@@ -62,6 +62,7 @@
         <fillField selector=".functionalTestSelector" userInput="someInput" stepKey="fillFieldKey1" />
         <fillField selector=".functionalTestSelector" userInput="0" stepKey="fillFieldKey2" />
         <generateDate date="Now" format="H:i:s" stepKey="generateDateKey"/>
+        <generateDate date="Now" format="H:i:s" stepKey="generateDateKey2" timezone="UTC"/>
         <grabAttributeFrom selector=".functionalTestSelector" userInput="someInput" stepKey="grabAttributeFromKey1" />
         <grabCookie userInput="grabCookieInput" parameterArray="['domain' => 'www.google.com']" stepKey="grabCookieKey1" />
         <grabFromCurrentUrl regex="/grabCurrentUrl" stepKey="grabFromCurrentUrlKey1" />

--- a/etc/config/.env.example
+++ b/etc/config/.env.example
@@ -31,6 +31,9 @@ BROWSER=chrome
 #FW_BP=
 #TESTS_MODULE_PATH=
 
+#*** Uncomment this property to change the default timezone MFTF will use for the generateDate action ***#
+#DEFAULT_TIMEZONE=America/Los_Angeles
+
 #*** These properties impact the modules loaded into MFTF, you can point to your own full path, or a custom set of modules located with the core set
 MODULE_WHITELIST=Magento_Framework,Magento_ConfigurableProductWishlist,Magento_ConfigurableProductCatalogSearch
 #CUSTOM_MODULE_PATHS=

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -62,6 +62,7 @@ class ActionObject
     const FUNCTION_CLOSURE_ACTIONS = ['waitForElementChange', 'performOn'];
     const MERGE_ACTION_ORDER_AFTER = 'after';
     const MERGE_ACTION_ORDER_BEFORE = 'before';
+    const ACTION_ATTRIBUTE_TIMEZONE = 'timezone';
     const ACTION_ATTRIBUTE_URL = 'url';
     const ACTION_ATTRIBUTE_SELECTOR = 'selector';
     const ACTION_ATTRIBUTE_VARIABLE_REGEX_PARAMETER = '/\(.+\)/';
@@ -256,6 +257,7 @@ class ActionObject
             $this->resolveSelectorReferenceAndTimeout();
             $this->resolveUrlReference();
             $this->resolveDataInputReferences();
+            $this->validateTimezoneAttribute();
             if ($this->getType() == "deleteData") {
                 $this->validateMutuallyExclusiveAttributes(self::DELETE_DATA_MUTUAL_EXCLUSIVE_ATTRIBUTES);
             }
@@ -596,6 +598,26 @@ class ActionObject
                 "Page of type 'external' is not compatible with action type '{$this->getType()}'",
                 ["type" => $this->getType()]
             );
+        }
+    }
+
+    /**
+     * Validates that the timezone attribute contains a valid value.
+     *
+     * @return void
+     * @throws TestReferenceException
+     */
+    private function validateTimezoneAttribute()
+    {
+        $attributes = $this->getCustomActionAttributes();
+        if (isset($attributes[self::ACTION_ATTRIBUTE_TIMEZONE])) {
+            $timezone = $attributes[self::ACTION_ATTRIBUTE_TIMEZONE];
+            if (array_search($timezone, timezone_identifiers_list()) === false) {
+                throw new TestReferenceException(
+                    "Timezone '{$timezone}' is not a valid timezone",
+                    ["stepKey" => $this->getStepKey(), self::ACTION_ATTRIBUTE_TIMEZONE => $timezone]
+                );
+            }
         }
     }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -612,7 +612,9 @@ class ActionObject
         $attributes = $this->getCustomActionAttributes();
         if (isset($attributes[self::ACTION_ATTRIBUTE_TIMEZONE])) {
             $timezone = $attributes[self::ACTION_ATTRIBUTE_TIMEZONE];
-            if (array_search($timezone, timezone_identifiers_list()) === false) {
+            try {
+                new DateTimeZone($timezone);
+            } catch (\Exception $e) {
                 throw new TestReferenceException(
                     "Timezone '{$timezone}' is not a valid timezone",
                     ["stepKey" => $this->getStepKey(), self::ACTION_ATTRIBUTE_TIMEZONE => $timezone]

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -19,6 +19,7 @@ use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
 
 /**
  * Class ActionObject
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ActionObject
 {
@@ -613,7 +614,7 @@ class ActionObject
         if (isset($attributes[self::ACTION_ATTRIBUTE_TIMEZONE])) {
             $timezone = $attributes[self::ACTION_ATTRIBUTE_TIMEZONE];
             try {
-                new DateTimeZone($timezone);
+                new \DateTimeZone($timezone);
             } catch (\Exception $e) {
                 throw new TestReferenceException(
                     "Timezone '{$timezone}' is not a valid timezone",

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1283,7 +1283,7 @@ class TestGenerator
                     $testSteps .= $argRef;
                     break;
                 case "generateDate":
-                    $timezone = "America/Los_Angeles";
+                    $timezone = getenv("DEFAULT_TIMEZONE");
                     if (isset($customActionAttributes['timezone'])) {
                         $timezone = $customActionAttributes['timezone'];
                     }

--- a/src/Magento/FunctionalTestingFramework/_bootstrap.php
+++ b/src/Magento/FunctionalTestingFramework/_bootstrap.php
@@ -49,7 +49,9 @@ if (file_exists($envFilepath . DIRECTORY_SEPARATOR . '.env')) {
     defined('DEFAULT_TIMEZONE') || define('DEFAULT_TIMEZONE', 'America/Los_Angeles');
     $env->setEnvironmentVariable('DEFAULT_TIMEZONE', DEFAULT_TIMEZONE);
 
-    if (array_search(DEFAULT_TIMEZONE, timezone_identifiers_list()) === false) {
+    try {
+        new DateTimeZone(DEFAULT_TIMEZONE);
+    } catch (\Exception $e) {
         throw new \Exception("Invalid DEFAULT_TIMEZONE in .env: " . DEFAULT_TIMEZONE . PHP_EOL);
     }
 }

--- a/src/Magento/FunctionalTestingFramework/_bootstrap.php
+++ b/src/Magento/FunctionalTestingFramework/_bootstrap.php
@@ -45,6 +45,13 @@ if (file_exists($envFilepath . DIRECTORY_SEPARATOR . '.env')) {
 
     defined('MAGENTO_CLI_COMMAND_PARAMETER') || define('MAGENTO_CLI_COMMAND_PARAMETER', 'command');
     $env->setEnvironmentVariable('MAGENTO_CLI_COMMAND_PARAMETER', MAGENTO_CLI_COMMAND_PARAMETER);
+    
+    defined('DEFAULT_TIMEZONE') || define('DEFAULT_TIMEZONE', 'America/Los_Angeles');
+    $env->setEnvironmentVariable('DEFAULT_TIMEZONE', DEFAULT_TIMEZONE);
+
+    if (array_search(DEFAULT_TIMEZONE, timezone_identifiers_list()) === false) {
+        throw new \Exception("Invalid DEFAULT_TIMEZONE in .env: " . DEFAULT_TIMEZONE . PHP_EOL);
+    }
 }
 
 // TODO REMOVE THIS CODE ONCE WE HAVE STOPPED SUPPORTING dev/tests/acceptance PATH


### PR DESCRIPTION

### Description
- new .env DEFAULT_TIMEZONE, defaults to 'America/Los_Angeles'
- generateDate now uses this value (or override if provided)
- DEFAULT_TIMEZONE and timezone attribute are now checked in generation; fast fail in generation as opposed to run-time
- test updates for the above

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests