### PR TITLE
MQE-1330: FT can not be executed for bundled extensions

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
@@ -57,7 +57,7 @@ class ModuleResolverTest extends MagentoTestCase
     public function testGetModulePathsAggregate()
     {
         $this->mockForceGenerate(false);
-        $this->setMockResolverClass(false, null, null, null, ["example" => "example" . DIRECTORY_SEPARATOR . "paths"]);
+        $this->setMockResolverClass(false, null, null, null, ["Magento_example" => "example" . DIRECTORY_SEPARATOR . "paths"]);
         $resolver = ModuleResolver::getInstance();
         $this->setMockResolverProperties($resolver, null, [0 => "Magento_example"]);
         $this->assertEquals(
@@ -79,7 +79,7 @@ class ModuleResolverTest extends MagentoTestCase
         $this->mockForceGenerate(false);
         $mockResolver = $this->setMockResolverClass(
             true,
-            [0 => "magento_example"],
+            [0 => "example"],
             null,
             null,
             ["example" => "example" . DIRECTORY_SEPARATOR . "paths"]

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/ModuleResolverTest.php
@@ -57,7 +57,13 @@ class ModuleResolverTest extends MagentoTestCase
     public function testGetModulePathsAggregate()
     {
         $this->mockForceGenerate(false);
-        $this->setMockResolverClass(false, null, null, null, ["Magento_example" => "example" . DIRECTORY_SEPARATOR . "paths"]);
+        $this->setMockResolverClass(
+            false,
+            null,
+            null,
+            null,
+            ["Magento_example" => "example" . DIRECTORY_SEPARATOR . "paths"]
+        );
         $resolver = ModuleResolver::getInstance();
         $this->setMockResolverProperties($resolver, null, [0 => "Magento_example"]);
         $this->assertEquals(

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -336,7 +336,8 @@ class ModuleResolver
         foreach ($enabledModules as $magentoModuleName) {
             if (!isset($this->knownDirectories[$magentoModuleName]) && !isset($allModulePaths[$magentoModuleName])) {
                 continue;
-            } elseif (isset($this->knownDirectories[$magentoModuleName]) && !isset($allModulePaths[$magentoModuleName])) {
+            } elseif (isset($this->knownDirectories[$magentoModuleName])
+                && !isset($allModulePaths[$magentoModuleName])) {
                 LoggingUtil::getInstance()->getLogger(ModuleResolver::class)->warn(
                     "Known directory could not match to an existing path.",
                     ['knownDirectory' => $magentoModuleName]

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -39,11 +39,6 @@ class ModuleResolver
     const REGISTRAR_CLASS = "\Magento\Framework\Component\ComponentRegistrar";
 
     /**
-     * Magento Directory Structure Name Prefix
-     */
-    const MAGENTO_PREFIX = "Magento_";
-
-    /**
      * Enabled modules.
      *
      * @var array|null
@@ -278,7 +273,6 @@ class ModuleResolver
 
         foreach ($relevantPaths as $codePath) {
             $mainModName = array_search($codePath, $allComponents) ?: basename(str_replace($pattern, '', $codePath));
-            $mainModName = str_replace(self::MAGENTO_PREFIX, "", $mainModName);
             $modulePaths[$mainModName][] = $codePath;
 
             if (MftfApplicationConfig::getConfig()->verboseEnabled()) {
@@ -340,17 +334,15 @@ class ModuleResolver
     {
         $enabledDirectoryPaths = [];
         foreach ($enabledModules as $magentoModuleName) {
-            // Magento_Backend -> Backend or DevDocs -> DevDocs (if whitelisted has no underscore)
-            $moduleShortName = explode('_', $magentoModuleName)[1] ?? $magentoModuleName;
-            if (!isset($this->knownDirectories[$moduleShortName]) && !isset($allModulePaths[$moduleShortName])) {
+            if (!isset($this->knownDirectories[$magentoModuleName]) && !isset($allModulePaths[$magentoModuleName])) {
                 continue;
-            } elseif (isset($this->knownDirectories[$moduleShortName]) && !isset($allModulePaths[$moduleShortName])) {
+            } elseif (isset($this->knownDirectories[$magentoModuleName]) && !isset($allModulePaths[$magentoModuleName])) {
                 LoggingUtil::getInstance()->getLogger(ModuleResolver::class)->warn(
                     "Known directory could not match to an existing path.",
-                    ['knownDirectory' => $moduleShortName]
+                    ['knownDirectory' => $magentoModuleName]
                 );
             } else {
-                $enabledDirectoryPaths[$moduleShortName] = $allModulePaths[$moduleShortName];
+                $enabledDirectoryPaths[$magentoModuleName] = $allModulePaths[$magentoModuleName];
             }
         }
         return $enabledDirectoryPaths;


### PR DESCRIPTION
### Description
- Removed all trimming of "Magento_" from enabled modules in ModuleResolver
- Removed all trimming of "*_" from module name in ModuleResolver

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests