### PR TITLE
MQE-1142: Use timeout value when waitForLoadingMaskToDisappear

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -377,7 +377,7 @@ class MagentoWebDriver extends WebDriver
      * @throws \Exception
      * @return void
      */
-    public function waitForLoadingMaskToDisappear($timeout)
+    public function waitForLoadingMaskToDisappear($timeout = null)
     {
         foreach (self::$loadingMasksLocators as $maskLocator) {
             // Get count of elements found for looping.


### PR DESCRIPTION
### Description
- Added default value for $timeout attribute (causing issues with CE tests)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests