### PR TITLE
MQE-1986: Mark `executeInSelenium` and `performOn` as deprecated in MFTF

### DIFF
--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -15,7 +15,7 @@ use Yandex\Allure\Adapter\Annotation\TestCaseId;
 /**
  * @Title("[NO TESTCASEID]: A Functional Cest")
  * @group functional
- * @Description("<h3>Test files</h3>verification/TestModule/Test/BasicFunctionalTest.xml<br>")
+ * @Description("<h3 class='y-label y-label_status_broken'>Deprecated Notice(s):</h3><ul><li>DEPRECATED ACTION in Test: at step performOnKey1 "performOn" is DEPRECATED and will be removed in MFTF 3.0.0.</li></ul><h3>Test files</h3>verification/TestModule/Test/BasicFunctionalTest.xml<br>")
  */
 class BasicFunctionalTestCest
 {

--- a/dev/tests/verification/Resources/ExecuteInSeleniumTest.txt
+++ b/dev/tests/verification/Resources/ExecuteInSeleniumTest.txt
@@ -13,7 +13,7 @@ use Yandex\Allure\Adapter\Model\SeverityLevel;
 use Yandex\Allure\Adapter\Annotation\TestCaseId;
 
 /**
- * @Description("<h3>Test files</h3>verification/TestModule/Test/ExecuteInSeleniumTest.xml<br>")
+ * @Description("<h3 class='y-label y-label_status_broken'>Deprecated Notice(s):</h3><ul><li>DEPRECATED ACTION in Test: at step executeInSeleniumStep "executeInSelenium" is DEPRECATED and will be removed in MFTF 3.0.0.</li></ul><h3>Test files</h3>verification/TestModule/Test/ExecuteInSeleniumTest.xml<br>")
  */
 class ExecuteInSeleniumTestCest
 {

--- a/docs/test/actions.md
+++ b/docs/test/actions.md
@@ -973,6 +973,8 @@ Attribute|Type|Use|Description
 
 ### executeInSelenium
 
+#### NOTE: `executeInSelenium` action is DEPRECATED and will be removed in MFTF 3.0.0.
+
 See [executeInSelenium docs on codeception.com](http://codeception.com/docs/modules/WebDriver#executeInSelenium).
 
 Attribute|Type|Use|Description
@@ -1459,6 +1461,8 @@ Attribute|Type|Use|Description
 ```
 
 ### performOn
+
+#### NOTE: `performOn` action is DEPRECATED and will be removed in MFTF 3.0.0.
 
 See [performOn docs on codeception.com](http://codeception.com/docs/modules/WebDriver#performOn).
 

--- a/src/Magento/FunctionalTestingFramework/Console/BaseGenerateCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/BaseGenerateCommand.php
@@ -12,15 +12,27 @@ use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 use Magento\FunctionalTestingFramework\Util\Path\FilePathFormatter;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\FunctionalTestingFramework\Util\Filesystem\DirSetupUtil;
 use Magento\FunctionalTestingFramework\Util\TestGenerator;
 use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Suite\Handlers\SuiteObjectHandler;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class BaseGenerateCommand extends Command
 {
+    const MFTF_3_O_0_DEPRECATION_MESSAGE = "MFTF NOTICES:\n"
+        . "\"executeInSelenium\" and \"performOn\" actions are DEPRECATED and will be removed in MFTF 3.0.0\n";
+
+    /**
+     * Console output style
+     *
+     * @var SymfonyStyle
+     */
+    private $ioStyle = null;
+
     /**
      * Configures the base command.
      *
@@ -177,5 +189,34 @@ class BaseGenerateCommand extends Command
 
         $json = json_encode($result);
         return $json;
+    }
+
+    /**
+     * Set Symfony Style for output
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function setOutputStyle(InputInterface $input, OutputInterface $output)
+    {
+        // For output style
+        if (null === $this->ioStyle) {
+            $this->ioStyle = new SymfonyStyle($input, $output);
+        }
+    }
+
+    /**
+     * Show predefined global notice messages
+     *
+     * @param OutputInterface $output
+     * @return void
+     */
+    protected function showMftfNotices(OutputInterface $output)
+    {
+        if (null !== $this->ioStyle) {
+            $this->ioStyle->note(self::MFTF_3_O_0_DEPRECATION_MESSAGE);
+        } else {
+            $output->writeln(self::MFTF_3_O_0_DEPRECATION_MESSAGE);
+        }
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateSuiteCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateSuiteCommand.php
@@ -58,6 +58,9 @@ class GenerateSuiteCommand extends BaseGenerateCommand
             $allowSkipped
         );
 
+        $this->setOutputStyle($input, $output);
+        $this->showMftfNotices($output);
+
         // Remove previous GENERATED_DIR if --remove option is used
         if ($remove) {
             $this->removeGeneratedDirectory($output, $output->isVerbose());

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateTestsCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateTestsCommand.php
@@ -82,6 +82,9 @@ class GenerateTestsCommand extends BaseGenerateCommand
             $allowSkipped
         );
 
+        $this->setOutputStyle($input, $output);
+        $this->showMftfNotices($output);
+
         if (!empty($tests)) {
             $json = $this->getTestAndSuiteConfiguration($tests);
         }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -84,6 +84,9 @@ class RunTestCommand extends BaseGenerateCommand
             $allowSkipped
         );
 
+        $this->setOutputStyle($input, $output);
+        $this->showMftfNotices($output);
+
         $testConfiguration = $this->getTestAndSuiteConfiguration($tests);
 
         if (!$skipGeneration) {

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -96,6 +96,9 @@ class RunTestFailedCommand extends BaseGenerateCommand
             $allowSkipped
         );
 
+        $this->setOutputStyle($input, $output);
+        $this->showMftfNotices($output);
+
         $testConfiguration = $this->getFailedTestList();
 
         if ($testConfiguration === null) {

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -79,6 +79,9 @@ class RunTestGroupCommand extends BaseGenerateCommand
             $allowSkipped
         );
 
+        $this->setOutputStyle($input, $output);
+        $this->showMftfNotices($output);
+
         if (!$skipGeneration) {
             $testConfiguration = $this->getGroupAndSuiteConfiguration($groups);
             $command = $this->getApplication()->find('generate:tests');

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -59,6 +59,8 @@ class TestGenerator
     const ARRAY_WRAP_OPEN = '[';
     const ARRAY_WRAP_CLOSE = ']';
 
+    const MFTF_3_O_0_DEPRECATION_MESSAGE = ' is DEPRECATED and will be removed in MFTF 3.0.0.';
+
     /**
      * Actor name for AcceptanceTest
      *
@@ -1041,6 +1043,8 @@ class TestGenerator
                     );
                     break;
                 case "executeInSelenium":
+                    $this->deprecationMessages[] = "DEPRECATED ACTION in Test: at step {$stepKey} \"executeInSelenium\""
+                        . self::MFTF_3_O_0_DEPRECATION_MESSAGE;
                     $testSteps .= $this->wrapFunctionCall($actor, $actionObject, $function);
                     break;
                 case "executeJS":
@@ -1052,6 +1056,16 @@ class TestGenerator
                     );
                     break;
                 case "performOn":
+                    $this->deprecationMessages[] = "DEPRECATED ACTION in Test: at step {$stepKey} \"performOn\""
+                        . self::MFTF_3_O_0_DEPRECATION_MESSAGE;
+                    $testSteps .= $this->wrapFunctionCall(
+                        $actor,
+                        $actionObject,
+                        $selector,
+                        $function,
+                        $time
+                    );
+                    break;
                 case "waitForElementChange":
                     $testSteps .= $this->wrapFunctionCall(
                         $actor,


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests