### PR TITLE
MQE-1514: Failure For seeCurrentUrlEquals Action Does Not Show Actual & Expected Results in Allure

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -9,6 +9,7 @@ namespace Magento\FunctionalTestingFramework\Module;
 use Codeception\Module\WebDriver;
 use Codeception\Test\Descriptor;
 use Codeception\TestInterface;
+use Yandex\Allure\Adapter\Allure;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Codeception\Exception\ModuleConfigException;
 use Codeception\Exception\ModuleException;
@@ -18,6 +19,8 @@ use Magento\FunctionalTestingFramework\DataGenerator\Persist\Curl\WebapiExecutor
 use Magento\FunctionalTestingFramework\Util\Protocol\CurlTransport;
 use Magento\FunctionalTestingFramework\Util\Protocol\CurlInterface;
 use Magento\FunctionalTestingFramework\Util\ConfigSanitizerUtil;
+use Yandex\Allure\Adapter\Event\AddAttachmentEvent;
+use Yandex\Allure\Adapter\Event\AddParameterEvent;
 use Yandex\Allure\Adapter\Support\AttachmentSupport;
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 
@@ -198,7 +201,10 @@ class MagentoWebDriver extends WebDriver
      */
     public function dontSeeCurrentUrlEquals($url)
     {
-        $this->assertNotEquals($url, $this->webDriver->getCurrentURL());
+        $actualUrl = $this->webDriver->getCurrentURL();
+        $comparison = "Expected: $url\nActual: $actualUrl";
+        Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
+        $this->assertNotEquals($url, $actualUrl);
     }
 
     /**
@@ -209,7 +215,10 @@ class MagentoWebDriver extends WebDriver
      */
     public function dontSeeCurrentUrlMatches($regex)
     {
-        $this->assertNotRegExp($regex, $this->webDriver->getCurrentURL());
+        $actualUrl = $this->webDriver->getCurrentURL();
+        $comparison = "Expected: $regex\nActual: $actualUrl";
+        Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
+        $this->assertNotRegExp($regex, $actualUrl);
     }
 
     /**
@@ -220,7 +229,10 @@ class MagentoWebDriver extends WebDriver
      */
     public function dontSeeInCurrentUrl($needle)
     {
-        $this->assertNotContains($needle, $this->webDriver->getCurrentURL());
+        $actualUrl = $this->webDriver->getCurrentURL();
+        $comparison = "Expected: $needle\nActual: $actualUrl";
+        Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
+        $this->assertNotContains($needle, $actualUrl);
     }
 
     /**
@@ -254,7 +266,10 @@ class MagentoWebDriver extends WebDriver
      */
     public function seeCurrentUrlEquals($url)
     {
-        $this->assertEquals($url, $this->webDriver->getCurrentURL());
+        $actualUrl = $this->webDriver->getCurrentURL();
+        $comparison = "Expected: $url\nActual: $actualUrl";
+        Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
+        $this->assertEquals($url, $actualUrl);
     }
 
     /**
@@ -265,7 +280,10 @@ class MagentoWebDriver extends WebDriver
      */
     public function seeCurrentUrlMatches($regex)
     {
-        $this->assertRegExp($regex, $this->webDriver->getCurrentURL());
+        $actualUrl = $this->webDriver->getCurrentURL();
+        $comparison = "Expected: $regex\nActual: $actualUrl";
+        Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
+        $this->assertRegExp($regex, $url);
     }
 
     /**
@@ -276,7 +294,10 @@ class MagentoWebDriver extends WebDriver
      */
     public function seeInCurrentUrl($needle)
     {
-        $this->assertContains($needle, $this->webDriver->getCurrentURL());
+        $actualUrl = $this->webDriver->getCurrentURL();
+        $comparison = "Expected: $needle\nActual: $actualUrl";
+        Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
+        $this->assertContains($needle, $actualUrl);
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -283,7 +283,7 @@ class MagentoWebDriver extends WebDriver
         $actualUrl = $this->webDriver->getCurrentURL();
         $comparison = "Expected: $regex\nActual: $actualUrl";
         Allure::lifecycle()->fire(new AddAttachmentEvent($comparison, 'Comparison'));
-        $this->assertRegExp($regex, $url);
+        $this->assertRegExp($regex, $actualUrl);
     }
 
     /**


### PR DESCRIPTION
## Description
* Attachment now added in MagentoWebDriver

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests