### PR TITLE
Mqe 1361: Unable to use empty string literal as argument to selector in tests

### DIFF
--- a/dev/tests/verification/Resources/SectionReplacementTest.txt
+++ b/dev/tests/verification/Resources/SectionReplacementTest.txt
@@ -68,5 +68,7 @@ class SectionReplacementTestCest
 		$I->click("#stringLiteral1-" . PersistedObjectHandler::getInstance()->retrieveEntityField('createdData', 'firstname', 'test') . " .Doe" . msq("uniqueData"));
 		$I->click("#element .1#element .2");
 		$I->click("#element .1#element .{$data}");
+		$I->click("(//div[@data-role='slide'])[1]/a[@data-element='link'][contains(@href,'')]");
+		$I->click("(//div[@data-role='slide'])[1]/a[@data-element='link'][contains(@href,' ')]");
 	}
 }

--- a/dev/tests/verification/TestModule/Section/SampleSection.xml
+++ b/dev/tests/verification/TestModule/Section/SampleSection.xml
@@ -18,5 +18,6 @@
         <element name="threeOneDuplicateParamElement" type="button" selector="#{{var1}}-{{var2}} .{{var1}} [{{var3}}]" parameterized="true"/>
         <element name="timeoutElement" type="button" selector="#foo" timeout="30"/>
         <element name="mergeElement" type="button" selector="#unMerge"/>
+        <element name="anotherTwoParamsElement" type="button" selector="(//div[@data-role='slide'])[{{arg1}}]/a[@data-element='link'][contains(@href,'{{arg2}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/dev/tests/verification/TestModule/Test/SectionReplacementTest.xml
+++ b/dev/tests/verification/TestModule/Test/SectionReplacementTest.xml
@@ -50,5 +50,8 @@
 
         <click stepKey="selectorReplaceTwoParamElements" selector="{{SampleSection.oneParamElement('1')}}{{SampleSection.oneParamElement('2')}}"/>
         <click stepKey="selectorReplaceTwoParamMixedTypes" selector="{{SampleSection.oneParamElement('1')}}{{SampleSection.oneParamElement({$data})}}"/>
+
+        <click stepKey="selectorParamWithEmptyString" selector="{{SampleSection.anotherTwoParamsElement('1', '')}}"/>
+        <click stepKey="selectorParamWithASpace" selector="{{SampleSection.anotherTwoParamsElement('1', ' ')}}"/>
     </test>
 </tests>

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -691,7 +691,7 @@ class ActionObject
         $resolvedParameters = [];
         foreach ($parameters as $parameter) {
             $parameter = trim($parameter);
-            preg_match_all("/[$'][\w\D]+[$']/", $parameter, $stringOrPersistedMatch);
+            preg_match_all("/[$'][\w\D]*[$']/", $parameter, $stringOrPersistedMatch);
             preg_match_all('/{\$[a-z][a-zA-Z\d]+}/', $parameter, $variableMatch);
             if (!empty($stringOrPersistedMatch[0])) {
                 $resolvedParameters[] = ltrim(rtrim($parameter, "'"), "'");


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests