### PR TITLE
MQE-1148: Include Parent In Output Of Duplicate StepKey or Section Element

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Validation/DuplicateNodeValidationUtilTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Validation/DuplicateNodeValidationUtilTest.php
@@ -29,6 +29,7 @@ class DuplicateNodeValidationUtilTest extends MagentoTestCase
                 ';
         $uniqueIdentifier = "stepKey";
         $filename = "file";
+        $testName = "test";
 
         // Perform Test
         $dom = new \DOMDocument();
@@ -40,8 +41,7 @@ class DuplicateNodeValidationUtilTest extends MagentoTestCase
         $validator->validateChildUniqueness(
             $testNode,
             $filename,
-            $uniqueIdentifier,
-            $exceptionCollector
+            $testName
         );
         $this->expectException(\Exception::class);
         $exceptionCollector->throwException();

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Config/Dom.php
@@ -18,6 +18,7 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
 {
     const DATA_FILE_NAME_ENDING = "Data";
     const DATA_META_FILENAME_ATTRIBUTE = "filename";
+    const DATA_META_NAME_ATTRIBUTE = "name";
 
     /**
      * NodeValidationUtil
@@ -74,7 +75,8 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
                 $entityNode->setAttribute(self::DATA_META_FILENAME_ATTRIBUTE, $filename);
                 $this->validationUtil->validateChildUniqueness(
                     $entityNode,
-                    $filename
+                    $filename,
+                    $entityNode->getAttribute(self::DATA_META_NAME_ATTRIBUTE)
                 );
             }
         }

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Config/OperationDom.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Config/OperationDom.php
@@ -18,6 +18,7 @@ class OperationDom extends \Magento\FunctionalTestingFramework\Config\MftfDom
 {
     const METADATA_FILE_NAME_ENDING = "meta";
     const METADATA_META_FILENAME_ATTRIBUTE = "filename";
+    const METADATA_META_NAME_ATTRIBUTE = "name";
 
     /**
      * NodeValidationUtil
@@ -74,7 +75,8 @@ class OperationDom extends \Magento\FunctionalTestingFramework\Config\MftfDom
                 $operationNode->setAttribute(self::METADATA_META_FILENAME_ATTRIBUTE, $filename);
                 $this->validateOperationElements(
                     $operationNode,
-                    $filename
+                    $filename,
+                    $operationNode->getAttribute(self::METADATA_META_NAME_ATTRIBUTE)
                 );
             }
         }
@@ -86,13 +88,15 @@ class OperationDom extends \Magento\FunctionalTestingFramework\Config\MftfDom
      * Recurse through child elements and validate uniqueKeys
      * @param \DOMElement $parentNode
      * @param string      $filename
+     * @param string      $topParent
      * @return void
      */
-    public function validateOperationElements(\DOMElement $parentNode, $filename)
+    public function validateOperationElements(\DOMElement $parentNode, $filename, $topParent)
     {
         $this->validationUtil->validateChildUniqueness(
             $parentNode,
-            $filename
+            $filename,
+            $topParent
         );
         $childNodes = $parentNode->childNodes;
 
@@ -103,7 +107,8 @@ class OperationDom extends \Magento\FunctionalTestingFramework\Config\MftfDom
             }
             $this->validateOperationElements(
                 $currentNode,
-                $filename
+                $filename,
+                $topParent
             );
         }
     }

--- a/src/Magento/FunctionalTestingFramework/Page/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Config/Dom.php
@@ -20,6 +20,7 @@ use Magento\FunctionalTestingFramework\Util\Validation\DuplicateNodeValidationUt
 class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
 {
     const PAGE_META_FILENAME_ATTRIBUTE = "filename";
+    const PAGE_META_NAME_ATTRIBUTE = "name";
 
     /**
      * Module Path extractor
@@ -79,7 +80,11 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
         $dom = parent::initDom($xml, $filename);
 
         $pagesNode = $dom->getElementsByTagName('pages')->item(0);
-        $this->validationUtil->validateChildUniqueness($pagesNode, $filename);
+        $this->validationUtil->validateChildUniqueness(
+            $pagesNode,
+            $filename,
+            $pagesNode->getAttribute(self::PAGE_META_NAME_ATTRIBUTE)
+        );
         $pageNodes = $dom->getElementsByTagName('page');
         $currentModule =
             $this->modulePathExtractor->extractModuleName($filename) .

--- a/src/Magento/FunctionalTestingFramework/Page/Config/SectionDom.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Config/SectionDom.php
@@ -20,6 +20,7 @@ use Magento\FunctionalTestingFramework\Util\Validation\DuplicateNodeValidationUt
 class SectionDom extends \Magento\FunctionalTestingFramework\Config\MftfDom
 {
     const SECTION_META_FILENAME_ATTRIBUTE = "filename";
+    const SECTION_META_NAME_ATTRIBUTE = "name";
 
     /**
      * NodeValidationUtil
@@ -71,7 +72,11 @@ class SectionDom extends \Magento\FunctionalTestingFramework\Config\MftfDom
         $sectionNodes = $dom->getElementsByTagName('section');
         foreach ($sectionNodes as $sectionNode) {
             $sectionNode->setAttribute(self::SECTION_META_FILENAME_ATTRIBUTE, $filename);
-            $this->validationUtil->validateChildUniqueness($sectionNode, $filename);
+            $this->validationUtil->validateChildUniqueness(
+                $sectionNode,
+                $filename,
+                $sectionNode->getAttribute(self::SECTION_META_NAME_ATTRIBUTE)
+            );
         }
         return $dom;
     }

--- a/src/Magento/FunctionalTestingFramework/Test/Config/ActionGroupDom.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/ActionGroupDom.php
@@ -15,6 +15,7 @@ use Magento\FunctionalTestingFramework\Util\Validation\DuplicateNodeValidationUt
 class ActionGroupDom extends Dom
 {
     const ACTION_GROUP_FILE_NAME_ENDING = "ActionGroup.xml";
+    const ACTION_GROUP_META_NAME_ATTRIBUTE = "name";
 
     /**
      * Takes a dom element from xml and appends the filename based on location while also validating the action group
@@ -35,22 +36,9 @@ class ActionGroupDom extends Dom
                 $actionGroupNode->setAttribute(self::TEST_META_FILENAME_ATTRIBUTE, $filename);
                 $this->validationUtil->validateChildUniqueness(
                     $actionGroupNode,
-                    $filename
+                    $filename,
+                    $actionGroupNode->getAttribute(self::ACTION_GROUP_META_NAME_ATTRIBUTE)
                 );
-                $beforeNode = $actionGroupNode->getElementsByTagName('before')->item(0);
-                $afterNode = $actionGroupNode->getElementsByTagName('after')->item(0);
-                if (isset($beforeNode)) {
-                    $this->validationUtil->validateChildUniqueness(
-                        $beforeNode,
-                        $filename
-                    );
-                }
-                if (isset($afterNode)) {
-                    $this->validationUtil->validateChildUniqueness(
-                        $afterNode,
-                        $filename
-                    );
-                }
                 if ($actionGroupNode->getAttribute(self::TEST_MERGE_POINTER_AFTER) !== "") {
                     $this->appendMergePointerToActions(
                         $actionGroupNode,

--- a/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
@@ -104,7 +104,8 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
 
                 $this->validationUtil->validateChildUniqueness(
                     $testNode,
-                    $filename
+                    $filename,
+                    $testNode->getAttribute(self::TEST_META_NAME_ATTRIBUTE)
                 );
                 $beforeNode = $testNode->getElementsByTagName('before')->item(0);
                 $afterNode = $testNode->getElementsByTagName('after')->item(0);
@@ -112,13 +113,15 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
                 if (isset($beforeNode)) {
                     $this->validationUtil->validateChildUniqueness(
                         $beforeNode,
-                        $filename
+                        $filename,
+                        $testNode->getAttribute(self::TEST_META_NAME_ATTRIBUTE) . "/before"
                     );
                 }
                 if (isset($afterNode)) {
                     $this->validationUtil->validateChildUniqueness(
                         $afterNode,
-                        $filename
+                        $filename,
+                        $testNode->getAttribute(self::TEST_META_NAME_ATTRIBUTE) . "/after"
                     );
                 }
             }

--- a/src/Magento/FunctionalTestingFramework/Util/Validation/DuplicateNodeValidationUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Validation/DuplicateNodeValidationUtil.php
@@ -45,7 +45,7 @@ class DuplicateNodeValidationUtil
      * @param string      $filename
      * @return void
      */
-    public function validateChildUniqueness(\DOMElement $parentNode, $filename)
+    public function validateChildUniqueness(\DOMElement $parentNode, $filename, $parentKey)
     {
         $childNodes = $parentNode->childNodes;
         $type = ucfirst($parentNode->tagName);
@@ -69,7 +69,7 @@ class DuplicateNodeValidationUtil
             $duplicates = array_diff_assoc($keyValues, $withoutDuplicates);
             $keyError = "";
             foreach ($duplicates as $duplicateKey => $duplicateValue) {
-                $keyError .= "\t{$this->uniqueKey}: {$duplicateValue} is used more than once.\n";
+                $keyError .= "\t{$this->uniqueKey}: {$duplicateValue} is used more than once. (Parent: {$parentKey})\n";
             }
 
             $errorMsg = "{$type} cannot use {$this->uniqueKey}s more than once.\t\n{$keyError}\tin file: {$filename}";


### PR DESCRIPTION
### Description
- Parent element is now included in exception output for duplicated child nodes.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests