### PR TITLE
Non-API operations fixes

### DIFF
--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/AdminExecutor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/AdminExecutor.php
@@ -158,7 +158,10 @@ class AdminExecutor extends AbstractExecutor implements CurlInterface
         if (!empty($returnRegex)) {
             preg_match($returnRegex, $this->response, $returnMatches);
             if (!empty($returnMatches)) {
-                return $returnMatches;
+                if (count($returnMatches) > 1) {
+                    unset($returnMatches);
+                }
+                return reset($returnMatches);
             }
         }
         return $this->response;

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/FrontendExecutor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/Curl/FrontendExecutor.php
@@ -179,7 +179,10 @@ class FrontendExecutor extends AbstractExecutor implements CurlInterface
         if (!empty($returnRegex)) {
             preg_match($returnRegex, $this->response, $returnMatches);
             if (!empty($returnMatches)) {
-                return $returnMatches;
+                if (count($returnMatches) > 1) {
+                    unset($returnMatches);
+                }
+                return reset($returnMatches);
             }
         }
         return $this->response;

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
@@ -119,6 +119,7 @@ class CurlHandler
         $contentType = $this->operationDefinition->getContentType();
         $successRegex = $this->operationDefinition->getSuccessRegex();
         $returnRegex = $this->operationDefinition->getReturnRegex();
+        $method = $this->operationDefinition->getApiMethod();
 
         $operationDataResolver = new OperationDataArrayResolver($dependentEntities);
         $this->requestData = $operationDataResolver->resolveOperationDataArray(
@@ -156,7 +157,7 @@ class CurlHandler
         $executor->write(
             $apiUrl,
             $this->requestData,
-            self::$curlMethodMapping[$this->operation],
+            $method ?? self::$curlMethodMapping[$this->operation],
             $headers
         );
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd
@@ -26,7 +26,7 @@
                         <xs:attribute type="xs:string" name="url"/>
                         <xs:attribute type="authEnum" name="auth"/>
                         <xs:attribute type="xs:boolean" name="removeBackend" use="optional" default="true"/>
-                        <xs:attribute type="xs:string" name="method"/>
+                        <xs:attribute type="operationMethodEnum" name="method"/>
                         <xs:attribute type="xs:string" name="successRegex"/>
                         <xs:attribute type="xs:string" name="returnRegex"/>
                         <xs:attribute type="xs:string" name="filename"/>
@@ -91,6 +91,14 @@
             <xs:enumeration value="adminFormKey" />
             <xs:enumeration value="customerFormKey" />
             <xs:enumeration value="anonymous" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="operationMethodEnum" final="restriction" >
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="GET" />
+            <xs:enumeration value="PUT" />
+            <xs:enumeration value="POST" />
+            <xs:enumeration value="DELETE" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
 ### Description

 - Fixes assignment of the correct value for object **return** property
 - Fix assignment of the correct operation **method**

 ### Steps to reproduce
- Magento 2.3.2 CE
- Change app/code/Magento/CatalogRule/Test/Mftf/Metadata/catalog-rule-meta.xml
    - **createCatalogRule** operation change url to `/catalog_rule/promo_catalog/save/back/edit` and add `returnRegex="~\/id\/(\d+?)\/~"`
    - imlement delete operation
    `<operation name="DeleteCatalogRule" dataType="catalogRule"
               type="delete"
               auth="adminFormKey"
               url="/catalog_rule/promo_catalog/delete/id/{return}"
               method="POST"
               successRegex="/messages-message-success/">
    </operation>`
- Create an run test
    `<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
        <test name="CreateCatalogRuleApiTest">
            <createData entity="_defaultCatalogRule" stepKey="createCatalogRule"/>
            <deleteData createDataKey="createCatalogRule" stepKey="deleteCatalogRule"/>
        </test>
    </tests>
    `
 ### Expected result
Test passed successfully

 ### Actual result
Test failed

### Notice
 - The first problem is that **createData** assign array as **return** field
 - The second - delete operation method is taken by operation **type** mapping, despite operation **method** is defined 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests