### PR TITLE
MQE-1124: [Github Issue] Allow running tests for modules installed in…

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
@@ -62,8 +62,6 @@ class ModuleResolverTest extends MagentoTestCase
         $this->setMockResolverProperties($resolver, null, [0 => "Magento_example"]);
         $this->assertEquals(
             [
-                "example" . DIRECTORY_SEPARATOR . "paths",
-                "example" . DIRECTORY_SEPARATOR . "paths",
                 "example" . DIRECTORY_SEPARATOR . "paths"
             ],
             $resolver->getModulesPath()
@@ -88,35 +86,28 @@ class ModuleResolverTest extends MagentoTestCase
         $this->setMockResolverProperties($resolver, null, null);
         $this->assertEquals(
             [
-                "example" . DIRECTORY_SEPARATOR . "paths",
-                "example" . DIRECTORY_SEPARATOR . "paths",
                 "example" . DIRECTORY_SEPARATOR . "paths"
             ],
             $resolver->getModulesPath()
         );
 
         // Define the Module paths from app/code
-        $appCodePath = MAGENTO_BP
-            . DIRECTORY_SEPARATOR
-            . 'app' . DIRECTORY_SEPARATOR
-            . 'code' . DIRECTORY_SEPARATOR;
+        $magentoBaseCodePath = MAGENTO_BP;
 
         // Define the Module paths from default TESTS_MODULE_PATH
         $modulePath = defined('TESTS_MODULE_PATH') ? TESTS_MODULE_PATH : TESTS_BP;
 
         // Define the Module paths from vendor modules
-        $vendorCodePath = PROJECT_ROOT
-            . DIRECTORY_SEPARATOR
-            . 'vendor' . DIRECTORY_SEPARATOR;
+        $projectRootCodePath = PROJECT_ROOT;
 
         $mockResolver->verifyInvoked('globRelevantPaths', [$modulePath, '']);
         $mockResolver->verifyInvoked(
             'globRelevantPaths',
-            [$appCodePath, DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR .'Mftf']
+            [$magentoBaseCodePath, 'Test' . DIRECTORY_SEPARATOR .'Mftf']
         );
         $mockResolver->verifyInvoked(
             'globRelevantPaths',
-            [$vendorCodePath, DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR .'Mftf']
+            [$projectRootCodePath, 'Test' . DIRECTORY_SEPARATOR .'Mftf']
         );
     }
 
@@ -151,8 +142,6 @@ class ModuleResolverTest extends MagentoTestCase
             function ($arg1, $arg2) {
                 if ($arg2 === "") {
                     $mockValue = ["somePath" => "somePath"];
-                } elseif (strpos($arg1, "app")) {
-                    $mockValue = ["otherPath" => "otherPath"];
                 } else {
                     $mockValue = ["lastPath" => "lastPath"];
                 }
@@ -161,7 +150,7 @@ class ModuleResolverTest extends MagentoTestCase
         );
         $resolver = ModuleResolver::getInstance();
         $this->setMockResolverProperties($resolver, null, null, ["somePath"]);
-        $this->assertEquals(["otherPath", "lastPath"], $resolver->getModulesPath());
+        $this->assertEquals(["lastPath"], $resolver->getModulesPath());
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'info',
             'excluding module',

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
@@ -62,6 +62,8 @@ class ModuleResolverTest extends MagentoTestCase
         $this->setMockResolverProperties($resolver, null, [0 => "Magento_example"]);
         $this->assertEquals(
             [
+                "example" . DIRECTORY_SEPARATOR . "paths",
+                "example" . DIRECTORY_SEPARATOR . "paths",
                 "example" . DIRECTORY_SEPARATOR . "paths"
             ],
             $resolver->getModulesPath()
@@ -86,6 +88,8 @@ class ModuleResolverTest extends MagentoTestCase
         $this->setMockResolverProperties($resolver, null, null);
         $this->assertEquals(
             [
+                "example" . DIRECTORY_SEPARATOR . "paths",
+                "example" . DIRECTORY_SEPARATOR . "paths",
                 "example" . DIRECTORY_SEPARATOR . "paths"
             ],
             $resolver->getModulesPath()
@@ -150,7 +154,7 @@ class ModuleResolverTest extends MagentoTestCase
         );
         $resolver = ModuleResolver::getInstance();
         $this->setMockResolverProperties($resolver, null, null, ["somePath"]);
-        $this->assertEquals(["lastPath"], $resolver->getModulesPath());
+        $this->assertEquals(["lastPath", "lastPath"], $resolver->getModulesPath());
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'info',
             'excluding module',

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -534,7 +534,13 @@ class ModuleResolver
     private function getRegisteredModuleList()
     {
         if (array_key_exists('MAGENTO_BP', $_ENV)) {
-            require_once(MAGENTO_BP . "/app/autoload.php");
+            $autoloadPath = realpath(MAGENTO_BP . "/app/autoload.php");
+            if ($autoloadPath) {
+                require_once($autoloadPath);
+            } else {
+                throw new TestFrameworkException("Magento app/autoload.php not found with given MAGENTO_BP:"
+                    . MAGENTO_BP);
+            }
         }
 
         try {

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -218,29 +218,24 @@ class ModuleResolver
     {
         $allModulePaths = [];
 
-        // Define the Module paths from app/code
-        $appCodePath = MAGENTO_BP
-            . DIRECTORY_SEPARATOR
-            . 'app' . DIRECTORY_SEPARATOR
-            . 'code' . DIRECTORY_SEPARATOR;
+        // Define the Module paths from magento bp
+        $magentoBaseCodePath = MAGENTO_BP;
 
         // Define the Module paths from default TESTS_MODULE_PATH
         $modulePath = defined('TESTS_MODULE_PATH') ? TESTS_MODULE_PATH : TESTS_BP;
         $modulePath = rtrim($modulePath, DIRECTORY_SEPARATOR);
 
-        // Define the Module paths from vendor modules
-        $vendorCodePath = PROJECT_ROOT
-            . DIRECTORY_SEPARATOR
-            . 'vendor' . DIRECTORY_SEPARATOR;
+        // Define the Module paths from project root
+        $projectRootCodePath = PROJECT_ROOT;
 
         $codePathsToPattern = [
             $modulePath => '',
-            $appCodePath => DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
-            $vendorCodePath => DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'Mftf'
+            $magentoBaseCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
+            $projectRootCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf'
         ];
 
         foreach ($codePathsToPattern as $codePath => $pattern) {
-            $allModulePaths = array_merge_recursive($allModulePaths, $this->globRelevantPaths($codePath, $pattern));
+            $allModulePaths = array_merge($allModulePaths, $this->globRelevantPaths($codePath, $pattern));
         }
 
         return $allModulePaths;
@@ -288,7 +283,15 @@ class ModuleResolver
      */
     private static function globRelevantWrapper($testPath, $pattern)
     {
-        return glob($testPath . '*' . DIRECTORY_SEPARATOR . '*' . $pattern);
+        if ($pattern == "") {
+            return glob($testPath . '*' . DIRECTORY_SEPARATOR . '*' . $pattern);
+        }
+        $subDirectory = "*" . DIRECTORY_SEPARATOR;
+        $directories = glob($testPath . $subDirectory . $pattern, GLOB_ONLYDIR);
+        foreach (glob($testPath . $subDirectory, GLOB_ONLYDIR) as $dir) {
+            $directories = array_merge($directories, self::globRelevantWrapper($dir, $pattern));
+        }
+        return $directories;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -532,7 +532,7 @@ class ModuleResolver
 
         try {
             $allComponents = [];
-            if (!class_exists("\Magento\Framework\Component\ComponentRegistrar")) {
+            if (!class_exists(self::REGISTRAR_CLASS)) {
                 throw new TestFrameworkException("Magento Installation not found when loading registered modules.\n");
             }
             $components = new \Magento\Framework\Component\ComponentRegistrar();

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -31,12 +31,17 @@ class ModuleResolver
     /**
      * List of path types present in Magento Component Registrar
      */
-    const PATHS = ['module', 'library', 'theme', 'language', 'setup'];
+    const PATHS = ['module', 'library', 'theme', 'language'];
 
     /**
      * Magento Registrar Class
      */
-    const REGISTRAR_CLASS = "\Magento\Framework\Component\Registrar";
+    const REGISTRAR_CLASS = "\Magento\Framework\Component\ComponentRegistrar";
+
+    /**
+     * Magento Directory Structure Name Prefix
+     */
+    const MAGENTO_PREFIX = "Magento_";
 
     /**
      * Enabled modules.
@@ -269,9 +274,11 @@ class ModuleResolver
             $relevantPaths = $this->globRelevantWrapper($testPath, $pattern);
         }
 
+        $allComponents = $this->getRegisteredModuleList();
+
         foreach ($relevantPaths as $codePath) {
-            $allComponents = $this->getRegisteredModuleList();
             $mainModName = array_search($codePath, $allComponents) ?: basename(str_replace($pattern, '', $codePath));
+            $mainModName = str_replace(self::MAGENTO_PREFIX, "", $mainModName);
             $modulePaths[$mainModName][] = $codePath;
 
             if (MftfApplicationConfig::getConfig()->verboseEnabled()) {
@@ -539,6 +546,9 @@ class ModuleResolver
             foreach (self::PATHS as $componentType) {
                 $allComponents = array_merge($allComponents, $components->getPaths($componentType));
             }
+            array_walk($allComponents, function (&$value) {
+                $value .= DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'Mftf';
+            });
             return $allComponents;
         } catch (TestFrameworkException $e) {
             LoggingUtil::getInstance()->getLogger(ModuleResolver::class)->warning(

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -235,7 +235,7 @@ class ModuleResolver
         ];
 
         foreach ($codePathsToPattern as $codePath => $pattern) {
-            $allModulePaths = array_merge($allModulePaths, $this->globRelevantPaths($codePath, $pattern));
+            $allModulePaths = array_merge_recursive($allModulePaths, $this->globRelevantPaths($codePath, $pattern));
         }
 
         return $allModulePaths;
@@ -289,7 +289,7 @@ class ModuleResolver
         $subDirectory = "*" . DIRECTORY_SEPARATOR;
         $directories = glob($testPath . $subDirectory . $pattern, GLOB_ONLYDIR);
         foreach (glob($testPath . $subDirectory, GLOB_ONLYDIR) as $dir) {
-            $directories = array_merge($directories, self::globRelevantWrapper($dir, $pattern));
+            $directories = array_merge_recursive($directories, self::globRelevantWrapper($dir, $pattern));
         }
         return $directories;
     }


### PR DESCRIPTION
… Magento instance via vendor directory. magento/magento2-functional-testing-framework#162

- Adjusted Module Resolver to look Recursively from Project Root, Magento BP and dev/tests
- Updated Module Resolver Unit Tests to reflect changes

Adjusted ModuleResolver to do a recursive search in directories related to PROJECT_ROOT and MAGENTO_BP

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<162>: Allow running tests for modules installed in Magento instance via vendor directory.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests