### PR TITLE
MQE-1222: Selector Fails To Resolve Correctly in Action Group

### DIFF
--- a/dev/tests/verification/Resources/ActionGroupWithSectionAndDataAsArguments.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithSectionAndDataAsArguments.txt
@@ -1,0 +1,32 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ */
+class ActionGroupWithSectionAndDataAsArgumentsCest
+{
+	/**
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function ActionGroupWithSectionAndDataAsArguments(AcceptanceTester $I)
+	{
+		$I->waitForElementVisible("#element .John");
+	}
+}

--- a/dev/tests/verification/TestModule/ActionGroup/BasicActionGroup.xml
+++ b/dev/tests/verification/TestModule/ActionGroup/BasicActionGroup.xml
@@ -118,4 +118,12 @@
     <actionGroup name="actionGroupWithSkipReadinessActions">
         <comment userInput="ActionGroupSkipReadiness" stepKey="skip" skipReadiness="true"/>
     </actionGroup>
+
+    <actionGroup name="actionGroupWithSectionAndData">
+        <arguments>
+            <argument name="content" type="string"/>
+            <argument name="section"/>
+        </arguments>
+        <waitForElementVisible selector="{{section.oneParamElement(content)}}" stepKey="arg1"/>
+    </actionGroup>
 </actionGroups>

--- a/dev/tests/verification/TestModule/Test/ActionGroupTest.xml
+++ b/dev/tests/verification/TestModule/Test/ActionGroupTest.xml
@@ -158,4 +158,11 @@
             <argument name="sameStepKeyAsArg" value="arg1"/>
         </actionGroup>
     </test>
+
+    <test name="ActionGroupWithSectionAndDataAsArguments">
+        <actionGroup ref="actionGroupWithSectionAndData" stepKey="actionGroup">
+            <argument name="content" value="{{simpleData.firstname}}"/>
+            <argument name="section" value="SampleSection"/>
+        </actionGroup>
+    </test>
 </tests>

--- a/dev/tests/verification/Tests/ActionGroupGenerationTest.php
+++ b/dev/tests/verification/Tests/ActionGroupGenerationTest.php
@@ -195,4 +195,15 @@ class ActionGroupGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('ActionGroupSkipReadiness');
     }
+
+    /**
+     * Test an action group with an arg containing stepKey text
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testActionGroupWithSectionAndDataArguments()
+    {
+        $this->generateAndCompareTest('ActionGroupWithSectionAndDataAsArguments');
+    }
 }

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ArgumentObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ArgumentObject.php
@@ -104,8 +104,8 @@ class ArgumentObject
      * Takes in boolean to determine if the replacement is being done with an inner argument (as in if it's a parameter)
      *
      * Example Type     Non Inner           Inner
-     * {{XML.DATA}}:    {{XML.DATA}}        XML.DATA
-     * $TEST.DATA$:     $TEST.DATA$         $TEST.DATA$
+     * {{XML.DATA}}     {{XML.DATA}}        XML.DATA
+     * $TEST.DATA$      $TEST.DATA$         $TEST.DATA$
      * stringLiteral    stringLiteral       'stringLiteral'
      *
      * @param boolean $isInnerArgument
@@ -114,6 +114,11 @@ class ArgumentObject
     private function resolveStringArgument($isInnerArgument)
     {
         if ($isInnerArgument) {
+            if (preg_match('/{{[\w.\[\]]+}}/', $this->value)) {
+                return ltrim(rtrim($this->value, "}"), "{");
+            } elseif (preg_match('/\${1,2}[\w.\[\]]+\${1,2}/', $this->value)) {
+                return $this->value;
+            }
             return "'" . $this->value . "'";
         } else {
             return $this->value;


### PR DESCRIPTION
### Description
- Added support for passing in data into arguments as `{{mydata.value}}`, solves use case where an actionGroup with the following:
-- Argument name=`data` type=`string`
-- Argument name=`section`
-- Action with `selector="{{section.elementWithParam(data)}}`
- In test
-- `data` = `{{mydata.value}}`
-- `section` = `existingSection`

- Above now correctly fetches and resolves `{{existingSection.elementWithParam(mydata.value)}}`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests