### PR TITLE
MQE-1150: Test generation fails for arguments containing hyphen character

### DIFF
--- a/dev/tests/verification/Resources/ActionGroupWithParameterizedElementWithHyphen.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithParameterizedElementWithHyphen.txt
@@ -1,0 +1,32 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ */
+class ActionGroupWithParameterizedElementWithHyphenCest
+{
+	/**
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function ActionGroupWithParameterizedElementWithHyphen(AcceptanceTester $I)
+	{
+		$keyoneActionGroup = $I->executeJS("#element .full-width");
+	}
+}

--- a/dev/tests/verification/TestModule/ActionGroup/FunctionalActionGroup.xml
+++ b/dev/tests/verification/TestModule/ActionGroup/FunctionalActionGroup.xml
@@ -85,4 +85,10 @@
         </arguments>
         <seeInCurrentUrl url="/{{persistedData.urlKey}}.html?___store={{xmlData.firstname}}" stepKey="checkUrl"/>
     </actionGroup>
+    <actionGroup name="SectionArgumentWithParameterizedSelector">
+        <arguments>
+            <argument name="section" defaultValue="SampleSection"/>
+        </arguments>
+        <executeJS function="{{section.oneParamElement('full-width')}}" stepKey="keyone"/>
+    </actionGroup>
 </actionGroups>

--- a/dev/tests/verification/TestModule/Test/ActionGroupTest.xml
+++ b/dev/tests/verification/TestModule/Test/ActionGroupTest.xml
@@ -158,4 +158,9 @@
             <argument name="sameStepKeyAsArg" value="arg1"/>
         </actionGroup>
     </test>
+    <test name="ActionGroupWithParameterizedElementWithHyphen">
+        <actionGroup ref="SectionArgumentWithParameterizedSelector" stepKey="actionGroup">
+            <argument name="section" value="SampleSection"/>
+        </actionGroup>
+    </test>
 </tests>

--- a/dev/tests/verification/Tests/ActionGroupGenerationTest.php
+++ b/dev/tests/verification/Tests/ActionGroupGenerationTest.php
@@ -195,4 +195,15 @@ class ActionGroupGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('ActionGroupSkipReadiness');
     }
+
+    /**
+     * Test an action group with an arg that resolves into section.element with a hyphen in the parameter
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testActionGroupWithHyphen()
+    {
+        $this->generateAndCompareTest('ActionGroupWithParameterizedElementWithHyphen');
+    }
 }

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -377,7 +377,7 @@ class MagentoWebDriver extends WebDriver
      * @throws \Exception
      * @return void
      */
-    public function waitForLoadingMaskToDisappear($timeout)
+    public function waitForLoadingMaskToDisappear($timeout = null)
     {
         foreach (self::$loadingMasksLocators as $maskLocator) {
             // Get count of elements found for looping.

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
@@ -204,7 +204,7 @@ class ActionGroupObject
         // $regexPattern match on:   $matches[0] {{section.element(arg.field)}}
         // $matches[1] = section.element
         // $matches[2] = arg.field
-        $regexPattern = '/{{([\w.\[\]]+)\(*([\w.$\',\s\[\]]+)*\)*}}/';
+        $regexPattern = '/{{([^(}]+)\(*([^)}]+)*\)*}}/';
 
         $newActionAttributes = [];
         foreach ($attributes as $attributeKey => $attributeValue) {


### PR DESCRIPTION
### Description
- Made regex more flexible, should accept any character except for ones that break the pattern.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests