### PR TITLE
MQE-1357: mftf run:failed cannot regenerate parallelized suites

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -135,6 +135,11 @@ class RunTestFailedCommand extends BaseGenerateCommand
                     if ($suiteName == self::DEFAULT_TEST_GROUP) {
                         array_push($failedTestDetails['tests'], $testName);
                     } else {
+                        // Trim potential suite_parallel_0 to suite_parallel
+                        $suiteNameArray = explode("_", $suiteName);
+                        if (is_numeric(array_pop($suiteNameArray))) {
+                            $suiteName = implode("_", $suiteNameArray);
+                        }
                         $failedTestDetails['suites'] = array_merge_recursive(
                             $failedTestDetails['suites'],
                             [$suiteName => [$testName]]


### PR DESCRIPTION
### Description
- RunTestFailedCommand now trims "_#" from end if it is there

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests