### PR TITLE
executeInSelenium action does not generate proper code

### DIFF
--- a/dev/tests/verification/Resources/ExecuteInSeleniumTest.txt
+++ b/dev/tests/verification/Resources/ExecuteInSeleniumTest.txt
@@ -1,0 +1,32 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ */
+class ExecuteInSeleniumTestCest
+{
+	/**
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function ExecuteInSeleniumTest(AcceptanceTester $I)
+	{
+		$I->executeInSelenium(function ($webdriver) { return 'Hello, World!'});
+	}
+}

--- a/dev/tests/verification/TestModule/Test/ExecuteInSeleniumTest.xml
+++ b/dev/tests/verification/TestModule/Test/ExecuteInSeleniumTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="ExecuteInSeleniumTest">
+        <executeInSelenium function="function ($webdriver) { return 'Hello, World!'}" stepKey="executeInSeleniumStep"/>
+    </test>
+</tests>

--- a/dev/tests/verification/Tests/ExecuteInSeleniumTest.php
+++ b/dev/tests/verification/Tests/ExecuteInSeleniumTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace tests\verification\Tests;
+
+use tests\util\MftfTestCase;
+
+class ExecuteInSeleniumTest extends MftfTestCase
+{
+    /**
+     * Tests generation of executeInSelenium action.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testExecuteJsTest()
+    {
+        $this->generateAndCompareTest('ExecuteInSeleniumTest');
+    }
+}

--- a/dev/tests/verification/Tests/ExecuteInSeleniumTest.php
+++ b/dev/tests/verification/Tests/ExecuteInSeleniumTest.php
@@ -15,7 +15,7 @@ class ExecuteInSeleniumTest extends MftfTestCase
      * @throws \Exception
      * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
      */
-    public function testExecuteJsTest()
+    public function testExecuteInSeleniumTest()
     {
         $this->generateAndCompareTest('ExecuteInSeleniumTest');
     }

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -60,7 +60,7 @@ class ActionObject
     const ASSERTION_VALUE_ATTRIBUTE = "value";
     const DELETE_DATA_MUTUAL_EXCLUSIVE_ATTRIBUTES = ["url", "createDataKey"];
     const EXTERNAL_URL_AREA_INVALID_ACTIONS = ['amOnPage'];
-    const FUNCTION_CLOSURE_ACTIONS = ['waitForElementChange', 'performOn'];
+    const FUNCTION_CLOSURE_ACTIONS = ['waitForElementChange', 'performOn', 'executeInSelenium'];
     const MERGE_ACTION_ORDER_AFTER = 'after';
     const MERGE_ACTION_ORDER_BEFORE = 'before';
     const ACTION_ATTRIBUTE_TIMEZONE = 'timezone';


### PR DESCRIPTION
**executeInSelenium** action does not generate proper code because this action was not included in `ActionObject::FUNCTION_CLOSURE_ACTIONS`

### Steps to reproduce
1. Create test with **executeInSelenium** action 
`<executeInSelenium function="function ($webdriver) { return 'Hello, World!'}" stepKey="testStep"/>`
2. Run `vendor/bin/mftf generate:tests`

### Expected result
There is generated action
`$I->executeInSelenium(function ($webdriver) { return 'Hello, World!'});`
Function is passed as Closure.

### Actual result
There is generated action
`$I->executeInSelenium("function ($webdriver) { return 'Hello, World!'}");`
Function is passed as string not Closure. So if you run test you will get exception here.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests