### PR TITLE
MQE-1357: mftf run:failed cannot regenerate parallelized suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Magento Functional Testing Framework Changelog
 ================================================
 
+2.3.11
+-----
+### Fixes
+* `mftf run:failed` now correctly regenerates tests that are in suites that were parallelized (`suite` => `suite_0`, `suite_1`)
+
 2.3.10
 -----
 ### Enhancements

--- a/bin/mftf
+++ b/bin/mftf
@@ -29,7 +29,7 @@ try {
 try {
     $application = new Symfony\Component\Console\Application();
     $application->setName('Magento Functional Testing Framework CLI');
-    $application->setVersion('2.3.10');
+    $application->setVersion('2.3.11');
     /** @var \Magento\FunctionalTestingFramework\Console\CommandListInterface $commandList */
     $commandList = new \Magento\FunctionalTestingFramework\Console\CommandList;
     foreach ($commandList->getCommands() as $command) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/magento2-functional-testing-framework",
     "description": "Magento2 Functional Testing Framework",
     "type": "library",
-    "version": "2.3.10",
+    "version": "2.3.11",
     "license": "AGPL-3.0",
     "keywords": ["magento", "automation", "functional", "testing"],
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afd707f35922d7ce72085b5fbe0c0ef7",
+    "content-hash": "8c1aec6635705d156a60b726ef9eb81e",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -135,6 +135,11 @@ class RunTestFailedCommand extends BaseGenerateCommand
                     if ($suiteName == self::DEFAULT_TEST_GROUP) {
                         array_push($failedTestDetails['tests'], $testName);
                     } else {
+                        // Trim potential suite_parallel_0 to suite_parallel
+                        $suiteNameArray = explode("_", $suiteName);
+                        if (is_numeric(array_pop($suiteNameArray))) {
+                            $suiteName = implode("_", $suiteNameArray);
+                        }
                         $failedTestDetails['suites'] = array_merge_recursive(
                             $failedTestDetails['suites'],
                             [$suiteName => [$testName]]


### PR DESCRIPTION
### Description
- RunTestFailedCommand now trims "_#" if it is present

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests