### PR TITLE
MQE-1622: MFTF Console Printer does not correctly consider --steps

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
+++ b/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
@@ -32,6 +32,16 @@ class Console extends \Codeception\Subscriber\Console
     private $actionGroupStepKey = null;
 
     /**
+     * Console constructor. Feeds the second option passed into parent constructor.
+     * @param array $extensionOptions
+     * @param array $options
+     */
+    public function __construct($extensionOptions = [], $options = [])
+    {
+        parent::__construct($options);
+    }
+
+    /**
      * Printing stepKey in before step action.
      *
      * @param StepEvent $e

--- a/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
+++ b/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
@@ -35,6 +35,8 @@ class Console extends \Codeception\Subscriber\Console
      * Console constructor. Feeds the second option passed into parent constructor.
      * @param array $extensionOptions
      * @param array $options
+     *
+     * @SuppressWarnings(PHPMD)
      */
     public function __construct($extensionOptions = [], $options = [])
     {

--- a/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
+++ b/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
@@ -32,7 +32,9 @@ class Console extends \Codeception\Subscriber\Console
     private $actionGroupStepKey = null;
 
     /**
-     * Console constructor. Feeds the second option passed into parent constructor.
+     * Console constructor. Parent constructor requires codeception CLI options, and does not have its own configs.
+     * Constructor is only different than parent due to the way Codeception instantiates Extensions.
+     *
      * @param array $extensionOptions
      * @param array $options
      *


### PR DESCRIPTION
### Description
- Added constructor to Console class

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests