### PR TITLE
MQE-1256: "Merge" works different for tests and action groups

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Config/ActionGroupDomTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Config/ActionGroupDomTest.php
@@ -25,7 +25,7 @@ class ActionGroupDomTest extends MagentoTestCase
          </actionGroups>";
 
         $exceptionCollector = new ExceptionCollector();
-        $actionDom = new ActionGroupDom($sampleXml, 'dupeStepKeyActionGroup.xml', $exceptionCollector);
+        new ActionGroupDom($sampleXml, 'dupeStepKeyActionGroup.xml', $exceptionCollector);
 
         $this->expectException(\Exception::class);
         $exceptionCollector->throwException();
@@ -46,5 +46,26 @@ class ActionGroupDomTest extends MagentoTestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage("XML Parse Error: invalid.xml\n");
         new ActionGroupDom($sampleXml, 'invalid.xml', $exceptionCollector);
+    }
+
+    /**
+     * Test detection of two ActionGroups with the same Name in the same file.
+     */
+    public function testActionGroupDomDuplicateActionGroupsValidation()
+    {
+        $sampleXml = '<actionGroups>
+            <actionGroup name="actionGroupName">
+                <wait time="1" stepKey="key1" />
+            </actionGroup>
+            <actionGroup name="actionGroupName">
+                <wait time="1" stepKey="key1" />
+            </actionGroup>
+        </actionGroups>';
+
+        $exceptionCollector = new ExceptionCollector();
+        new ActionGroupDom($sampleXml, 'dupeNameActionGroup.xml', $exceptionCollector);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp("/name: actionGroupName is used more than once./");
+        $exceptionCollector->throwException();
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Config/DomTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Config/DomTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Tests\unit\Magento\FunctionalTestFramework\Test\Config;
+
+use Magento\FunctionalTestingFramework\Exceptions\Collector\ExceptionCollector;
+use Magento\FunctionalTestingFramework\Config\Dom\ValidationException;
+use Magento\FunctionalTestingFramework\Test\Config\ActionGroupDom;
+use Magento\FunctionalTestingFramework\Util\MagentoTestCase;
+
+class DomTest extends MagentoTestCase
+{
+    /**
+     * Test Test duplicate step key validation
+     */
+    public function testTestStepKeyDuplicateValidation()
+    {
+        $sampleXml = '<tests>
+            <test name="testName">
+                <comment userInput="step1" stepKey="key1"/>
+                <comment userInput="step2" stepKey="key1"/>
+            </test>
+        </tests>';
+
+        $exceptionCollector = new ExceptionCollector();
+        new ActionGroupDom($sampleXml, 'dupeStepKeyTest.xml', $exceptionCollector);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp("/stepKey: key1 is used more than once. \(Parent: testName\)/");
+        $exceptionCollector->throwException();
+    }
+
+    /**
+     * Test detection of two Tests with the same Name in the same file.
+     */
+    public function testTestNameDuplicateValidation()
+    {
+        $sampleXml = '<tests>
+            <test name="testName">
+                <comment userInput="step1" stepKey="key1"/>
+            </test>
+            <test name="testName">
+                <comment userInput="step1" stepKey="key1"/>
+            </test>
+        </tests>';
+
+        $exceptionCollector = new ExceptionCollector();
+        new ActionGroupDom($sampleXml, 'dupeTestsTest.xml', $exceptionCollector);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp("/name: testName is used more than once./");
+        $exceptionCollector->throwException();
+    }
+}

--- a/src/Magento/FunctionalTestingFramework/Config/MftfDom.php
+++ b/src/Magento/FunctionalTestingFramework/Config/MftfDom.php
@@ -59,4 +59,18 @@ class MftfDom extends \Magento\FunctionalTestingFramework\Config\Dom
         $dom = $this->initDom($xml, $filename, $exceptionCollector);
         $this->mergeNode($dom->documentElement, '');
     }
+
+    /**
+     * Checks if the filename given ends with the correct suffix.
+     * @param string $filename
+     * @param string $suffix
+     * @return boolean
+     */
+    public function checkFilenameSuffix($filename, $suffix)
+    {
+        if (substr_compare($filename, $suffix, -strlen($suffix)) === 0) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Magento/FunctionalTestingFramework/Test/Config/ActionGroupDom.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/ActionGroupDom.php
@@ -29,12 +29,19 @@ class ActionGroupDom extends Dom
     {
         $dom = parent::initDom($xml, $filename);
 
-        if (strpos($filename, self::ACTION_GROUP_FILE_NAME_ENDING)) {
+        if ($this->checkFilenameSuffix($filename, self::ACTION_GROUP_FILE_NAME_ENDING)) {
+            $actionGroupsNode = $dom->getElementsByTagName('actionGroups')[0];
             $actionGroupNodes = $dom->getElementsByTagName('actionGroup');
+
+            $this->testsValidationUtil->validateChildUniqueness(
+                $actionGroupsNode,
+                $filename,
+                null
+            );
             foreach ($actionGroupNodes as $actionGroupNode) {
                 /** @var \DOMElement $actionGroupNode */
                 $actionGroupNode->setAttribute(self::TEST_META_FILENAME_ATTRIBUTE, $filename);
-                $this->validationUtil->validateChildUniqueness(
+                $this->actionsValidationUtil->validateChildUniqueness(
                     $actionGroupNode,
                     $filename,
                     $actionGroupNode->getAttribute(self::ACTION_GROUP_META_NAME_ATTRIBUTE)

--- a/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
@@ -19,7 +19,7 @@ use Magento\FunctionalTestingFramework\Util\Validation\DuplicateNodeValidationUt
  */
 class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
 {
-    const TEST_FILE_NAME_ENDING = 'Test';
+    const TEST_FILE_NAME_ENDING = 'Test.xml';
     const TEST_META_FILENAME_ATTRIBUTE = 'filename';
     const TEST_META_NAME_ATTRIBUTE = 'name';
     const TEST_HOOK_NAMES = ["after", "before"];
@@ -27,10 +27,16 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
     const TEST_MERGE_POINTER_AFTER = "insertAfter";
 
     /**
-     * NodeValidationUtil
+     * NodeValidationUtil for test actions
      * @var DuplicateNodeValidationUtil
      */
-    protected $validationUtil;
+    protected $actionsValidationUtil;
+
+    /**
+     * NodeValidationUtil for test names
+     * @var DuplicateNodeValidationUtil
+     */
+    protected $testsValidationUtil;
 
     /**
      * ExceptionCollector
@@ -57,7 +63,8 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
         $schemaFile = null,
         $errorFormat = self::ERROR_FORMAT_DEFAULT
     ) {
-        $this->validationUtil = new DuplicateNodeValidationUtil('stepKey', $exceptionCollector);
+        $this->actionsValidationUtil = new DuplicateNodeValidationUtil('stepKey', $exceptionCollector);
+        $this->testsValidationUtil = new DuplicateNodeValidationUtil('name', $exceptionCollector);
         $this->exceptionCollector = $exceptionCollector;
         parent::__construct(
             $xml,
@@ -81,8 +88,14 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
     {
         $dom = parent::initDom($xml, $filename);
 
-        if (strpos($filename, self::TEST_FILE_NAME_ENDING)) {
+        if ($this->checkFilenameSuffix($filename, self::TEST_FILE_NAME_ENDING)) {
+            $testsNode = $dom->getElementsByTagName('tests')[0];
             $testNodes = $dom->getElementsByTagName('test');
+            $this->testsValidationUtil->validateChildUniqueness(
+                $testsNode,
+                $filename,
+                null
+            );
             foreach ($testNodes as $testNode) {
                 /** @var \DOMElement $testNode */
                 $testNode->setAttribute(self::TEST_META_FILENAME_ATTRIBUTE, $filename);
@@ -102,7 +115,7 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
                     );
                 }
 
-                $this->validationUtil->validateChildUniqueness(
+                $this->actionsValidationUtil->validateChildUniqueness(
                     $testNode,
                     $filename,
                     $testNode->getAttribute(self::TEST_META_NAME_ATTRIBUTE)
@@ -111,14 +124,14 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
                 $afterNode = $testNode->getElementsByTagName('after')->item(0);
 
                 if (isset($beforeNode)) {
-                    $this->validationUtil->validateChildUniqueness(
+                    $this->actionsValidationUtil->validateChildUniqueness(
                         $beforeNode,
                         $filename,
                         $testNode->getAttribute(self::TEST_META_NAME_ATTRIBUTE) . "/before"
                     );
                 }
                 if (isset($afterNode)) {
-                    $this->validationUtil->validateChildUniqueness(
+                    $this->actionsValidationUtil->validateChildUniqueness(
                         $afterNode,
                         $filename,
                         $testNode->getAttribute(self::TEST_META_NAME_ATTRIBUTE) . "/after"

--- a/src/Magento/FunctionalTestingFramework/Util/Validation/DuplicateNodeValidationUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Validation/DuplicateNodeValidationUtil.php
@@ -69,7 +69,11 @@ class DuplicateNodeValidationUtil
             $duplicates = array_diff_assoc($keyValues, $withoutDuplicates);
             $keyError = "";
             foreach ($duplicates as $duplicateKey => $duplicateValue) {
-                $keyError .= "\t{$this->uniqueKey}: {$duplicateValue} is used more than once. (Parent: {$parentKey})\n";
+                $keyError .= "\t{$this->uniqueKey}: {$duplicateValue} is used more than once.";
+                if ($parentKey !== null) {
+                    $keyError .=" (Parent: {$parentKey})";
+                }
+                $keyError .= "\n";
             }
 
             $errorMsg = "{$type} cannot use {$this->uniqueKey}s more than once.\t\n{$keyError}\tin file: {$filename}";


### PR DESCRIPTION
### Description
- Actiongroup and test dom classes now check for duplicate child <test> and <actionGroup> elements.
- Minor bugfix around searching filename, "test" is literally always going to appear in filepath due to directory structure.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests