### PR TITLE
MQE-1372: If Suite before fails build must be RED

### DIFF
--- a/dev/tests/verification/Resources/functionalSuiteHooks.txt
+++ b/dev/tests/verification/Resources/functionalSuiteHooks.txt
@@ -30,7 +30,7 @@ class functionalSuiteHooks extends \Codeception\GroupObject
 
         if ($this->preconditionFailure != null) {
             //if our preconditions fail, we need to mark all the tests as incomplete.
-            $e->getTest()->getMetadata()->setIncomplete($this->preconditionFailure);
+            $e->getTest()->getMetadata()->setIncomplete("SUITE PRECONDITION FAILED:" . PHP_EOL . $this->preconditionFailure);
         }
     }
 

--- a/etc/config/codeception.dist.yml
+++ b/etc/config/codeception.dist.yml
@@ -12,7 +12,6 @@ settings:
     memory_limit: 1024M
 extensions:
     enabled:
-        - Codeception\Extension\RunFailed
         - Magento\FunctionalTestingFramework\Extension\TestContextExtension
         - Magento\FunctionalTestingFramework\Allure\Adapter\MagentoAllureAdapter
     config:

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -148,5 +148,4 @@ class MagentoAllureAdapter extends AllureAdapter
         $message = $e->getMessage();
         $this->getLifecycle()->fire($event->withException($e)->withMessage($message));
     }
-
 }

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -10,6 +10,8 @@ use Yandex\Allure\Adapter\AllureAdapter;
 use Yandex\Allure\Adapter\Event\StepStartedEvent;
 use Yandex\Allure\Adapter\Event\StepFinishedEvent;
 use Yandex\Allure\Adapter\Event\StepFailedEvent;
+use Yandex\Allure\Adapter\Event\TestCaseFailedEvent;
+use Codeception\Event\FailEvent;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\StepEvent;
 
@@ -132,4 +134,19 @@ class MagentoAllureAdapter extends AllureAdapter
         }
         $this->getLifecycle()->fire(new StepFinishedEvent());
     }
+
+    /**
+     * Override of parent method, fires a TestCaseFailedEvent if a test is marked as incomplete.
+     *
+     * @param FailEvent $failEvent
+     * @return void
+     */
+    public function testIncomplete(FailEvent $failEvent)
+    {
+        $event = new TestCaseFailedEvent();
+        $e = $failEvent->getFail();
+        $message = $e->getMessage();
+        $this->getLifecycle()->fire($event->withException($e)->withMessage($message));
+    }
+
 }

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -184,6 +184,12 @@ class TestContextExtension extends BaseExtension
         $file = $this->getLogDir() . self::TEST_FAILED_FILE;
         $result = $e->getResult();
         $output = [];
+
+        // Remove previous file regardless if we're writing a new file
+        if (is_file($file)) {
+            unlink($file);
+        }
+
         foreach ($result->failures() as $fail) {
             $output[] = $this->localizePath(\Codeception\Test\Descriptor::getTestFullName($fail->failedTest()));
         }
@@ -194,8 +200,7 @@ class TestContextExtension extends BaseExtension
             $output[] = $this->localizePath(\Codeception\Test\Descriptor::getTestFullName($fail->failedTest()));
         }
 
-        if (empty($output) && is_file($file)) {
-            unlink($file);
+        if (empty($output)) {
             return;
         }
 

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -173,7 +173,6 @@ class TestContextExtension extends BaseExtension
         ErrorLogger::getInstance()->logErrors($this->getDriver(), $e);
     }
 
-
     /**
      * Saves failed tests from last codecept run command into a file in _output directory
      * Removes file if there were no failures in last run command
@@ -205,7 +204,7 @@ class TestContextExtension extends BaseExtension
 
     /**
      * Returns localized path to string, for writing failed file.
-     * @param $path
+     * @param string $path
      * @return string
      */
     protected function localizePath($path)

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -16,6 +16,7 @@ use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHan
 class TestContextExtension extends BaseExtension
 {
     const TEST_PHASE_AFTER = "_after";
+    const TEST_FAILED_FILE = 'failed';
 
     /**
      * Codeception Events Mapping to methods
@@ -35,7 +36,8 @@ class TestContextExtension extends BaseExtension
             Events::TEST_START => 'testStart',
             Events::TEST_FAIL => 'testFail',
             Events::STEP_AFTER => 'afterStep',
-            Events::TEST_END => 'testEnd'
+            Events::TEST_END => 'testEnd',
+            Events::RESULT_PRINT_AFTER => 'saveFailed'
         ];
         self::$events = array_merge(parent::$events, $events);
         parent::_initialize();
@@ -169,5 +171,49 @@ class TestContextExtension extends BaseExtension
     public function afterStep(\Codeception\Event\StepEvent $e)
     {
         ErrorLogger::getInstance()->logErrors($this->getDriver(), $e);
+    }
+
+
+    /**
+     * Saves failed tests from last codecept run command into a file in _output directory
+     * Removes file if there were no failures in last run command
+     * @param \Codeception\Event\PrintResultEvent $e
+     * @return void
+     */
+    public function saveFailed(\Codeception\Event\PrintResultEvent $e)
+    {
+        $file = $this->getLogDir() . self::TEST_FAILED_FILE;
+        $result = $e->getResult();
+        $output = [];
+        foreach ($result->failures() as $fail) {
+            $output[] = $this->localizePath(\Codeception\Test\Descriptor::getTestFullName($fail->failedTest()));
+        }
+        foreach ($result->errors() as $fail) {
+            $output[] = $this->localizePath(\Codeception\Test\Descriptor::getTestFullName($fail->failedTest()));
+        }
+        foreach ($result->notImplemented() as $fail) {
+            $output[] = $this->localizePath(\Codeception\Test\Descriptor::getTestFullName($fail->failedTest()));
+        }
+
+        if (empty($output) && is_file($file)) {
+            unlink($file);
+            return;
+        }
+
+        file_put_contents($file, implode("\n", $output));
+    }
+
+    /**
+     * Returns localized path to string, for writing failed file.
+     * @param $path
+     * @return string
+     */
+    protected function localizePath($path)
+    {
+        $root = realpath($this->getRootDir()) . DIRECTORY_SEPARATOR;
+        if (substr($path, 0, strlen($root)) == $root) {
+            return substr($path, strlen($root));
+        }
+        return $path;
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Suite/views/SuiteClass.mustache
+++ b/src/Magento/FunctionalTestingFramework/Suite/views/SuiteClass.mustache
@@ -31,7 +31,7 @@ class {{suiteName}} extends \Codeception\GroupObject
 
         if ($this->preconditionFailure != null) {
             //if our preconditions fail, we need to mark all the tests as incomplete.
-            $e->getTest()->getMetadata()->setIncomplete($this->preconditionFailure);
+            $e->getTest()->getMetadata()->setIncomplete("SUITE PRECONDITION FAILED:" . PHP_EOL . $this->preconditionFailure);
         }
     }
 


### PR DESCRIPTION
### Description
- Removed use of Codeception\Extension\RunFailed
- Moved RunFailed functionality to TestContextExtension, to be able to write incomplete tests to the `failed` file (for build reasons)
- Incomplete tests are now set as failed in MagentoAllureAdapter

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests