### PR TITLE
Fixed misspelling.

### DIFF
--- a/docs/commands/codeception.md
+++ b/docs/commands/codeception.md
@@ -21,7 +21,7 @@ Run all tests without the `<group value="skip"/>` [annotation][]:
 vendor/bin/codecept run functional --skip-group skip  -c dev/tests/acceptance/codeception.yml
 ```
 
-Run all tests with the `<group value="example"/>` [annotation][] but with no `<group value="skpip"/>`:
+Run all tests with the `<group value="example"/>` [annotation][] but with no `<group value="skip"/>`:
 
 ```bash
 vendor/bin/codecept run functional --group example --skip-group skip -c dev/tests/acceptance/codeception.yml


### PR DESCRIPTION
This PR fixes a typo in https://devdocs.magento.com/mftf/docs/commands/codeception.html#usage-examples
Fixes #4169.