### PR TITLE
MFTF 2.5.1 Release Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Magento Functional Testing Framework Changelog
 ================================================
 
+2.5.1
+-----
+
+### Fixes
+* Fixed missing `use` statement in the generate:suite command
+
+### GitHub Issues
+* [#471](https://github.com/magento/magento2-functional-testing-framework/issues/471) -- PHP Fatal error: MftfApplicationConfig not found in GenerateSuiteCommand
+
 2.5.0
 -----
 * Traceability

--- a/bin/mftf
+++ b/bin/mftf
@@ -29,7 +29,7 @@ try {
 try {
     $application = new Symfony\Component\Console\Application();
     $application->setName('Magento Functional Testing Framework CLI');
-    $application->setVersion('2.5.0');
+    $application->setVersion('2.5.1');
     /** @var \Magento\FunctionalTestingFramework\Console\CommandListInterface $commandList */
     $commandList = new \Magento\FunctionalTestingFramework\Console\CommandList;
     foreach ($commandList->getCommands() as $command) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/magento2-functional-testing-framework",
     "description": "Magento2 Functional Testing Framework",
     "type": "library",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": "AGPL-3.0",
     "keywords": ["magento", "automation", "functional", "testing"],
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01cbd9e237e76de7070a3c0de4ee8b9f",
+    "content-hash": "eed8abcb8179f4cf41aa0780ea5d9f8e",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",
@@ -250,7 +250,7 @@
                 {
                     "name": "Tobias Nyholm",
                     "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
+                    "homepage": "https://github.com/nyholm"
                 }
             ],
             "description": "Library of all the php-cache adapters",

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateSuiteCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateSuiteCommand.php
@@ -7,6 +7,7 @@ declare(strict_types = 1);
 
 namespace Magento\FunctionalTestingFramework\Console;
 
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Suite\SuiteGenerator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
### Description
This is a small hotfix to fix the broken `generate:suite` command that was missing a `use` statement.

### Fixed Issues (if relevant)
-  [MQE-1816](https://jira.corp.magento.com/browse/MQE-1816) Fix missing MftfApplicationConfig import in GenerateSuiteCommand

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests