### PR TITLE
Fix Element with no type attribute warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Magento Functional Testing Framework Changelog
     
 ### Fixes
 * Fixed an issue where mftf would fail to parse test materials for extensions installed under `vendor`.
+* Fixed an issue where an `element` with no `type` would cause PHP warnings during test runs.
 
 2.3.9
 -----

--- a/src/Magento/FunctionalTestingFramework/Page/Handlers/SectionObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Handlers/SectionObjectHandler.php
@@ -67,7 +67,7 @@ class SectionObjectHandler implements ObjectHandlerInterface
                     if (preg_match('/[^a-zA-Z0-9_]/', $elementName)) {
                         throw new XmlException(sprintf(self::ELEMENT_NAME_ERROR_MSG, $elementName, $sectionName));
                     }
-                    $elementType = $elementData[SectionObjectHandler::TYPE];
+                    $elementType = $elementData[SectionObjectHandler::TYPE] ?? null;
                     $elementSelector = $elementData[SectionObjectHandler::SELECTOR] ?? null;
                     $elementLocatorFunc = $elementData[SectionObjectHandler::LOCATOR_FUNCTION] ?? null;
                     $elementTimeout = $elementData[SectionObjectHandler::TIMEOUT] ?? null;


### PR DESCRIPTION
### Description
- If an element has no type, it will cause a warning if it's parsed during a test run. This will lead to the test execution being aborted due to this warning, and thus no test artifacts.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests