### PR TITLE
MQE-1040: MFTF standalone commands do not pass down constants correctly

### DIFF
--- a/dev/tests/functional/standalone_bootstrap.php
+++ b/dev/tests/functional/standalone_bootstrap.php
@@ -28,7 +28,6 @@ if (file_exists($envFilePath . DIRECTORY_SEPARATOR . '.env')) {
     if (array_key_exists('MAGENTO_BP', $_ENV)) {
         // TODO REMOVE THIS CODE ONCE WE HAVE STOPPED SUPPORTING dev/tests/acceptance PATH
         // define TEST_PATH and TEST_MODULE_PATH
-//        defined('TESTS_BP') || define('TESTS_BP', realpath(MAGENTO_BP . DIRECTORY_SEPARATOR . 'dev/tests/acceptance/'));
         defined('TESTS_BP') || define('TESTS_BP', dirname(dirname(__DIR__)));
         $RELATIVE_TESTS_MODULE_PATH = '/tests/functional/tests/MFTF';
         defined('TESTS_MODULE_PATH') || define(

--- a/dev/tests/functional/standalone_bootstrap.php
+++ b/dev/tests/functional/standalone_bootstrap.php
@@ -28,9 +28,9 @@ if (file_exists($envFilePath . DIRECTORY_SEPARATOR . '.env')) {
     if (array_key_exists('MAGENTO_BP', $_ENV)) {
         // TODO REMOVE THIS CODE ONCE WE HAVE STOPPED SUPPORTING dev/tests/acceptance PATH
         // define TEST_PATH and TEST_MODULE_PATH
-        defined('TESTS_BP') || define('TESTS_BP', realpath(MAGENTO_BP . DIRECTORY_SEPARATOR . 'dev/tests/acceptance/'));
-
-        $RELATIVE_TESTS_MODULE_PATH = '/tests/functional/Magento/FunctionalTest';
+//        defined('TESTS_BP') || define('TESTS_BP', realpath(MAGENTO_BP . DIRECTORY_SEPARATOR . 'dev/tests/acceptance/'));
+        defined('TESTS_BP') || define('TESTS_BP', dirname(dirname(__DIR__)));
+        $RELATIVE_TESTS_MODULE_PATH = '/tests/functional/tests/MFTF';
         defined('TESTS_MODULE_PATH') || define(
             'TESTS_MODULE_PATH',
             realpath(TESTS_BP . $RELATIVE_TESTS_MODULE_PATH)

--- a/src/Magento/FunctionalTestingFramework/_bootstrap.php
+++ b/src/Magento/FunctionalTestingFramework/_bootstrap.php
@@ -32,6 +32,10 @@ if (file_exists($envFilepath . DIRECTORY_SEPARATOR . '.env')) {
         defined($key) || define($key, $var);
     }
 
+    if (array_key_exists('MAGENTO_BP', $_ENV)) {
+        defined('TESTS_BP') || define('TESTS_BP', realpath(PROJECT_ROOT . DIRECTORY_SEPARATOR . 'dev/tests/acceptance'));
+    }
+
     defined('MAGENTO_CLI_COMMAND_PATH') || define(
         'MAGENTO_CLI_COMMAND_PATH',
         'dev/tests/acceptance/utils/command.php'


### PR DESCRIPTION
- Corrected original ticket
- Changed functional run location from alternate Magento Directory to project directory whether standalone or in vendor

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests