### PR TITLE
updated Contribution Guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the license [here][] or contact [license@magentocommerce.com][] for a copy.
 
 <!-- Link Definitions -->
 [Getting Started]: docs/getting-started.md
-[Contribution Guidelines]: .github/CONTRIBUTING.html
+[Contribution Guidelines]: https://github.com/magento/magento2-functional-testing-framework/blob/develop/.github/CONTRIBUTING.md
 [DevDocs Contributing]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [security@magento.com]: mailto:security@magento.com
 [encryption key]: https://info2.magento.com/rs/magentoenterprise/images/security_at_magento.asc


### PR DESCRIPTION
### Description

This PR updates a broken link in the Readme file for the MFTF Contribution Guidelines. The existing link produces a 404 error.

File affected: https://github.com/magento/magento2-functional-testing-framework/blob/develop/README.md

### Fixed Issues (if relevant)

Changed existing link (.github/CONTRIBUTING.html) to https://github.com/magento/magento2-functional-testing-framework/blob/develop/.github/CONTRIBUTING.md

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests