### PR TITLE
MQE-1917: ENABLE_BROWSER_LOG = false attaches JS logs to allure

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -182,7 +182,7 @@ class TestContextExtension extends BaseExtension
     public function afterStep(\Codeception\Event\StepEvent $e)
     {
         $browserLog = $this->getDriver()->webDriver->manage()->getLog("browser");
-        if (getenv('ENABLE_BROWSER_LOG')) {
+        if (getenv('ENABLE_BROWSER_LOG') === 'true') {
             foreach (explode(',', getenv('BROWSER_LOG_BLACKLIST')) as $source) {
                 $browserLog = BrowserLogUtil::filterLogsOfType($browserLog, $source);
             }


### PR DESCRIPTION
Fix for ENABLE_BROWSER_LOG=false not turning off logging.

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests