### PR TITLE
Add possibility to include multiple non primitive types in an array

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
@@ -9,6 +9,7 @@ use AspectMock\Test as AspectMock;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\OperationDefinitionObjectHandler;
 use Magento\FunctionalTestingFramework\DataGenerator\Persist\OperationDataArrayResolver;
+use Magento\FunctionalTestingFramework\Util\Iterator\AbstractIterator;
 use Magento\FunctionalTestingFramework\Util\MagentoTestCase;
 use tests\unit\Util\EntityDataObjectBuilder;
 use tests\unit\Util\OperationDefinitionBuilder;
@@ -353,6 +354,123 @@ class OperationDataArrayResolverTest extends MagentoTestCase
 
         // Do assert on result here
         $this->assertEquals(self::NESTED_METADATA_ARRAY_RESULT, $result);
+    }
+
+    public function testNestedMetadataArrayOfDiverseObjects() {
+
+        $entityDataObjBuilder = new EntityDataObjectBuilder();
+        $parentDataObject = $entityDataObjBuilder
+            ->withName("parentObject")
+            ->withType("parentType")
+            ->withLinkedEntities(['child1Object' => 'childType1','child2Object' => 'childType2'])
+            ->build();
+
+
+        $child1DataObject = $entityDataObjBuilder
+            ->withName('child1Object')
+            ->withType('childType1')
+            ->withDataFields(['city' => 'Testcity','zip' => 12345])
+            ->build();
+
+        $child2DataObject = $entityDataObjBuilder
+            ->withName('child2Object')
+            ->withType('childType2')
+            ->withDataFields(['city' => 'Testcity 2','zip' => 54321,'state' => 'Teststate'])
+            ->build();
+
+        $mockDOHInstance = AspectMock::double(DataObjectHandler::class,
+            [
+                'getObject' => function ($name) use ($child1DataObject, $child2DataObject) {
+            switch ($name) {
+                case 'child1Object':
+                    return $child1DataObject;
+                case 'child2Object':
+                    return $child2DataObject;
+            }
+                }
+            ])->make();
+        AspectMock::double(DataObjectHandler::class,[
+            'getInstance' => $mockDOHInstance
+        ]);
+
+        $operationDefinitionBuilder = new OperationDefinitionBuilder();
+        $child1OperationDefinition = $operationDefinitionBuilder
+            ->withName('createchildType1')
+            ->withOperation('create')
+            ->withType('childType1')
+            ->withMetadata([
+                'city' => 'string',
+                'zip' => 'integer'
+            ])->build();
+
+        $child2OperationDefinition = $operationDefinitionBuilder
+            ->withName('createchildType2')
+            ->withOperation('create')
+            ->withType('childType2')
+            ->withMetadata([
+                'city' => 'string',
+                'zip' => 'integer',
+                'state' => 'string'
+            ])->build();
+
+        $mockODOHInstance = AspectMock::double(
+            OperationDefinitionObjectHandler::class,
+            [
+                'getObject' => function($name) use ($child1OperationDefinition, $child2OperationDefinition) {
+                    switch ($name) {
+                        case 'createchildType1':
+                            return $child1OperationDefinition;
+                        case 'createchildType2':
+                            return $child2OperationDefinition;
+                    }
+                }
+            ]
+            )->make();
+        AspectMock::double(OperationDefinitionObjectHandler::class,
+            [
+                'getInstance' => $mockODOHInstance
+            ]);
+
+        $arrayObElementBuilder = new OperationElementBuilder();
+        $arrayElement = $arrayObElementBuilder
+            ->withKey('address')
+            ->withType(['childType1','childType2'])
+            ->withFields([])
+            ->withElementType(OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY)
+            //->withNestedElements(['childType1' => $child1Element, 'childType2' => $child2Element])
+            ->build();
+
+        $parentOpElementBuilder = new OperationElementBuilder();
+        $parentElement = $parentOpElementBuilder
+            ->withKey('parentType')
+            ->withType('parentType')
+            ->addElements(['address' => $arrayElement])
+            ->build();
+
+        $operationResolver = new OperationDataArrayResolver();
+        $result = $operationResolver->resolveOperationDataArray($parentDataObject,[$parentElement],'create',false);
+
+        $expectedResult = [
+            'parentType' => [
+                'address' => [
+                    [
+                        'city' => 'Testcity',
+                        'zip' => '12345'
+                    ],
+                    [
+                        'city' => 'Testcity 2',
+                        'zip' => '54321',
+                        'state' => 'Teststate'
+                    ]
+                ],
+                'name' => 'Hopper',
+                'gpa' => '3.5678',
+                'phone' => '5555555',
+                'isPrimary' => '1'
+            ]
+        ];
+
+        $this->assertEquals($expectedResult, $result);
     }
 
     /**

--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
@@ -356,7 +356,8 @@ class OperationDataArrayResolverTest extends MagentoTestCase
         $this->assertEquals(self::NESTED_METADATA_ARRAY_RESULT, $result);
     }
 
-    public function testNestedMetadataArrayOfDiverseObjects() {
+    public function testNestedMetadataArrayOfDiverseObjects()
+    {
 
         $entityDataObjBuilder = new EntityDataObjectBuilder();
         $parentDataObject = $entityDataObjBuilder
@@ -364,7 +365,6 @@ class OperationDataArrayResolverTest extends MagentoTestCase
             ->withType("parentType")
             ->withLinkedEntities(['child1Object' => 'childType1','child2Object' => 'childType2'])
             ->build();
-
 
         $child1DataObject = $entityDataObjBuilder
             ->withName('child1Object')
@@ -378,18 +378,20 @@ class OperationDataArrayResolverTest extends MagentoTestCase
             ->withDataFields(['city' => 'Testcity 2','zip' => 54321,'state' => 'Teststate'])
             ->build();
 
-        $mockDOHInstance = AspectMock::double(DataObjectHandler::class,
+        $mockDOHInstance = AspectMock::double(
+            DataObjectHandler::class,
             [
                 'getObject' => function ($name) use ($child1DataObject, $child2DataObject) {
-            switch ($name) {
-                case 'child1Object':
-                    return $child1DataObject;
-                case 'child2Object':
-                    return $child2DataObject;
-            }
+                    switch ($name) {
+                        case 'child1Object':
+                            return $child1DataObject;
+                        case 'child2Object':
+                            return $child2DataObject;
+                    }
                 }
-            ])->make();
-        AspectMock::double(DataObjectHandler::class,[
+            ]
+        )->make();
+        AspectMock::double(DataObjectHandler::class, [
             'getInstance' => $mockDOHInstance
         ]);
 
@@ -416,7 +418,7 @@ class OperationDataArrayResolverTest extends MagentoTestCase
         $mockODOHInstance = AspectMock::double(
             OperationDefinitionObjectHandler::class,
             [
-                'getObject' => function($name) use ($child1OperationDefinition, $child2OperationDefinition) {
+                'getObject' => function ($name) use ($child1OperationDefinition, $child2OperationDefinition) {
                     switch ($name) {
                         case 'createchildType1':
                             return $child1OperationDefinition;
@@ -425,11 +427,13 @@ class OperationDataArrayResolverTest extends MagentoTestCase
                     }
                 }
             ]
-            )->make();
-        AspectMock::double(OperationDefinitionObjectHandler::class,
+        )->make();
+        AspectMock::double(
+            OperationDefinitionObjectHandler::class,
             [
                 'getInstance' => $mockODOHInstance
-            ]);
+            ]
+        );
 
         $arrayObElementBuilder = new OperationElementBuilder();
         $arrayElement = $arrayObElementBuilder
@@ -448,7 +452,7 @@ class OperationDataArrayResolverTest extends MagentoTestCase
             ->build();
 
         $operationResolver = new OperationDataArrayResolver();
-        $result = $operationResolver->resolveOperationDataArray($parentDataObject,[$parentElement],'create',false);
+        $result = $operationResolver->resolveOperationDataArray($parentDataObject, [$parentElement], 'create', false);
 
         $expectedResult = [
             'parentType' => [

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
@@ -109,7 +109,7 @@ class OperationDataArrayResolver
                     $operationElementType,
                     $operationDataArray
                 );
-            } else if (is_array($operationElementType)) {
+            } elseif (is_array($operationElementType)) {
                 foreach ($operationElementType as $currentElementType) {
                     if (in_array($currentElementType, self::PRIMITIVE_TYPES)) {
                         $this->resolvePrimitiveReferenceElement(
@@ -256,7 +256,8 @@ class OperationDataArrayResolver
         $linkedEntityObj = $this->resolveLinkedEntityObject($entityName);
 
         // in array case
-        if (!is_array($operationElement->getValue()) && !empty($operationElement->getNestedOperationElement($operationElement->getValue()))
+        if (!is_array($operationElement->getValue())
+            && !empty($operationElement->getNestedOperationElement($operationElement->getValue()))
             && $operationElement->getType() == OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY
         ) {
             $operationSubArray = $this->resolveOperationDataArray(

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
@@ -109,6 +109,26 @@ class OperationDataArrayResolver
                     $operationElementType,
                     $operationDataArray
                 );
+            } else if (is_array($operationElementType)) {
+                foreach ($operationElementType as $currentElementType) {
+                    if (in_array($currentElementType, self::PRIMITIVE_TYPES)) {
+                        $this->resolvePrimitiveReferenceElement(
+                            $entityObject,
+                            $operationElement,
+                            $currentElementType,
+                            $operationDataArray
+                        );
+                    } else {
+                        $this->resolveNonPrimitiveReferenceElement(
+                            $entityObject,
+                            $operation,
+                            $fromArray,
+                            $currentElementType,
+                            $operationElement,
+                            $operationDataArray
+                        );
+                    }
+                }
             } else {
                 $this->resolveNonPrimitiveReferenceElement(
                     $entityObject,
@@ -236,7 +256,7 @@ class OperationDataArrayResolver
         $linkedEntityObj = $this->resolveLinkedEntityObject($entityName);
 
         // in array case
-        if (!empty($operationElement->getNestedOperationElement($operationElement->getValue()))
+        if (!is_array($operationElement->getValue()) && !empty($operationElement->getNestedOperationElement($operationElement->getValue()))
             && $operationElement->getType() == OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY
         ) {
             $operationSubArray = $this->resolveOperationDataArray(

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Util/OperationElementExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Util/OperationElementExtractor.php
@@ -114,7 +114,9 @@ class OperationElementExtractor
         foreach ($operationArrayArray as $operationFieldType) {
             $operationElementValue = [];
             if (isset($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE])) {
-                foreach ($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE] as $operationFieldValue) {
+                foreach ($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE]
+                         as $operationFieldValue
+                ) {
                     $operationElementValue[] = $operationFieldValue[OperationElementExtractor::OPERATION_OBJECT_ARRAY_VALUE] ?? null;
                 }
             }

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Util/OperationElementExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Util/OperationElementExtractor.php
@@ -114,10 +114,10 @@ class OperationElementExtractor
         foreach ($operationArrayArray as $operationFieldType) {
             $operationElementValue = [];
             if (isset($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE])) {
-                foreach ($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE]
-                         as $operationFieldValue
-                ) {
-                    $operationElementValue[] = $operationFieldValue[OperationElementExtractor::OPERATION_OBJECT_ARRAY_VALUE] ?? null;
+                foreach ($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE] as
+                    $operationFieldValue) {
+                    $operationElementValue[] =
+                        $operationFieldValue[OperationElementExtractor::OPERATION_OBJECT_ARRAY_VALUE] ?? null;
                 }
             }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Util/OperationElementExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Util/OperationElementExtractor.php
@@ -112,9 +112,16 @@ class OperationElementExtractor
     private function extractOperationArray(&$operationArrayData, $operationArrayArray)
     {
         foreach ($operationArrayArray as $operationFieldType) {
-            $operationElementValue =
-                $operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE][0]
-                [OperationElementExtractor::OPERATION_OBJECT_ARRAY_VALUE] ?? null;
+            $operationElementValue = [];
+            if (isset($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE])) {
+                foreach ($operationFieldType[OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY_VALUE] as $operationFieldValue) {
+                    $operationElementValue[] = $operationFieldValue[OperationElementExtractor::OPERATION_OBJECT_ARRAY_VALUE] ?? null;
+                }
+            }
+
+            if (count($operationElementValue) === 1) {
+                $operationElementValue = array_pop($operationElementValue);
+            }
 
             $nestedOperationElements = [];
             if (array_key_exists(OperationElementExtractor::OPERATION_OBJECT_OBJ_NAME, $operationFieldType)) {


### PR DESCRIPTION


<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

If an array is defined for an entity it is currently not possible to
include different types of non primitive types in the same array.

E.g. it is not possible to add a product, whose "custom_attributes" field
should contain attributes that have a primitive type (e.g. url_key) and an
array type (e.g. category_ids)

This PR adds the ability to define multiple non primitive types for an array
type.

The definition of the CreateProduct request in 
magento-catalog/Test/Mftf/Metadata/product-meta.xml could be changed to

```xml
<array key="custom_attributes">
  <value>custom_attribute_array</value>
  <value>custom_attribute</value>
</array>
```

<!--- Provide a description of the changes proposed in the pull request -->

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests