### PR TITLE
added file name suffix principle for data

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -121,6 +121,7 @@ The following conventions apply to MFTF `<data>`:
 * A `<data>` file may contain multiple data entities.
 * Camel case is used for `<data>` elements. The name represents the `<data>` type. For example, a file with customer data is `CustomerData.xml`. A file for simple product would be `SimpleProductData.xml`.
 * Camel case is used for the entity name.
+* The file name must have the suffix `Data.xml`.
 
 ## Example
 


### PR DESCRIPTION
### Description
MFTF will only read data nodes from files, which have the suffix `Data.xml`. I did not find a place where this is documented and I think it fits here.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [X] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests