### PR TITLE
MQE-1373: Cannot Use Data Returned By Test Actions As Substitutable V…

### DIFF
--- a/dev/tests/verification/Resources/ActionGroupWithParameterizedElementsWithStepKeyReferences.txt
+++ b/dev/tests/verification/Resources/ActionGroupWithParameterizedElementsWithStepKeyReferences.txt
@@ -1,0 +1,47 @@
+<?php
+namespace Magento\AcceptanceTest\_default\Backend;
+
+use Magento\FunctionalTestingFramework\AcceptanceTester;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
+use \Codeception\Util\Locator;
+use Yandex\Allure\Adapter\Annotation\Features;
+use Yandex\Allure\Adapter\Annotation\Stories;
+use Yandex\Allure\Adapter\Annotation\Title;
+use Yandex\Allure\Adapter\Annotation\Description;
+use Yandex\Allure\Adapter\Annotation\Parameter;
+use Yandex\Allure\Adapter\Annotation\Severity;
+use Yandex\Allure\Adapter\Model\SeverityLevel;
+use Yandex\Allure\Adapter\Annotation\TestCaseId;
+
+/**
+ */
+class ActionGroupWithParameterizedElementsWithStepKeyReferencesCest
+{
+	/**
+	 * @Features({"TestModule"})
+	 * @Parameter(name = "AcceptanceTester", value="$I")
+	 * @param AcceptanceTester $I
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function ActionGroupWithParameterizedElementsWithStepKeyReferences(AcceptanceTester $I)
+	{
+		$I->comment("Entering Action Group [actionGroup] actionGroupWithParametrizedSelectors");
+		$testVariableActionGroup = $I->executeJS("return 1"); // stepKey: testVariableActionGroup
+		$testVariable2ActionGroup = $I->executeJS("return 'test'"); // stepKey: testVariable2ActionGroup
+		$I->comment("[createSimpleDataActionGroup] create 'simpleData' entity");
+		PersistedObjectHandler::getInstance()->createEntity(
+			"createSimpleDataActionGroup",
+			"test",
+			"simpleData",
+			[],
+			[]
+		);
+
+		$I->click("#{$testVariable2ActionGroup} .John"); // stepKey: click1ActionGroup
+		$I->click("#Doe-" . msq("simpleParamData") . "prename .{$testVariableActionGroup}"); // stepKey: click2ActionGroup
+		$I->seeElement("//div[@name='Tiberius'][@class={$testVariableActionGroup}][@data-element='{$testVariable2ActionGroup}'][" . PersistedObjectHandler::getInstance()->retrieveEntityField('createSimpleData', 'name', 'test') . "]"); // stepKey: see1ActionGroup
+		$I->comment("Exiting Action Group [actionGroup] actionGroupWithParametrizedSelectors");
+	}
+}

--- a/dev/tests/verification/TestModule/ActionGroup/FunctionalActionGroup.xml
+++ b/dev/tests/verification/TestModule/ActionGroup/FunctionalActionGroup.xml
@@ -91,4 +91,16 @@
         </arguments>
         <executeJS function="{{section.oneParamElement('full-width')}}" stepKey="keyone"/>
     </actionGroup>
+    <actionGroup name="actionGroupWithParametrizedSelectors">
+        <arguments>
+            <argument name="param" type="entity"/>
+            <argument name="param2" type="entity" defaultValue="simpleParamData"/>
+        </arguments>
+        <executeJS function="return 1" stepKey="testVariable"/>
+        <executeJS function="return 'test'" stepKey="testVariable2"/>
+        <createData entity="simpleData" stepKey="createSimpleData"/>
+        <click selector="{{SampleSection.twoParamElement({$testVariable2}, param.firstname)}}" stepKey="click1"/>
+        <click selector="{{SampleSection.threeParamElement(param.lastname, param2.uniqueNamePre, {$testVariable})}}" stepKey="click2"/>
+        <seeElement selector="{{SampleSection.fourParamElement(param.middlename, {$testVariable}, {$testVariable2}, $$createSimpleData.name$$)}}" stepKey="see1"/>
+    </actionGroup>
 </actionGroups>

--- a/dev/tests/verification/TestModule/Section/SampleSection.xml
+++ b/dev/tests/verification/TestModule/Section/SampleSection.xml
@@ -15,6 +15,7 @@
         <element name="oneParamElement" type="button" selector="#element .{{var1}}" parameterized="true"/>
         <element name="twoParamElement" type="button" selector="#{{var1}} .{{var2}}" parameterized="true"/>
         <element name="threeParamElement" type="button" selector="#{{var1}}-{{var2}} .{{var3}}" parameterized="true"/>
+        <element name="fourParamElement" type="input" selector="//div[@name='{{arg1}}'][@class={{arg2}}][@data-element='{{arg3}}'][{{arg4}}]" parameterized="true"/>
         <element name="threeOneDuplicateParamElement" type="button" selector="#{{var1}}-{{var2}} .{{var1}} [{{var3}}]" parameterized="true"/>
         <element name="timeoutElement" type="button" selector="#foo" timeout="30"/>
         <element name="mergeElement" type="button" selector="#unMerge"/>

--- a/dev/tests/verification/TestModule/Test/ActionGroupTest.xml
+++ b/dev/tests/verification/TestModule/Test/ActionGroupTest.xml
@@ -171,4 +171,11 @@
             <argument name="section" value="SampleSection"/>
         </actionGroup>
     </test>
+
+    <test name="ActionGroupWithParameterizedElementsWithStepKeyReferences">
+        <actionGroup ref="actionGroupWithParametrizedSelectors" stepKey="actionGroup">
+            <argument name="param" value="simpleData"/>
+            <argument name="param2" value="simpleParamData"/>
+        </actionGroup>
+    </test>
 </tests>

--- a/dev/tests/verification/Tests/ActionGroupGenerationTest.php
+++ b/dev/tests/verification/Tests/ActionGroupGenerationTest.php
@@ -217,4 +217,15 @@ class ActionGroupGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('XmlCommentedActionGroupTest');
     }
+
+    /**
+     * Test generation of a test referencing an action group with selectors referencing stepKeys.
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testActionGroupWithActionStepKeyReferencesInSelectors()
+    {
+        $this->generateAndCompareTest('ActionGroupWithParameterizedElementsWithStepKeyReferences');
+    }
 }

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
@@ -226,7 +226,7 @@ class ActionGroupObject
         // $regexPattern match on:   $matches[0] {{section.element(arg.field)}}
         // $matches[1] = section.element
         // $matches[2] = arg.field
-        $regexPattern = '/{{([^(}]+)\(*([^)}]+)*\)*}}/';
+        $regexPattern = '/{{([^(}]+)\(*([^)]+)*?\)*}}/';
 
         $newActionAttributes = [];
         foreach ($attributes as $attributeKey => $attributeValue) {

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1482,6 +1482,8 @@ class TestGenerator
             $persistedVarRefInvoked = "PersistedObjectHandler::getInstance()->retrieveEntityField('"
                 . $stepKey . $testInvocationKey . "', 'field', 'test')";
 
+            // only replace when whole word matches exactly
+            // e.g. testVar => $testVar but not $testVar2
             if (strpos($output, $stepKeyVarRef) !== false) {
                 $output = preg_replace('/\B\\' .$stepKeyVarRef. '\b/', $stepKeyVarRef . $testInvocationKey, $output);
             }

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1483,7 +1483,7 @@ class TestGenerator
                 . $stepKey . $testInvocationKey . "', 'field', 'test')";
 
             if (strpos($output, $stepKeyVarRef) !== false) {
-                $output = str_replace($stepKeyVarRef, $stepKeyVarRef . $testInvocationKey, $output);
+                $output = preg_replace('/\B\\' .$stepKeyVarRef. '\b/', $stepKeyVarRef . $testInvocationKey, $output);
             }
 
             if (strpos($output, $persistedVarRef) !== false) {


### PR DESCRIPTION
* [MC-1373](https://jira.corp.magento.com/browse/MC-1373)

to replace custom field key in create data
fixed regex to include action group parameter references
fixed test generator to make full word replacement of stepKey references

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests