### PR TITLE
Removed breaking "\r\n" instances from command.

### DIFF
--- a/docs/commands/mftf.md
+++ b/docs/commands/mftf.md
@@ -173,7 +173,7 @@ Complex configuration to generate a few non-suite tests, a single test in a suit
 The command that encodes this complex configuration:
 
 ```bash
-vendor/bin/mftf generate:tests --tests "{"tests\":["general_test1\","general_test2\","general_test3\"],"suites\":{"sample\":["suite_test1\"],"sample2\":null}}"
+vendor/bin/mftf generate:tests --tests "{\"tests\":[\"general_test1\",\"general_test2\",\"general_test3\"],\"suites\":{\"sample\":[\"suite_test1\"],\"sample2\":null}}"
 ```
 
 Note that the strings must be escaped and surrounded in quotes.

--- a/docs/commands/mftf.md
+++ b/docs/commands/mftf.md
@@ -173,7 +173,7 @@ Complex configuration to generate a few non-suite tests, a single test in a suit
 The command that encodes this complex configuration:
 
 ```bash
-vendor/bin/mftf generate:tests --tests "{\"tests\":[\"general_test1\",\"general_test2\",\"general_test3\"],\"suites\":{\"sample\":[\"suite_test1\"],\"sample2\":null}}"
+vendor/bin/mftf generate:tests --tests '{"tests":["general_test1","general_test2","general_test3"],"suites":{"sample":["suite_test1"],"sample2":null}}'
 ```
 
 Note that the strings must be escaped and surrounded in quotes.

--- a/docs/commands/mftf.md
+++ b/docs/commands/mftf.md
@@ -173,7 +173,7 @@ Complex configuration to generate a few non-suite tests, a single test in a suit
 The command that encodes this complex configuration:
 
 ```bash
-vendor/bin/mftf generate:tests --tests "{\r\n\"tests\":[\r\n\"general_test1\",\r\n\"general_test2\",\r\n\"general_test3\"\r\n],\r\n\"suites\":{\r\n\"sample\":[\r\n\"suite_test1\"\r\n],\r\n\"sample2\":null\r\n}\r\n}"
+vendor/bin/mftf generate:tests --tests "{"tests\":["general_test1\","general_test2\","general_test3\"],"suites\":{"sample\":["suite_test1\"],"sample2\":null}}"
 ```
 
 Note that the strings must be escaped and surrounded in quotes.


### PR DESCRIPTION
### Description
Cleans up a command that had errant "\r\n" that would break the command if copy/pasted.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests