### PR TITLE
MQE-1117: dontSeeJsError does not catch JS errors

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Extension/ErrorLogger.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/ErrorLogger.php
@@ -49,8 +49,8 @@ class ErrorLogger
     public function logErrors($module, $stepEvent)
     {
         //Types available should be "server", "browser", "driver". Only care about browser at the moment.
-        if (in_array("browser", $module->$webDriver->manage()->getAvailableLogTypes())) {
-            $browserLogEntries = $module->$webDriver->manage()->getLog("browser");
+        if (in_array("browser", $module->webDriver->manage()->getAvailableLogTypes())) {
+            $browserLogEntries = $module->webDriver->manage()->getLog("browser");
             foreach ($browserLogEntries as $entry) {
                 if (array_key_exists("source", $entry) && $entry["source"] === "javascript") {
                     $this->logError("javascript", $stepEvent, $entry);


### PR DESCRIPTION
### Description
- Syntax issue in ErrorLogger.php fixed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests