### PR TITLE
Add option to generate:tests for XSD validation on 'merged files'

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2644,16 +2644,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.13",
+            "version": "6.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693"
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0973426fb012359b2f18d3bd1e90ef1172839693",
-                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
                 "shasum": ""
             },
             "require": {
@@ -2724,7 +2724,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-08T15:10:43+00:00"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/dev/tests/_bootstrap.php
+++ b/dev/tests/_bootstrap.php
@@ -32,6 +32,7 @@ $kernel->init([
     true,
     \Magento\FunctionalTestingFramework\Config\MftfApplicationConfig::UNIT_TEST_PHASE,
     true,
+    false,
     false
 );
 

--- a/etc/config/.env.example
+++ b/etc/config/.env.example
@@ -42,8 +42,9 @@ BROWSER=chrome
 MODULE_WHITELIST=Magento_Framework,Magento_ConfigurableProductWishlist,Magento_ConfigurableProductCatalogSearch
 #CUSTOM_MODULE_PATHS=
 
-#*** Bool property which allows the user to toggle debug output during test execution
+#*** Bool properties which allows the user to toggle debug output during test execution
 #MFTF_DEBUG=
+#MFTF_FAST_DEBUG=
 
 #*** Default timeout for wait actions
 #WAIT_TIMEOUT=10

--- a/src/Magento/FunctionalTestingFramework/Config/MftfApplicationConfig.php
+++ b/src/Magento/FunctionalTestingFramework/Config/MftfApplicationConfig.php
@@ -36,11 +36,18 @@ class MftfApplicationConfig
     private $verboseEnabled;
 
     /**
-     * Determines whether the user would like to execute mftf in a verbose run.
+     * Determines whether the user would like to execute mftf in a 'per file' debug mode
      *
      * @var boolean
      */
     private $debugEnabled;
+
+    /**
+     * Determines whether the user would like to execute mftf in a 'merged file' debug mode
+     *
+     * @var boolean
+     */
+    private $fastDebugEnabled;
 
     /**
      * MftfApplicationConfig Singelton Instance
@@ -53,16 +60,18 @@ class MftfApplicationConfig
      * MftfApplicationConfig constructor.
      *
      * @param boolean $forceGenerate
-     * @param string  $phase
+     * @param string $phase
      * @param boolean $verboseEnabled
      * @param boolean $debugEnabled
+     * @param null $fastDebugEnabled
      * @throws TestFrameworkException
      */
     private function __construct(
         $forceGenerate = false,
         $phase = self::EXECUTION_PHASE,
         $verboseEnabled = null,
-        $debugEnabled = null
+        $debugEnabled = null,
+        $fastDebugEnabled = null
     ) {
         $this->forceGenerate = $forceGenerate;
 
@@ -73,6 +82,7 @@ class MftfApplicationConfig
         $this->phase = $phase;
         $this->verboseEnabled = $verboseEnabled;
         $this->debugEnabled = $debugEnabled;
+        $this->fastDebugEnabled = $fastDebugEnabled;
     }
 
     /**
@@ -83,13 +93,14 @@ class MftfApplicationConfig
      * @param string  $phase
      * @param boolean $verboseEnabled
      * @param boolean $debugEnabled
+     * * @param boolean $fastDebugEnabled
      * @return void
      */
-    public static function create($forceGenerate, $phase, $verboseEnabled, $debugEnabled)
+    public static function create($forceGenerate, $phase, $verboseEnabled, $debugEnabled, $fastDebugEnabled)
     {
         if (self::$MFTF_APPLICATION_CONTEXT == null) {
             self::$MFTF_APPLICATION_CONTEXT =
-                new MftfApplicationConfig($forceGenerate, $phase, $verboseEnabled, $debugEnabled);
+                new MftfApplicationConfig($forceGenerate, $phase, $verboseEnabled, $debugEnabled, $fastDebugEnabled);
         }
     }
 
@@ -128,7 +139,7 @@ class MftfApplicationConfig
      */
     public function verboseEnabled()
     {
-        return $this->verboseEnabled ?? getenv('MFTF_DEBUG');
+        return $this->verboseEnabled ?? (strcasecmp(getenv('MFTF_DEBUG'),'true') == 0);
     }
 
     /**
@@ -139,7 +150,18 @@ class MftfApplicationConfig
      */
     public function debugEnabled()
     {
-        return $this->debugEnabled ?? getenv('MFTF_DEBUG');
+        return $this->debugEnabled ?? (strcasecmp(getenv('MFTF_DEBUG'),'true') == 0);
+    }
+
+    /**
+     * Returns a boolean indicating whether the user has indicated a fast debug run, which will lengthy validation
+     * on merged file instead of 'per file' with some extra error messaging to be run
+     *
+     * @return boolean
+     */
+    public function fastDebugEnabled()
+    {
+        return $this->fastDebugEnabled ?? (strcasecmp(getenv('MFTF_FAST_DEBUG'),'true') == 0);
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
@@ -231,14 +231,13 @@ class Filesystem implements \Magento\FunctionalTestingFramework\Config\ReaderInt
         if ($this->validationState->isValidationRequired()) {
             $errors = [];
             if ($configMerger && !$configMerger->validate($this->schemaFile, $errors)) {
-                $message = $filename ? $filename . PHP_EOL . "Invalid Document \n" : PHP_EOL . "Invalid Document \n";
-                foreach ($errors as $error ){
+                foreach ($errors as $error){
                     LoggingUtil::getInstance()->getLogger(Filesystem::class)->buildFailure(
-                        "XSD schema validation error",
+                        "XSD schema error ",
                         [ "file"=> $filename ? $filename: ":mergedFile:", "error" => $error]
                     );
                 }
-                throw new \Exception($message . implode("\n", $errors));
+                throw new \Exception("Error: XSD schema issues found in file(s) " . $filename . "\n");
             }
         }
     }

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
@@ -232,6 +232,12 @@ class Filesystem implements \Magento\FunctionalTestingFramework\Config\ReaderInt
             $errors = [];
             if ($configMerger && !$configMerger->validate($this->schemaFile, $errors)) {
                 $message = $filename ? $filename . PHP_EOL . "Invalid Document \n" : PHP_EOL . "Invalid Document \n";
+                foreach ($errors as $error ){
+                    LoggingUtil::getInstance()->getLogger(Filesystem::class)->buildFailure(
+                        "XSD schema validation error",
+                        [ "file"=> $filename ? $filename: ":mergedFile:", "error" => $error]
+                    );
+                }
                 throw new \Exception($message . implode("\n", $errors));
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/MftfFilesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/MftfFilesystem.php
@@ -51,6 +51,9 @@ class MftfFilesystem extends \Magento\FunctionalTestingFramework\Config\Reader\F
         if ($fileList->valid()) {
             $this->validateSchema($configMerger, $fileList->getFilename());
         }
+        if (MftfApplicationConfig::getConfig()->fastDebugEnabled()) {
+            $this->validateSchema($configMerger);
+        }
 
         $output = [];
         if ($configMerger) {

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/MftfFilesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/MftfFilesystem.php
@@ -6,6 +6,7 @@
 
 namespace Magento\FunctionalTestingFramework\Config\Reader;
 
+use Magento\AdminNotification\Block\Inbox;
 use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Exceptions\Collector\ExceptionCollector;
 use Magento\FunctionalTestingFramework\Util\Iterator\File;
@@ -51,7 +52,8 @@ class MftfFilesystem extends \Magento\FunctionalTestingFramework\Config\Reader\F
         if ($fileList->valid()) {
             $this->validateSchema($configMerger, $fileList->getFilename());
         }
-        if (MftfApplicationConfig::getConfig()->fastDebugEnabled()) {
+        if (MftfApplicationConfig::getConfig()->fastDebugEnabled() &&
+            !MftfApplicationConfig::getConfig()->debugEnabled()) {
             $this->validateSchema($configMerger);
         }
 

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateDocsCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateDocsCommand.php
@@ -67,6 +67,7 @@ class GenerateDocsCommand extends Command
             $force,
             MftfApplicationConfig::GENERATION_PHASE,
             false,
+            false,
             false
         );
 

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateTestsCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateTestsCommand.php
@@ -55,7 +55,12 @@ class GenerateTestsCommand extends BaseGenerateCommand
                 'debug',
                 'd',
                 InputOption::VALUE_NONE,
-                'run extra validation when generating tests'
+                'run extra validation per file when generating tests'
+            )->addOption(
+                'fastdebug',
+                'a',
+                InputOption::VALUE_NONE,
+                'run extra validation on merged files when generating tests'
             );
 
         parent::configure();
@@ -79,8 +84,8 @@ class GenerateTestsCommand extends BaseGenerateCommand
         $force = $input->getOption('force');
         $time = $input->getOption('time') * 60 * 1000; // convert from minutes to milliseconds
         $debug = $input->getOption('debug');
+        $fastDebug = $input->getOption('fastdebug');
         $remove = $input->getOption('remove');
-
         $verbose = $output->isVerbose();
 
         if ($json !== null && !json_decode($json)) {
@@ -95,10 +100,10 @@ class GenerateTestsCommand extends BaseGenerateCommand
 
         // Remove previous GENERATED_DIR if --remove option is used
         if ($remove) {
-            $this->removeGeneratedDirectory($output, $verbose || $debug);
+            $this->removeGeneratedDirectory($output, $verbose || $debug || $fastDebug);
         }
 
-        $testConfiguration = $this->createTestConfiguration($json, $tests, $force, $debug, $verbose);
+        $testConfiguration = $this->createTestConfiguration($json, $tests, $force, $debug, $fastDebug, $verbose);
 
         // create our manifest file here
         $testManifest = TestManifestFactory::makeManifest($config, $testConfiguration['suites']);
@@ -125,19 +130,21 @@ class GenerateTestsCommand extends BaseGenerateCommand
      * @param array   $tests
      * @param boolean $force
      * @param boolean $debug
+     * @param boolean $fastDebug
      * @param boolean $verbose
      * @return array
      * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
      * @throws \Magento\FunctionalTestingFramework\Exceptions\XmlException
      */
-    private function createTestConfiguration($json, array $tests, bool $force, bool $debug, bool $verbose)
+    private function createTestConfiguration($json, array $tests, bool $force, bool $debug, bool $fastDebug, bool $verbose)
     {
         // set our application configuration so we can references the user options in our framework
         MftfApplicationConfig::create(
             $force,
             MftfApplicationConfig::GENERATION_PHASE,
             $verbose,
-            $debug
+            $debug,
+            $fastDebug
         );
 
         $testConfiguration = [];

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -72,6 +72,7 @@ class RunTestFailedCommand extends BaseGenerateCommand
             false,
             MftfApplicationConfig::GENERATION_PHASE,
             false,
+            false,
             false
         );
 

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -77,6 +77,7 @@ class RunTestGroupCommand extends BaseGenerateCommand
             $force,
             MftfApplicationConfig::GENERATION_PHASE,
             false,
+            false,
             false
         );
 

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
@@ -75,6 +75,7 @@ class TestDependencyCheck implements StaticCheckInterface
             true,
             MftfApplicationConfig::UNIT_TEST_PHASE,
             false,
+            false,
             false
         );
 

--- a/src/Magento/FunctionalTestingFramework/Util/Logger/MftfLogger.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Logger/MftfLogger.php
@@ -13,7 +13,7 @@ use Monolog\Logger;
 class MftfLogger extends Logger
 {
     /**
-     * Prints a deprecation warning, as well as adding a log at the WARNING level.
+     * Prints a deprecation warning, as well as adds a log at the WARNING level.
      *
      * @param  string $message The log message.
      * @param  array  $context The log context.
@@ -27,5 +27,22 @@ class MftfLogger extends Logger
             print ($message . json_encode($context) . "\n");
         }
         parent::warning($message, $context);
+    }
+
+    /**
+     * Prints a critical failure, as well as adds a log at the CRITICAL level.
+     *
+     * @param  string $message The log message.
+     * @param  array  $context The log context.
+     * @return void
+     */
+    public function buildFailure($message, array $context = [])
+    {
+        $message = "BUILD FAILURE: " . $message;
+        // Suppress print during unit testing
+        if (MftfApplicationConfig::getConfig()->getPhase() !== MftfApplicationConfig::UNIT_TEST_PHASE) {
+            print ($message . json_encode($context) . "\n");
+        }
+        parent::critical($message, $context);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
https://jira.corp.magento.com/browse/MQE-1541

- Added a --fastdebug (-a) option to generate:tests option to run XSD validation against 'merged files'.
- Introduce a new .env parameter 'MFTF_FAST_DEBUG' that can be used to enable/disable fast debugging
- Logging xsd validation errors as CRITICAL in mftf log

### Fixed Issues (if relevant)
1. Fixed incorrect parsing while reading MFTF_DEBUG parameters from .env


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests