### PR TITLE
MQE-1644: Add ability to see JS log in Allure 

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Extension/BrowserLogUtilTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Extension/BrowserLogUtilTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace tests\unit\Magento\FunctionalTestFramework\Extension;
+
+use Magento\FunctionalTestingFramework\Util\MagentoTestCase;
+use Magento\FunctionalTestingFramework\Extension\BrowserLogUtil;
+
+class BrowserLogUtilTest extends MagentoTestCase
+{
+    public function testGetLogsOfType()
+    {
+        $entryOne = [
+            "level" => "WARNING",
+            "message" => "warningMessage",
+            "source" => "console-api",
+            "timestamp" => 1234567890
+        ];
+        $entryTwo = [
+            "level" => "ERROR",
+            "message" => "errorMessage",
+            "source" => "other",
+            "timestamp" => 1234567890
+        ];
+        $entryThree = [
+            "level" => "LOG",
+            "message" => "logMessage",
+            "source" => "javascript",
+            "timestamp" => 1234567890
+        ];
+        $log = [
+            $entryOne,
+            $entryTwo,
+            $entryThree
+        ];
+
+        $actual = BrowserLogUtil::getLogsOfType($log, 'console-api');
+
+        self::assertEquals($entryOne, $actual[0]);
+    }
+
+    public function testFilterLogsOfType()
+    {
+        $entryOne = [
+            "level" => "WARNING",
+            "message" => "warningMessage",
+            "source" => "console-api",
+            "timestamp" => 1234567890
+        ];
+        $entryTwo = [
+            "level" => "ERROR",
+            "message" => "errorMessage",
+            "source" => "other",
+            "timestamp" => 1234567890
+        ];
+        $entryThree = [
+            "level" => "LOG",
+            "message" => "logMessage",
+            "source" => "javascript",
+            "timestamp" => 1234567890
+        ];
+        $log = [
+            $entryOne,
+            $entryTwo,
+            $entryThree
+        ];
+
+        $actual = BrowserLogUtil::filterLogsOfType($log, 'console-api');
+
+        self::assertEquals($entryTwo, $actual[0]);
+        self::assertEquals($entryThree, $actual[1]);
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,6 +277,24 @@ Example:
 CREDENTIAL_VAULT_SECRET_BASE_PATH=secret
 ```
 
+### ENABLE_BROWSER_LOG
+
+Enables addition of browser logs to Allure steps
+
+```conf
+ENABLE_BROWSER_LOG=true
+```
+
+### BROWSER_LOG_BLACKLIST
+
+Blacklists types of browser log entries from appearing in Allure steps.
+
+Denoted in browser log entry as `"SOURCE": "type"`.
+
+```conf
+BROWSER_LOG_BLACKLIST=other,console-api
+```
+
 <!-- Link definitions -->
 
 [`MAGENTO_CLI_COMMAND_PATH`]: #magento_cli_command_path

--- a/etc/config/.env.example
+++ b/etc/config/.env.example
@@ -54,4 +54,9 @@ MODULE_WHITELIST=Magento_Framework,ConfigurableProductWishlist,ConfigurableProdu
 
 #*** Default timeout for wait actions
 #WAIT_TIMEOUT=10
+
+#*** Uncomment and set to enable browser log entries on actions in Allure. Blacklist is used to filter logs of a specific "source"
+#ENABLE_BROWSER_LOG=true
+#BROWSER_LOG_BLACKLIST=other
+
 #*** End of .env ***#

--- a/src/Magento/FunctionalTestingFramework/Extension/BrowserLogUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/BrowserLogUtil.php
@@ -16,23 +16,20 @@ class BrowserLogUtil
     const ERROR_TYPE_JAVASCRIPT = "javascript";
 
     /**
-     * Loops through stepEvent for browser log entries
+     * Loops throw errors in log and logs them to allure. Uses Module to set the error itself
      *
-     * @param \Magento\FunctionalTestingFramework\Module\MagentoWebDriver $module
-     * @param \Codeception\Event\StepEvent                                $stepEvent
+     * @param array                         $log
+     * @param \Codeception\Module\WebDriver $module
+     * @param \Codeception\Event\StepEvent  $stepEvent
      * @return void
      */
-    public static function logErrors($module, $stepEvent)
+    public static function logErrors($log, $module, $stepEvent)
     {
-        //Types available should be "server", "browser", "driver". Only care about browser at the moment.
-        if (in_array(self::LOG_TYPE_BROWSER, $module->webDriver->manage()->getAvailableLogTypes())) {
-            $browserLogEntries = $module->webDriver->manage()->getLog(self::LOG_TYPE_BROWSER);
-            $jsErrors = self::getLogsOfType($browserLogEntries, self::ERROR_TYPE_JAVASCRIPT);
-            foreach ($jsErrors as $entry) {
-                self::logError(self::ERROR_TYPE_JAVASCRIPT, $stepEvent, $entry);
-                //Set javascript error in MagentoWebDriver internal array
-                $module->setJsError("ERROR({$entry["level"]}) - " . $entry["message"]);
-            }
+        $jsErrors = self::getLogsOfType($log, self::ERROR_TYPE_JAVASCRIPT);
+        foreach ($jsErrors as $entry) {
+            self::logError(self::ERROR_TYPE_JAVASCRIPT, $stepEvent, $entry);
+            //Set javascript error in MagentoWebDriver internal array
+            $module->setJsError("ERROR({$entry["level"]}) - " . $entry["message"]);
         }
     }
 

--- a/src/Magento/FunctionalTestingFramework/Extension/BrowserLogUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/BrowserLogUtil.php
@@ -39,7 +39,7 @@ class BrowserLogUtil
     /**
      * Loops through given log and returns entries of the given type.
      *
-     * @param array $log
+     * @param array  $log
      * @param string $type
      * @return array
      */
@@ -57,7 +57,7 @@ class BrowserLogUtil
     /**
      * Loops through given log and filters entries of the given type.
      *
-     * @param array $log
+     * @param array  $log
      * @param string $type
      * @return array
      */

--- a/src/Magento/FunctionalTestingFramework/Extension/BrowserLogUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/BrowserLogUtil.php
@@ -7,40 +7,13 @@
 namespace Magento\FunctionalTestingFramework\Extension;
 
 /**
- * Class ErrorLogger
+ * Class BrowserLogUtil
  * @package Magento\FunctionalTestingFramework\Extension
  */
-class ErrorLogger
+class BrowserLogUtil
 {
     const LOG_TYPE_BROWSER = "browser";
     const ERROR_TYPE_JAVASCRIPT = "javascript";
-
-    /**
-     * Error Logger Instance
-     * @var ErrorLogger
-     */
-    private static $errorLogger;
-
-    /**
-     * Singleton method to return ErrorLogger.
-     * @return ErrorLogger
-     */
-    public static function getInstance()
-    {
-        if (!self::$errorLogger) {
-            self::$errorLogger = new ErrorLogger();
-        }
-
-        return self::$errorLogger;
-    }
-
-    /**
-     * ErrorLogger constructor.
-     */
-    private function __construct()
-    {
-        // private constructor
-    }
 
     /**
      * Loops through stepEvent for browser log entries
@@ -49,14 +22,14 @@ class ErrorLogger
      * @param \Codeception\Event\StepEvent                                $stepEvent
      * @return void
      */
-    public function logErrors($module, $stepEvent)
+    public static function logErrors($module, $stepEvent)
     {
         //Types available should be "server", "browser", "driver". Only care about browser at the moment.
         if (in_array(self::LOG_TYPE_BROWSER, $module->webDriver->manage()->getAvailableLogTypes())) {
             $browserLogEntries = $module->webDriver->manage()->getLog(self::LOG_TYPE_BROWSER);
-            $jsErrors = $this->getLogsOfType($browserLogEntries, self::ERROR_TYPE_JAVASCRIPT);
+            $jsErrors = self::getLogsOfType($browserLogEntries, self::ERROR_TYPE_JAVASCRIPT);
             foreach ($jsErrors as $entry) {
-                $this->logError(self::ERROR_TYPE_JAVASCRIPT, $stepEvent, $entry);
+                self::logError(self::ERROR_TYPE_JAVASCRIPT, $stepEvent, $entry);
                 //Set javascript error in MagentoWebDriver internal array
                 $module->setJsError("ERROR({$entry["level"]}) - " . $entry["message"]);
             }
@@ -70,7 +43,7 @@ class ErrorLogger
      * @param string $type
      * @return array
      */
-    public function getLogsOfType($log, $type)
+    public static function getLogsOfType($log, $type)
     {
         $errors = [];
         foreach ($log as $entry) {
@@ -88,7 +61,7 @@ class ErrorLogger
      * @param string $type
      * @return array
      */
-    public function filterLogsOfType($log, $type)
+    public static function filterLogsOfType($log, $type)
     {
         $errors = [];
         foreach ($log as $entry) {
@@ -106,7 +79,7 @@ class ErrorLogger
      * @param array                        $entry
      * @return void
      */
-    private function logError($type, $stepEvent, $entry)
+    private static function logError($type, $stepEvent, $entry)
     {
         //TODO Add to overall log
         $stepEvent->getTest()->getScenario()->comment("{$type} ERROR({$entry["level"]}) - " . $entry["message"]);

--- a/src/Magento/FunctionalTestingFramework/Extension/ErrorLogger.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/ErrorLogger.php
@@ -64,7 +64,7 @@ class ErrorLogger
     }
 
     /**
-     * Loops through given logs and returns entries of the given type.
+     * Loops through given log and returns entries of the given type.
      *
      * @param array $log
      * @param string $type
@@ -75,6 +75,24 @@ class ErrorLogger
         $errors = [];
         foreach ($log as $entry) {
             if (array_key_exists("source", $entry) && $entry["source"] === $type) {
+                $errors[] = $entry;
+            }
+        }
+        return $errors;
+    }
+
+    /**
+     * Loops through given log and filters entries of the given type.
+     *
+     * @param array $log
+     * @param string $type
+     * @return array
+     */
+    public function filterLogsOfType($log, $type)
+    {
+        $errors = [];
+        foreach ($log as $entry) {
+            if (array_key_exists("source", $entry) && $entry["source"] !== $type) {
                 $errors[] = $entry;
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -177,14 +177,14 @@ class TestContextExtension extends BaseExtension
         if (getenv('ENABLE_BROWSER_LOG')) {
             $browserLog = $this->getDriver()->webDriver->manage()->getLog("browser");
             foreach (explode(',', getenv('BROWSER_LOG_BLACKLIST')) as $source) {
-                $browserLog = ErrorLogger::getInstance()->filterLogsOfType($browserLog, $source);
+                $browserLog = BrowserLogUtil::filterLogsOfType($browserLog, $source);
             }
 
             if (!empty($browserLog)) {
                 AllureHelper::addAttachmentToCurrentStep(json_encode($browserLog, JSON_PRETTY_PRINT), "Browser Log");
             }
         }
-        ErrorLogger::getInstance()->logErrors($this->getDriver(), $e);
+        BrowserLogUtil::logErrors($this->getDriver(), $e);
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -174,11 +174,14 @@ class TestContextExtension extends BaseExtension
      */
     public function afterStep(\Codeception\Event\StepEvent $e)
     {
-        if (getenv('ENABLE_JS_LOG')) {
-            $browserLogEntries = $this->getDriver()->webDriver->manage()->getLog("browser");
-            $jsErrors = ErrorLogger::getInstance()->getLogsOfType($browserLogEntries, ErrorLogger::ERROR_TYPE_JAVASCRIPT);
-            if (!empty($jsErrors)) {
-                AllureHelper::addAttachmentToCurrentStep($jsErrors);
+        if (getenv('ENABLE_BROWSER_LOG')) {
+            $browserLog = $this->getDriver()->webDriver->manage()->getLog("browser");
+            foreach (explode(',', getenv('BROWSER_LOG_BLACKLIST')) as $source) {
+                $browserLog = ErrorLogger::getInstance()->filterLogsOfType($browserLog, $source);
+            }
+
+            if (!empty($browserLog)) {
+                AllureHelper::addAttachmentToCurrentStep(json_encode($browserLog, JSON_PRETTY_PRINT), "Browser Log");
             }
         }
         ErrorLogger::getInstance()->logErrors($this->getDriver(), $e);

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -7,6 +7,7 @@
 namespace Magento\FunctionalTestingFramework\Extension;
 
 use Codeception\Events;
+use Magento\FunctionalTestingFramework\Allure\AllureHelper;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
 
 /**
@@ -173,6 +174,13 @@ class TestContextExtension extends BaseExtension
      */
     public function afterStep(\Codeception\Event\StepEvent $e)
     {
+        if (getenv('ENABLE_JS_LOG')) {
+            $browserLogEntries = $this->getDriver()->webDriver->manage()->getLog("browser");
+            $jsErrors = ErrorLogger::getInstance()->getLogsOfType($browserLogEntries, ErrorLogger::ERROR_TYPE_JAVASCRIPT);
+            if (!empty($jsErrors)) {
+                AllureHelper::addAttachmentToCurrentStep($jsErrors);
+            }
+        }
         ErrorLogger::getInstance()->logErrors($this->getDriver(), $e);
     }
 

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -174,17 +174,16 @@ class TestContextExtension extends BaseExtension
      */
     public function afterStep(\Codeception\Event\StepEvent $e)
     {
+        $browserLog = $this->getDriver()->webDriver->manage()->getLog("browser");
         if (getenv('ENABLE_BROWSER_LOG')) {
-            $browserLog = $this->getDriver()->webDriver->manage()->getLog("browser");
             foreach (explode(',', getenv('BROWSER_LOG_BLACKLIST')) as $source) {
                 $browserLog = BrowserLogUtil::filterLogsOfType($browserLog, $source);
             }
-
             if (!empty($browserLog)) {
                 AllureHelper::addAttachmentToCurrentStep(json_encode($browserLog, JSON_PRETTY_PRINT), "Browser Log");
             }
         }
-        BrowserLogUtil::logErrors($this->getDriver(), $e);
+        BrowserLogUtil::logErrors($browserLog, $this->getDriver(), $e);
     }
 
     /**


### PR DESCRIPTION
### Description
- Refactored ErrorLogger (no longer singleton, renamed for its actual use
- Added `stepAfter` actions to log browser logs

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests