### PR TITLE
MQE-1606: Mftf static check script should return error exit code when check fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dev/tests/functional/_output
 dev/mftf.log
 dev/tests/mftf.log
 dev/tests/docs/*
+dev/tests/_output
+dev/tests/functional.suite.yml

--- a/src/Magento/FunctionalTestingFramework/Console/StaticChecksCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/StaticChecksCommand.php
@@ -47,10 +47,20 @@ class StaticChecksCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $staticCheckObjects = $this->staticChecksList->getStaticChecks();
+
+        $errors = [];
+
         foreach ($staticCheckObjects as $staticCheck) {
             $staticOutput = $staticCheck->execute($input);
             LoggingUtil::getInstance()->getLogger(get_class($staticCheck))->info($staticOutput);
             $output->writeln($staticOutput);
+            $errors += $staticCheck->getErrors();
+        }
+
+        if (empty($errors)) {
+            return 0;
+        } else {
+            return 1;
         }
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Console/StaticChecksCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/StaticChecksCommand.php
@@ -9,18 +9,19 @@ declare(strict_types = 1);
 namespace Magento\FunctionalTestingFramework\Console;
 
 use Magento\FunctionalTestingFramework\StaticCheck\StaticChecksList;
+use Magento\FunctionalTestingFramework\StaticCheck\StaticCheckListInterface;
 use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
+use Exception;
 
 class StaticChecksCommand extends Command
 {
     /**
      * Pool of static check scripts to run
      *
-     * @var \Magento\FunctionalTestingFramework\StaticCheck\StaticCheckListInterface
+     * @var StaticCheckListInterface
      */
     private $staticChecksList;
 
@@ -41,8 +42,8 @@ class StaticChecksCommand extends Command
      *
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int|null|void
-     * @throws \Exception
+     * @return int
+     * @throws Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -51,7 +52,9 @@ class StaticChecksCommand extends Command
         $errors = [];
 
         foreach ($staticCheckObjects as $staticCheck) {
-            $staticOutput = $staticCheck->execute($input);
+            $staticCheck->execute($input);
+
+            $staticOutput = $staticCheck->getOutput();
             LoggingUtil::getInstance()->getLogger(get_class($staticCheck))->info($staticOutput);
             $output->writeln($staticOutput);
             $errors += $staticCheck->getErrors();

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/StaticCheckInterface.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/StaticCheckInterface.php
@@ -16,7 +16,7 @@ interface StaticCheckInterface
     /**
      * Executes static check script, returns output.
      * @param InputInterface $input
-     * @return string
+     * @return void
      */
     public function execute(InputInterface $input);
 
@@ -25,4 +25,10 @@ interface StaticCheckInterface
      * @return array
      */
     public function getErrors();
+
+    /**
+     * Return string of a short human readable result of the check. For example: "No Dependency errors found."
+     * @return string
+     */
+    public function getOutput();
 }

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/StaticCheckInterface.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/StaticCheckInterface.php
@@ -19,4 +19,10 @@ interface StaticCheckInterface
      * @return string
      */
     public function execute(InputInterface $input);
+
+    /**
+     * Return array containing all errors found after running the execute() function.
+     * @return array
+     */
+    public function getErrors();
 }

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/StaticCheckListInterface.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/StaticCheckListInterface.php
@@ -14,7 +14,7 @@ interface StaticCheckListInterface
     /**
      * Gets list of static check script instances
      *
-     * @return \Magento\FunctionalTestingFramework\StaticCheck\StaticCheckListInterface[]
+     * @return StaticCheckInterface[]
      */
     public function getStaticChecks();
 }

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/StaticChecksList.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/StaticChecksList.php
@@ -16,14 +16,14 @@ class StaticChecksList implements StaticCheckListInterface
     /**
      * Property contains all static check scripts.
      *
-     * @var \Magento\FunctionalTestingFramework\StaticCheck\StaticCheckListInterface[]
+     * @var StaticCheckInterface[]
      */
     private $checks;
 
     /**
      * Constructor
      *
-     * @param array $scripts
+     * @param array $checks
      */
     public function __construct(array $checks = [])
     {

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
@@ -129,6 +129,10 @@ class TestDependencyCheck implements StaticCheckInterface
         return $this->errors;
     }
 
+    /**
+     * Return string of a short human readable result of the check. For example: "No Dependency errors found."
+     * @return string
+     */
     public function getOutput()
     {
         return $this->output;

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
@@ -63,6 +63,12 @@ class TestDependencyCheck implements StaticCheckInterface
     private $alreadyExtractedDependencies;
 
     /**
+     * Array containing all errors found after running the execute() function.
+     * @var array
+     */
+    private $errors;
+
+    /**
      * Checks test dependencies, determined by references in tests versus the dependencies listed in the Magento module
      *
      * @param InputInterface $input
@@ -98,13 +104,22 @@ class TestDependencyCheck implements StaticCheckInterface
         $actionGroupXmlFiles = $this->buildFileList($allModules, $filePaths[1]);
         $dataXmlFiles= $this->buildFileList($allModules, $filePaths[2]);
 
-        $testErrors = [];
-        $testErrors += $this->findErrorsInFileSet($testXmlFiles);
-        $testErrors += $this->findErrorsInFileSet($actionGroupXmlFiles);
-        $testErrors += $this->findErrorsInFileSet($dataXmlFiles);
+        $this->errors = [];
+        $this->errors += $this->findErrorsInFileSet($testXmlFiles);
+        $this->errors += $this->findErrorsInFileSet($actionGroupXmlFiles);
+        $this->errors += $this->findErrorsInFileSet($dataXmlFiles);
 
         //print all errors to file
-        return $this->printErrorsToFile($testErrors);
+        return $this->printErrorsToFile($this->getErrors());
+    }
+
+    /**
+     * Return array containing all errors found after running the execute() function.
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
     }
 
     /**


### PR DESCRIPTION
### Description
The static-checks command now returns 1 if any errors are found and 0 if there are no errors.

### Fixed Issues (if relevant)
https://jira.corp.magento.com/browse/MQE-1606

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests