### PR TITLE
MQE-1264: Failing Allure steps showing up as passed

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -125,7 +125,7 @@ class MagentoAllureAdapter extends AllureAdapter
      * @throws \Yandex\Allure\Adapter\AllureException
      * @return void
      */
-    public function stepAfter(StepEvent $stepEvent)
+    public function stepAfter(StepEvent $stepEvent = null)
     {
         if ($stepEvent->getStep()->hasFailed()) {
             $this->getLifecycle()->fire(new StepFailedEvent());

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -5,10 +5,11 @@
  */
 namespace Magento\FunctionalTestingFramework\Allure\Adapter;
 
-use Magento\FunctionalTestingFramework\Data\Argument\Interpreter\NullType;
 use Magento\FunctionalTestingFramework\Suite\Handlers\SuiteObjectHandler;
 use Yandex\Allure\Adapter\AllureAdapter;
 use Yandex\Allure\Adapter\Event\StepStartedEvent;
+use Yandex\Allure\Adapter\Event\StepFinishedEvent;
+use Yandex\Allure\Adapter\Event\StepFailedEvent;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\StepEvent;
 

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -118,4 +118,18 @@ class MagentoAllureAdapter extends AllureAdapter
         $this->emptyStep = false;
         $this->getLifecycle()->fire(new StepStartedEvent($stepName));
     }
+
+    /**
+     * Override of parent method, fires StepFailedEvent if step has failed (for xml output)
+     * @param StepEvent $stepEvent
+     * @throws \Yandex\Allure\Adapter\AllureException
+     * @return void
+     */
+    public function stepAfter(StepEvent $stepEvent)
+    {
+        if ($stepEvent->getStep()->hasFailed()) {
+            $this->getLifecycle()->fire(new StepFailedEvent());
+        }
+        $this->getLifecycle()->fire(new StepFinishedEvent());
+    }
 }


### PR DESCRIPTION
### Description
- MagnetoAllureAdapter overrides parent `stepAfter()`, fires off StepFailedEvent to properly set the step status

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests