### PR TITLE
#339 Add information about web server configuration

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,8 @@
 
 <div class="bs-callout bs-callout-info" markdown="1">
 [Find your MFTF version][] of the MFTF.
-The latest Magento 2.3 release supports MFTF 2.3.13.
-The latest Magento 2.2 release supports MFTF 2.3.8.
+The latest Magento 2.3.x release supports MFTF 2.4.5.
+The latest Magento 2.2.x release supports MFTF 2.4.5.
 </div>
 
 ## Prepare environment  {#prepare-environment}
@@ -18,6 +18,7 @@ Make sure that you have the following software installed and configured on your 
 <div class="bs-callout bs-callout-tip" markdown="1">
 [PhpStorm] supports [Codeception test execution][], which is helpful when debugging.
 </div>
+
 ## Install Magento {#install-magento}
 
 Use instructions below to install Magento.
@@ -81,7 +82,8 @@ To enable the **Admin Account Sharing** setting, to avoid unpredictable logout d
 4. Click **Save Config**.
 
 ### Webserver configuration {#web-server-configuration}
-The MFTF doesn't support executing CLI commands if your web server points to `<MAGE_ROOT_DIR>/pub` directory as recommended in the [Installation Guide][Installation Guide docroot]. For the MFTF to execute the CLI commands, the web server must point to the Magento root directory.
+
+The MFTF does not support executing CLI commands if your web server points to `<MAGE_ROOT_DIR>/pub` directory as recommended in the [Installation Guide][Installation Guide docroot]. For the MFTF to execute the CLI commands, the web server must point to the Magento root directory.
 
 #### Nginx settings {#nginx-settings}
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,10 @@ To enable the **Admin Account Sharing** setting, to avoid unpredictable logout d
 3. Set **Add Secret Key to URLs** to **No**.
 4. Click **Save Config**.
 
-### Nginx settings {#nginx-settings}
+### Webserver configuration {#web-server-configuration}
+The MFTF doesn't support executing CLI commands if your web server points to `<MAGE_ROOT_DIR>/pub` directory as recommended in the [Installation Guide][Installation Guide docroot]. For the MFTF to execute the CLI commands, the web server must point to the Magento root directory.
+
+#### Nginx settings {#nginx-settings}
 
 If Nginx Web server is used on your development environment then **Use Web Server Rewrites** setting in **Stores** > Settings > **Configuration** > **Web** > **Search Engine Optimization** must be set to **Yes**.
 
@@ -323,3 +326,4 @@ allure serve dev/tests/_output/allure-results/
 [Set up a standalone MFTF]: #set-up-a-standalone-mftf
 [test suite]: suite.html
 [Find your MFTF version]: introduction.html#find-your-mftf-version
+[Installation Guide docroot]: https://devdocs.magento.com/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.html


### PR DESCRIPTION
### Description
As mentioned in #339 the MFTF doesn't support executing CLI command if the web server points to `<MAGE_ROOT_DIR>/pub` as recommended in the [DevDocs](https://devdocs.magento.com/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.html). I added information about it in the docs. It is not mentioned currently and might save other developers some time figuring it out (it would've saved me some time).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests