### PR TITLE
 Update requirements to include php7.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 install: composer install --no-interaction --prefer-source
 env:
   matrix:

--- a/bin/phpunit-checks
+++ b/bin/phpunit-checks
@@ -15,7 +15,9 @@ vendor/bin/phpunit --configuration dev/tests/phpunit.xml --testsuite unit --cove
 echo "==============================="
 echo "       UNIT TEST COVERAGE"
 echo "==============================="
-vendor/bin/coverage-check clover.xml $UNIT_COVERAGE_THRESHOLD
+if [[ ${TRAVIS_PHP_VERSION:0:3} != "7.3" ]]
+    then vendor/bin/coverage-check clover.xml $UNIT_COVERAGE_THRESHOLD
+fi
 
 echo "==============================="
 echo "      VERIFICATION TESTS"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
+        "php": "7.0.2||7.0.4||~7.0.6||~7.1.0||~7.2.0||~7.3.0",
         "ext-curl": "*",
         "allure-framework/allure-codeception": "~1.2.6",
         "codeception/codeception": "~2.3.4",
@@ -25,7 +25,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "~3.2",
         "sebastian/phpcpd": "~3.0 || ~4.0",
-        "brainmaestro/composer-git-hooks": "^2.3",
+        "brainmaestro/composer-git-hooks": "^2.3.1",
         "doctrine/cache": "<1.7.0",
         "codeception/aspect-mock": "^3.0",
         "goaop/framework": "2.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab52f12570440f5833f0d81bce06f884",
+    "content-hash": "0a58509a75dc4ea99a4bef3d13ee4075",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",
@@ -4508,20 +4508,20 @@
     "packages-dev": [
         {
             "name": "brainmaestro/composer-git-hooks",
-            "version": "v2.6.0",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BrainMaestro/composer-git-hooks.git",
-                "reference": "1ae36cc7c1a4387f026e5f085b3ba63fdf912cb7"
+                "reference": "137dd2aec2be494918f8bdfb18f57b55ff20015e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BrainMaestro/composer-git-hooks/zipball/1ae36cc7c1a4387f026e5f085b3ba63fdf912cb7",
-                "reference": "1ae36cc7c1a4387f026e5f085b3ba63fdf912cb7",
+                "url": "https://api.github.com/repos/BrainMaestro/composer-git-hooks/zipball/137dd2aec2be494918f8bdfb18f57b55ff20015e",
+                "reference": "137dd2aec2be494918f8bdfb18f57b55ff20015e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || >=7.0",
                 "symfony/console": "^3.2 || ^4.0"
             },
             "require-dev": {
@@ -4571,7 +4571,7 @@
                 "composer",
                 "git"
             ],
-            "time": "2018-10-28T02:55:04+00:00"
+            "time": "2018-12-28T14:57:06+00:00"
         },
         {
             "name": "codacy/coverage",
@@ -5684,7 +5684,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0"
+        "php": "7.0.2||7.0.4||~7.0.6||~7.1.0||~7.2.0||~7.3.0",
+        "ext-curl": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
### Description
Add support for php 7.3

* add php 7.3 to .travis.yml
  - Initial successful build on travis - skips coverage check on 7.3 image due to lack of stable xdebug support.
* update `brainmaestro/composer-git-hooks` to `v2.6.1`
  - The update to this package was only a commit bumping the version number https://github.com/BrainMaestro/composer-git-hooks/commit/137dd2aec2be494918f8bdfb18f57b55ff20015e

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests