### PR TITLE
MQE-1627: RetrieveEntityField generation does not consider ActionGroup

### DIFF
--- a/dev/tests/verification/Resources/PersistenceCustomFieldsTest.txt
+++ b/dev/tests/verification/Resources/PersistenceCustomFieldsTest.txt
@@ -111,5 +111,36 @@ class PersistenceCustomFieldsTestCest
 		);
 
 		$I->comment("Exiting Action Group [createdAG] PersistenceActionGroup");
+		$I->comment("Entering Action Group [AGKEY] DataPersistenceSelfReferenceActionGroup");
+		$I->comment("[createData1AGKEY] create 'entity1' entity");
+		PersistedObjectHandler::getInstance()->createEntity(
+			"createData1AGKEY",
+			"test",
+			"entity1",
+			[],
+			[]
+		);
+
+		$I->comment("[createData2AGKEY] create 'entity2' entity");
+		PersistedObjectHandler::getInstance()->createEntity(
+			"createData2AGKEY",
+			"test",
+			"entity2",
+			[],
+			[]
+		);
+
+		$createData3AGKEYFields['key1'] = PersistedObjectHandler::getInstance()->retrieveEntityField('createData1AGKEY', 'field', 'test');
+		$createData3AGKEYFields['key2'] = PersistedObjectHandler::getInstance()->retrieveEntityField('createData2AGKEY', 'field', 'test');
+		$I->comment("[createData3AGKEY] create 'entity3' entity");
+		PersistedObjectHandler::getInstance()->createEntity(
+			"createData3AGKEY",
+			"test",
+			"entity3",
+			[],
+			$createData3AGKEYFields
+		);
+
+		$I->comment("Exiting Action Group [AGKEY] DataPersistenceSelfReferenceActionGroup");
 	}
 }

--- a/dev/tests/verification/TestModule/ActionGroup/PersistenceActionGroup.xml
+++ b/dev/tests/verification/TestModule/ActionGroup/PersistenceActionGroup.xml
@@ -30,4 +30,12 @@
         <getData entity="someEneity" stepKey="getData"/>
         <comment userInput="$createData.field$" stepKey="comment"/>
     </actionGroup>
+    <actionGroup name="DataPersistenceSelfReferenceActionGroup">
+        <createData entity="entity1" stepKey="createData1"/>
+        <createData entity="entity2" stepKey="createData2"/>
+        <createData entity="entity3" stepKey="createData3">
+            <field key="key1">$createData1.field$</field>
+            <field key="key2">$createData2.field$</field>
+        </createData>
+    </actionGroup>
 </actionGroups>

--- a/dev/tests/verification/TestModule/Test/PersistenceCustomFieldsTest.xml
+++ b/dev/tests/verification/TestModule/Test/PersistenceCustomFieldsTest.xml
@@ -33,5 +33,6 @@
             <argument name="arg2" value="DefaultPerson.firstname"/>
             <argument name="arg3" value="$createdData3.firstname$"/>
         </actionGroup>
+        <actionGroup ref="DataPersistenceSelfReferenceActionGroup" stepKey="AGKEY"/>
     </test>
 </tests>

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1291,6 +1291,7 @@ class TestGenerator
                     break;
                 case "field":
                     $fieldKey = $actionObject->getCustomActionAttributes()['key'];
+                    $input = $this->resolveStepKeyReferences($input, $actionObject->getActionOrigin());
                     $input = $this->resolveTestVariable(
                         [$input],
                         $actionObject->getActionOrigin()


### PR DESCRIPTION
### Description
- Testgenerator fix
- verification tests addition

### Fixed Issues (if relevant)
* #317 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests