### PR TITLE
MQE-1763: Investigate and fix failure due to absence of AcceptanceTester class

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,39 +61,5 @@ Use of PhantomJS is not supported by the MFTF.
 
 For headless browsing, the [Headless Chrome][]{:target="\_blank"} has better compatibility with the MFTF.
 
-### Chrome
-
-You are seeing an "unhandled inspector error" exception:
-
-```terminal
-[Facebook\WebDriver\Exception\UnknownServerException]
-unknown error: undhandled inspector error: {"code":-32601, "message":
-"'Network.deleteCookie' wasn't found"} ....
-```
-
-![Screenshot with the exception](./img/trouble-chrome232.png)
-
-#### Reason
-
-Chrome v62 is in the process of being rolled out, and it causes an error with ChromeDriver v2.32+.
-
-#### Solution
-
-Use [ChromeDriver 74.0.3729.6+][]{:target="\_blank"} and [Selenium Server Standalone v3.9+][]{:target="\_blank"} in order to execute tests in Google Chrome v62+.
-
-### Firefox
-
-Tests that use the `moveMouseOver` action cause an error when run locally.
-
-#### Reason
-
-There is a compatibility issue with Codeception's `moveMouseOver` function and GeckoDriver with Firefox.
-
-#### Solution
-
-None yet. Solving this problem is dependent on a GeckoDriver fix.
-
 <!-- Link Definitions -->
 [Headless Chrome]: https://developers.google.com/web/updates/2017/04/headless-chrome
-[ChromeDriver 74.0.3729.6+]: https://chromedriver.storage.googleapis.com/index.html?path=2.33/
-[Selenium Server Standalone v3.9+]: http://www.seleniumhq.org/download/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,40 @@
 
 Having a little trouble with the MFTF? See some common errors and fixes below.
 
+## AcceptanceTester class issues
+
+If you see the following error:
+
+```terminal
+AcceptanceTester class doesn't exist in suite folder.
+Run the 'build' command to generate it
+```
+
+#### Reason
+
+Something went wrong during the `mftf build:project` command that prevented the creation of the AcceptanceTester class.
+
+#### Solution
+
+This issue is fixed in MFTF 2.5.0.
+
+In versions of MFTF lower than 2.5.0 you should:
+
+1. Open the functional.suite.yml file at:
+    ```terminal
+    <magento root directory>/dev/tests/acceptance/tests/functional.suite.yml
+    ```
+2. Add quotation marks (`"`) around these values:
+    1. `%SELENIUM_HOST%`
+    2. `%SELENIUM_PORT%`
+    3. `%SELENIUM_PROTOCOL%`
+    4. `%SELENIUM_PATH%`
+3. Run the `vendor/bin/mftf build:project` command again.
+4. You should see the AcceptanceTester class is created at:
+    ```terminal
+   <magento root directory>/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/AcceptanceTester.php
+    ```
+
 ## WebDriver issues
 
 Troubleshoot your WebDriver issues on various browsers.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,30 +11,34 @@ AcceptanceTester class doesn't exist in suite folder.
 Run the 'build' command to generate it
 ```
 
-#### Reason
+### Reason
 
 Something went wrong during the `mftf build:project` command that prevented the creation of the AcceptanceTester class.
 
-#### Solution
+### Solution
 
-This issue is fixed in MFTF 2.5.0.
+This issue is fixed in the MFTF 2.5.0.
 
-In versions of MFTF lower than 2.5.0 you should:
+In versions of the MFTF lower than 2.5.0 you should:
 
 1. Open the functional.suite.yml file at:
-    ```terminal
-    <magento root directory>/dev/tests/acceptance/tests/functional.suite.yml
-    ```
-2. Add quotation marks (`"`) around these values:
+
+   ```terminal
+   <magento root directory>/dev/tests/acceptance/tests/functional.suite.yml
+   ```
+1. Add quotation marks (`"`) around these values:
+
     1. `%SELENIUM_HOST%`
-    2. `%SELENIUM_PORT%`
-    3. `%SELENIUM_PROTOCOL%`
-    4. `%SELENIUM_PATH%`
-3. Run the `vendor/bin/mftf build:project` command again.
-4. You should see the AcceptanceTester class is created at:
-    ```terminal
+    1. `%SELENIUM_PORT%`
+    1. `%SELENIUM_PROTOCOL%`
+    1. `%SELENIUM_PATH%`
+    
+1. Run the `vendor/bin/mftf build:project` command again.
+1. You should see the AcceptanceTester class is created at:
+
+   ```terminal
    <magento root directory>/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/AcceptanceTester.php
-    ```
+   ```
 
 ## WebDriver issues
 
@@ -51,7 +55,7 @@ No active session with ID e56f9260-b366-11e7-966b-db3e6f35d8e1
 
 #### Reason
 
-Use of PhantomJS is not actually supported by the MFTF.
+Use of PhantomJS is not supported by the MFTF.
 
 #### Solution
 
@@ -83,7 +87,7 @@ Tests that use the `moveMouseOver` action cause an error when run locally.
 
 #### Reason
 
-There's a compatibility issue with Codeception's `moveMouseOver` function and GeckoDriver with Firefox.
+There is a compatibility issue with Codeception's `moveMouseOver` function and GeckoDriver with Firefox.
 
 #### Solution
 

--- a/src/Magento/FunctionalTestingFramework/Console/BuildProjectCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/BuildProjectCommand.php
@@ -102,7 +102,9 @@ class BuildProjectCommand extends Command
         );
 
         if ($codeceptReturnCode !== 0) {
-            throw new TestFrameworkException("The codecept build command failed unexpectedly. Please see the above output for more details.");
+            throw new TestFrameworkException(
+                "The codecept build command failed unexpectedly. Please see the above output for more details."
+            );
         }
 
         if ($input->getOption('upgrade')) {

--- a/src/Magento/FunctionalTestingFramework/Console/BuildProjectCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/BuildProjectCommand.php
@@ -7,6 +7,7 @@ declare(strict_types = 1);
 
 namespace Magento\FunctionalTestingFramework\Console;
 
+use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -94,13 +95,15 @@ class BuildProjectCommand extends Command
         $process->setWorkingDirectory(TESTS_BP);
         $process->setIdleTimeout(600);
         $process->setTimeout(0);
-        $process->run(
+        $codeceptReturnCode = $process->run(
             function ($type, $buffer) use ($output) {
-                if ($output->isVerbose()) {
-                    $output->write($buffer);
-                }
+                $output->write($buffer);
             }
         );
+
+        if ($codeceptReturnCode !== 0) {
+            throw new TestFrameworkException("The codecept build command failed unexpectedly. Please see the above output for more details.");
+        }
 
         if ($input->getOption('upgrade')) {
             $upgradeCommand = new UpgradeTestsCommand();
@@ -133,9 +136,7 @@ class BuildProjectCommand extends Command
             $output->writeln("codeception.yml configuration successfully applied.");
         }
 
-        if ($output->isVerbose()) {
-            $output->writeln("codeception.yml applied to " . TESTS_BP . DIRECTORY_SEPARATOR . 'codeception.yml');
-        }
+        $output->writeln("codeception.yml applied to " . TESTS_BP . DIRECTORY_SEPARATOR . 'codeception.yml');
 
         // copy the functional suite yml, will only copy if there are differences between the template the destination
         $fileSystem->copy(
@@ -144,10 +145,8 @@ class BuildProjectCommand extends Command
         );
         $output->writeln('functional.suite.yml configuration successfully applied.');
 
-        if ($output->isVerbose()) {
-            $output->writeln("functional.suite.yml applied to " .
-                TESTS_BP . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'functional.suite.yml');
-        }
+        $output->writeln("functional.suite.yml applied to " .
+            TESTS_BP . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'functional.suite.yml');
 
         $fileSystem->copy(
             FW_BP . '/etc/config/.credentials.example',


### PR DESCRIPTION
### Description
This bug was reproducible on branches that had updated the `symfony/yaml` package in composer from v3.4.30 to v4.3.4. The updated package was less forgiving about our functional.suite.yml file which did not properly quote string values in some cases.

This PR only exists to ensure that in the future we get better output from the `mftf build:project` command. This output was hidden in the Jenkins job because the `--verbose` flag was not used. If we had that output in Jenkins, then this bug would have been trivial to identify.

I also added troubleshooting steps to devdocs for users on versions lower than MFTF 2.5.0.

TLDR: No bug here. I increased output from `mftf build:project` and wrote some docs.

### Fixed Issues (if relevant)
1. https://jira.corp.magento.com/browse/MQE-1763

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests