### PR TITLE
MQE-1673: command.php truncating values '0'

### DIFF
--- a/etc/config/command.php
+++ b/etc/config/command.php
@@ -26,7 +26,7 @@ if (!empty($_POST['token']) && !empty($_POST['command'])) {
             $commandParts = array_filter(explode(" ", $command), 'strlen');
             $argumentParts = array_filter(explode(" ", $arguments), 'strlen');
             $magentoBinaryParts = array_filter(explode(" ", $magentoBinary), 'strlen');
-            $commandArray = array_merge($magentoBinaryParts, $commandParts);
+            $commandArray = array_merge($magentoBinaryParts, $commandParts, $argumentParts);
             $process = new Symfony\Component\Process\Process($commandArray);
             $process->setIdleTimeout(60);
             $process->setTimeout(0);

--- a/etc/config/command.php
+++ b/etc/config/command.php
@@ -23,9 +23,9 @@ if (!empty($_POST['token']) && !empty($_POST['command'])) {
         $valid = validateCommand($magentoBinary, $command);
         if ($valid) {
             // Turn string into array for symfony escaping
-            $commandParts = array_filter(explode(" ", $command));
-            $argumentParts = array_filter(explode(" ", $arguments));
-            $magentoBinaryParts = array_filter(explode(" ", $magentoBinary));
+            $commandParts = array_filter(explode(" ", $command), 'strlen');
+            $argumentParts = array_filter(explode(" ", $arguments), 'strlen');
+            $magentoBinaryParts = array_filter(explode(" ", $magentoBinary), 'strlen');
             $commandArray = array_merge($magentoBinaryParts, $commandParts);
             $process = new Symfony\Component\Process\Process($commandArray);
             $process->setIdleTimeout(60);


### PR DESCRIPTION
### Description
- added strlen to prevent removal of "0"
- added bugfix for `argumentParts` array not being used

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests