### PR TITLE
Quick Fix: PHP's max() requires at least 1 argument

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -601,6 +601,10 @@ class MagentoWebDriver extends WebDriver
      */
     private function getLastCronExecution(array $cronGroups = [])
     {
+        if (empty($this->cronExecution)) {
+            return 0;
+        }
+
         if (empty($cronGroups)) {
             return (int)max($this->cronExecution);
         }
@@ -1060,7 +1064,7 @@ class MagentoWebDriver extends WebDriver
     /**
      * Waits proper amount of time to perform Cron execution
      *
-     * @param string  $cronGroups
+     * @param array   $cronGroups
      * @param integer $timeout
      * @param string  $arguments
      * @return string


### PR DESCRIPTION
### Description
The issue with `[PHPUnit\Framework\Exception] max(): Array must contain at least one element` appears only when no groups provided. That's why I return `0` when there's no entry for `$this->cronExecution`

### Fixed Issues (if relevant)
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests