### PR TITLE
[2.3.7] Bug fix MQE-1142: Use timeout value when waitForLoadingMaskToDisappear

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -367,16 +367,17 @@ class MagentoWebDriver extends WebDriver
 
         $this->waitForJS('return document.readyState == "complete"', $timeout);
         $this->waitForAjaxLoad($timeout);
-        $this->waitForLoadingMaskToDisappear();
+        $this->waitForLoadingMaskToDisappear($timeout);
     }
 
     /**
      * Wait for all visible loading masks to disappear. Gets all elements by mask selector, then loops over them.
      *
+     * @param integer $timeout
      * @throws \Exception
      * @return void
      */
-    public function waitForLoadingMaskToDisappear()
+    public function waitForLoadingMaskToDisappear($timeout)
     {
         foreach (self::$loadingMasksLocators as $maskLocator) {
             // Get count of elements found for looping.
@@ -385,7 +386,7 @@ class MagentoWebDriver extends WebDriver
             for ($i = 1; $i <= count($loadingMaskElements); $i++) {
                 // Formatting and looping on i as we can't interact elements returned above
                 // eg.  (//div[@data-role="spinner"])[1]
-                $this->waitForElementNotVisible("({$maskLocator})[{$i}]", 30);
+                $this->waitForElementNotVisible("({$maskLocator})[{$i}]", $timeout);
             }
         }
     }


### PR DESCRIPTION
### Description
MQE-1142: Use timeout value when waitForLoadingMaskToDisappear

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests