### PR TITLE
Added clarity in selector paths

### DIFF
--- a/docs/guides/selectors.md
+++ b/docs/guides/selectors.md
@@ -216,7 +216,7 @@ Example:
 //div[@class=’form-group’]//input[@id='user-message']
 ```
 
-In the GOOD example above, all <div class='form-group'/> elements in the DOM are matched first, and then all <input id='user-message'/> with <div class='form-group'/> as one of its parents is matched. Doesn't matter if the parent is anywhere up in the parent hierarchy.
+In the `GOOD` example above, all `<div class='form-group'/>` elements in the DOM are matched first, and then all `<input id='user-message'/>` with `<div class='form-group'/>` as one of its parents is matched. The parent does not have to immediately precede it since it uses another double forward slash `//`.
 
 #### Parent Selectors
 

--- a/docs/guides/selectors.md
+++ b/docs/guides/selectors.md
@@ -208,7 +208,7 @@ Here is an example of what NOT to do, but this demonstrates how the selector wor
 
 In the BAD example above, we are specifying a very precise path to an input element in the DOM, starting from the very top of the document.
 
-Similarly, the relative XPath selector is a double forward slash `//`. It is used to start searching for an element anywhere in the DOM starting from the element preceedingly defined. If no element is defined before, the entire DOM is searched.
+Similarly, the relative XPath selector is a double forward slash `//`. It is used to start searching for an element anywhere in the DOM starting from the specified element. If no element is defined, the entire DOM is searched.
 
 Example:
 
@@ -216,7 +216,7 @@ Example:
 //div[@class=’form-group’]//input[@id='user-message']
 ```
 
-In the `GOOD` example above, all `<div class='form-group'/>` elements in the DOM are matched first, and then all `<input id='user-message'/>` with `<div class='form-group'/>` as one of its parents is matched. The parent does not have to immediately precede it since it uses another double forward slash `//`.
+In the `GOOD` example above, all `<div class='form-group'/>` elements in the DOM are matched first. Then all `<input id='user-message'/>` with `<div class='form-group'/>` as one of its parents are matched. The parent does not have to immediately precede it since it uses another double forward slash `//`.
 
 #### Parent Selectors
 

--- a/docs/guides/selectors.md
+++ b/docs/guides/selectors.md
@@ -208,13 +208,15 @@ Here is an example of what NOT to do, but this demonstrates how the selector wor
 
 In the BAD example above, we are specifying a very precise path to an input element in the DOM, starting from the very top of the document.
 
-Similarly, the relative XPath selector is a double forward slash `//`. It is used to start searching for an element anywhere in the DOM.
+Similarly, the relative XPath selector is a double forward slash `//`. It is used to start searching for an element anywhere in the DOM starting from the element preceedingly defined. If no element is defined before, the entire DOM is searched.
 
 Example:
 
 ```xpath
 //div[@class=’form-group’]//input[@id='user-message']
 ```
+
+In the GOOD example above, all <div class='form-group'/> elements in the DOM are matched first, and then all <input id='user-message'/> with <div class='form-group'/> as one of its parents is matched. Doesn't matter if the parent is anywhere up in the parent hierarchy.
 
 #### Parent Selectors
 


### PR DESCRIPTION
# Description

-  Added clarity in the differences between `/` and `//` XPath selector syntax

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests