### PR TITLE
MQE-1288: ModuleResolver test paths are too greedy

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
@@ -101,17 +101,17 @@ class ModuleResolverTest extends MagentoTestCase
         // Define the Module paths from default TESTS_MODULE_PATH
         $modulePath = defined('TESTS_MODULE_PATH') ? TESTS_MODULE_PATH : TESTS_BP;
 
-        // Define the Module paths from vendor modules
-        $projectRootCodePath = PROJECT_ROOT;
-
         $mockResolver->verifyInvoked('globRelevantPaths', [$modulePath, '']);
         $mockResolver->verifyInvoked(
             'globRelevantPaths',
-            [$magentoBaseCodePath, 'Test' . DIRECTORY_SEPARATOR .'Mftf']
+            [$magentoBaseCodePath . DIRECTORY_SEPARATOR . "vendor" , 'Test' . DIRECTORY_SEPARATOR .'Mftf']
         );
         $mockResolver->verifyInvoked(
             'globRelevantPaths',
-            [$projectRootCodePath, 'Test' . DIRECTORY_SEPARATOR .'Mftf']
+            [
+                $magentoBaseCodePath . DIRECTORY_SEPARATOR . "app" . DIRECTORY_SEPARATOR . "code",
+                'Test' . DIRECTORY_SEPARATOR .'Mftf'
+            ]
         );
     }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
@@ -88,7 +88,8 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
     {
         $dom = parent::initDom($xml, $filename);
 
-        if ($this->checkFilenameSuffix($filename, self::TEST_FILE_NAME_ENDING)) {
+        // Cannot rely on filename to ensure this file is a Test.xml
+        if ($dom->getElementsByTagName('tests')->length > 0) {
             $testsNode = $dom->getElementsByTagName('tests')[0];
             $testNodes = $dom->getElementsByTagName('test');
             $this->testsValidationUtil->validateChildUniqueness(

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -240,13 +240,14 @@ class ModuleResolver
         $modulePath = defined('TESTS_MODULE_PATH') ? TESTS_MODULE_PATH : TESTS_BP;
         $modulePath = rtrim($modulePath, DIRECTORY_SEPARATOR);
 
-        // Define the Module paths from project root
-        $projectRootCodePath = PROJECT_ROOT;
+        $vendorCodePath = DIRECTORY_SEPARATOR . "vendor";
+        $appCodePath = DIRECTORY_SEPARATOR . "app" . DIRECTORY_SEPARATOR . "code";
 
         $codePathsToPattern = [
             $modulePath => '',
-            $magentoBaseCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
-            $projectRootCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf'
+            $magentoBaseCodePath . $vendorCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
+            $magentoBaseCodePath . $appCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
+
         ];
 
         foreach ($codePathsToPattern as $codePath => $pattern) {

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -246,8 +246,7 @@ class ModuleResolver
         $codePathsToPattern = [
             $modulePath => '',
             $magentoBaseCodePath . $vendorCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
-            $magentoBaseCodePath . $appCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf',
-
+            $magentoBaseCodePath . $appCodePath => 'Test' . DIRECTORY_SEPARATOR . 'Mftf'
         ];
 
         foreach ($codePathsToPattern as $codePath => $pattern) {


### PR DESCRIPTION
Modified Module Resolver to restrict search areas for MFTF Tests

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests