### PR TITLE
fixed static checks command name

### DIFF
--- a/docs/commands/mftf.md
+++ b/docs/commands/mftf.md
@@ -429,9 +429,9 @@ vendor/bin/mftf setup:env
 
 The example parameters are taken from the `etc/config/.env.example` file.
 
-### `static:checks`
+### `static-checks`
 
-Runs all MFTF static:checks on the test codebase that MFTF is currently attached to.
+Runs all MFTF static-checks on the test codebase that MFTF is currently attached to.
 
 #### Existing static checks
 
@@ -440,7 +440,7 @@ Runs all MFTF static:checks on the test codebase that MFTF is currently attached
 #### Usage
 
 ```bash
-vendor/bin/mftf static:checks
+vendor/bin/mftf static-checks
 ```
 
 ### `upgrade:tests`


### PR DESCRIPTION
### Description
Fixes the command name of static checks`. See https://github.com/magento/magento2-functional-testing-framework/blob/5a4909cc0de0ca9d201709a6e07aabe13e8610e5/src/Magento/FunctionalTestingFramework/Console/StaticChecksCommand.php#L35

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [X] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests