### PR TITLE
MQE-1254: MFTF with Firefox fails due to getLog call

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Extension/ErrorLogger.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/ErrorLogger.php
@@ -48,10 +48,12 @@ class ErrorLogger
     public function logErrors($webDriver, $stepEvent)
     {
         //Types available should be "server", "browser", "driver". Only care about browser at the moment.
-        $browserLogEntries = $webDriver->manage()->getLog("browser");
-        foreach ($browserLogEntries as $entry) {
-            if (array_key_exists("source", $entry) && $entry["source"] === "javascript") {
-                $this->logError("javascript", $stepEvent, $entry);
+        if (in_array("browser", $webDriver->manage()->getAvailableLogTypes())) {
+            $browserLogEntries = $webDriver->manage()->getLog("browser");
+            foreach ($browserLogEntries as $entry) {
+                if (array_key_exists("source", $entry) && $entry["source"] === "javascript") {
+                    $this->logError("javascript", $stepEvent, $entry);
+                }
             }
         }
     }


### PR DESCRIPTION
- Added check to ascertain browser is among the available log types

Prevents a call to getLog for a type of log that may not exist

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests