### PR TITLE
MQE-1439: Invalid XML character in AdminDateFormatOnAttributePageTest causes Allure report parse error

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -98,10 +98,13 @@ class MagentoAllureAdapter extends AllureCodeception
     }
 
     /**
-     * Override of parent method, only different to prevent replacing of . to •
+     * Override of parent method:
+     *     prevent replacing of . to •
+     *     strips control characters
      *
      * @param StepEvent $stepEvent
      * @return void
+     * @throws \Yandex\Allure\Adapter\AllureException
      */
     public function stepBefore(StepEvent $stepEvent)
     {

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -117,6 +117,9 @@ class MagentoAllureAdapter extends AllureCodeception
 
         $stepName = $stepAction . ' ' . $stepArgs;
 
+        // Strip control characters so that report generation does not fail
+        $stepName = preg_replace('/[[:cntrl:]]/', '', $stepName);
+
         $this->emptyStep = false;
         $this->getLifecycle()->fire(new StepStartedEvent($stepName));
     }


### PR DESCRIPTION
### Description
* Control characters break Allure report generation
* This change strips control characters
* When this is released, we can unskip MFTF testCaseId MAGETWO-96136
* [Here's a link to a build](http://10.234.200.213:8080/job/Functional-Tests-EE/790/allure/#suites/8187718e2fd144987673ef34ee62b41b/98636d84d0259c4d/) where this is fixed and MAGETWO-96136 is unskipped and ran

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests