### PR TITLE
Fixes a code example on the Actions page.

### DIFF
--- a/docs/test/actions.md
+++ b/docs/test/actions.md
@@ -22,13 +22,13 @@ This step can be referenced within the test using `conditionalClickStep1`.
 
 The value format should met the following principles:
 
-* Must be unique within [`<test>`](../test.md#test-tag).
-* Naming should be as descriptive as possible:
-  * Describe the action performed.
-  * Briefly describe the purpose.
-  * Describe which data is in use.
-* Should be in camelCase with lowercase first letter.
-* Should be the last attribute of an element.
+*  Must be unique within [`<test>`](../test.md#test-tag).
+*  Naming should be as descriptive as possible:
+   *  Describe the action performed.
+   *  Briefly describe the purpose.
+   *  Describe which data is in use.
+*  Should be in camelCase with lowercase first letter.
+*  Should be the last attribute of an element.
 
 ### `before` and `after`
 
@@ -142,14 +142,14 @@ Here, [`<click>`](#click) performs a click on a button that can be found by the 
 
 The following test actions return a variable:
 
-* [grabAttributeFrom](#grabattributefrom)
-* [grabCookie](#grabcookie)
-* [grabFromCurrentUrl](#grabfromcurrenturl)
-* [grabMultiple](#grabmultiple)
-* [grabPageSource](#grabpagesource)
-* [grabTextFrom](#grabtextfrom)
-* [grabValueFrom](#grabvaluefrom)
-* [executeJS](#executejs)
+*  [grabAttributeFrom](#grabattributefrom)
+*  [grabCookie](#grabcookie)
+*  [grabFromCurrentUrl](#grabfromcurrenturl)
+*  [grabMultiple](#grabmultiple)
+*  [grabPageSource](#grabpagesource)
+*  [grabTextFrom](#grabtextfrom)
+*  [grabValueFrom](#grabvaluefrom)
+*  [executeJS](#executejs)
 
 Learn more in [Using data returned by test actions](../data.md#use-data-returned-by-test-actions).
 
@@ -157,10 +157,10 @@ Learn more in [Using data returned by test actions](../data.md#use-data-returned
 
 The following test actions handle data entities using [metadata](../metadata.md):
 
-* [createData](#createdata)
-* [deleteData](#deletedata)
-* [updateData](#updatedata)
-* [getData](#getdata)
+*  [createData](#createdata)
+*  [deleteData](#deletedata)
+*  [updateData](#updatedata)
+*  [getData](#getdata)
 
 Learn more in [Handling a REST API response](../metadata.md#rest-response).
 
@@ -1287,7 +1287,6 @@ Attribute|Type|Use|Description
 `before`|string|optional| `stepKey` of action that must be executed next.
 `after`|string|optional| `stepKey` of preceding action.
 
-
 #### Example
 ```xml
 <magentoCron stepKey="runStagingCronJobs" groups="staging"/>
@@ -1974,13 +1973,13 @@ Attribute|Type|Use|Description
 #### Examples
 
 ```xml
-<!-- Verify there are 10 `<div id="product" ... >...</div>` elements on the page. -->
+<!-- Verify there are 10 `<div class="product" ... >...</div>` elements on the page. -->
 <seeNumberOfElements userInput="10" selector="div.product" stepKey="seeTenProducts"/>
 ```
 
 ```xml
-<!-- Verify there are between 5 and 10 `<div id="product" ... >...</div>` elements on the page. -->
-<seeNumberOfElements userInput="[5, 10]" selector=".product" stepKey="seeFiveToTenProducts"/>
+<!-- Verify there are between 5 and 10 `<div class="product" ... >...</div>` elements on the page. -->
+<seeNumberOfElements parameterArray="[5, 10]" selector="div.product" stepKey="seeFiveToTenProducts"/>
 ```
 
 ### seeOptionIsSelected


### PR DESCRIPTION
### Description

This PR fixes an error in the example code for `seeNumberOfElements` on the Actions topic.
https://devdocs.magento.com/mftf/docs/test/actions.html#seenumberofelements

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests