### PR TITLE
Return exit codes of process started by 'run:test', 'run:group' or 'run:failed' command

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -46,12 +46,12 @@ class RunTestCommand extends BaseGenerateCommand
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @return integer|null|void
+     * @return int
      * @throws \Exception
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tests = $input->getArgument('name');
         $skipGeneration = $input->getOption('skip-generate');
@@ -85,7 +85,8 @@ class RunTestCommand extends BaseGenerateCommand
         $process->setWorkingDirectory(TESTS_BP);
         $process->setIdleTimeout(600);
         $process->setTimeout(0);
-        $process->run(
+
+        return $process->run(
             function ($type, $buffer) use ($output) {
                 $output->write($buffer);
             }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -46,7 +46,7 @@ class RunTestCommand extends BaseGenerateCommand
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @return int
+     * @return integer
      * @throws \Exception
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -59,13 +59,13 @@ class RunTestFailedCommand extends BaseGenerateCommand
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @return integer|null|void
+     * @return int
      * @throws \Exception
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Create Mftf Configuration
         MftfApplicationConfig::create(
@@ -87,7 +87,7 @@ class RunTestFailedCommand extends BaseGenerateCommand
         $command->run(new ArrayInput($args), $output);
 
         $testManifestList = $this->readTestManifestFile();
-
+        $returnCode = 0;
         foreach ($testManifestList as $testCommand) {
             $codeceptionCommand = realpath(PROJECT_ROOT . '/vendor/bin/codecept') . ' run functional ';
             $codeceptionCommand .= $testCommand;
@@ -96,11 +96,11 @@ class RunTestFailedCommand extends BaseGenerateCommand
             $process->setWorkingDirectory(TESTS_BP);
             $process->setIdleTimeout(600);
             $process->setTimeout(0);
-            $process->run(
+            $returnCode = max($returnCode, $process->run(
                 function ($type, $buffer) use ($output) {
                     $output->write($buffer);
                 }
-            );
+            ));
             if (file_exists(self::TESTS_FAILED_FILE)) {
                 $this->failedList = array_merge(
                     $this->failedList,
@@ -111,6 +111,8 @@ class RunTestFailedCommand extends BaseGenerateCommand
         foreach ($this->failedList as $test) {
             $this->writeFailedTestToFile($test, self::TESTS_FAILED_FILE);
         }
+
+        return $returnCode;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -59,7 +59,7 @@ class RunTestFailedCommand extends BaseGenerateCommand
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @return int
+     * @return integer
      * @throws \Exception
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
@@ -78,7 +78,8 @@ class RunTestFailedCommand extends BaseGenerateCommand
         $testConfiguration = $this->getFailedTestList();
 
         if ($testConfiguration === null) {
-            return null;
+            // no failed tests found, run is a success
+            return 0;
         }
 
         $command = $this->getApplication()->find('generate:tests');

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -53,12 +53,12 @@ class RunTestGroupCommand extends BaseGenerateCommand
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @return integer|null|void
+     * @return int
      * @throws \Exception
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $skipGeneration = $input->getOption('skip-generate');
         $force = $input->getOption('force');
@@ -102,7 +102,8 @@ class RunTestGroupCommand extends BaseGenerateCommand
         $process->setWorkingDirectory(TESTS_BP);
         $process->setIdleTimeout(600);
         $process->setTimeout(0);
-        $process->run(
+
+        return $process->run(
             function ($type, $buffer) use ($output) {
                 $output->write($buffer);
             }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -53,7 +53,7 @@ class RunTestGroupCommand extends BaseGenerateCommand
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @return int
+     * @return integer
      * @throws \Exception
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)


### PR DESCRIPTION
### Description
Return the already available exit codes of the spawned processes as return code for the commands

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#337: run:<x> command always returns exit code of 0 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests