### PR TITLE
MQE-2040: Unable to run suites from standalone MFTF

### DIFF
--- a/dev/tests/functional/standalone_bootstrap.php
+++ b/dev/tests/functional/standalone_bootstrap.php
@@ -75,8 +75,3 @@ if (!(bool)$debug_mode && extension_loaded('xdebug')) {
     xdebug_disable();
 }
 
-// include suite php files
-$groupPath = PROJECT_ROOT . '/src/Magento/FunctionalTestingFramework/Group';
-foreach (glob($groupPath. '/*.php') as $suitePhpFile) {
-    include_once $suitePhpFile;
-}

--- a/dev/tests/functional/standalone_bootstrap.php
+++ b/dev/tests/functional/standalone_bootstrap.php
@@ -74,4 +74,3 @@ $debug_mode = $_ENV['MFTF_DEBUG'] ?? false;
 if (!(bool)$debug_mode && extension_loaded('xdebug')) {
     xdebug_disable();
 }
-

--- a/dev/tests/functional/standalone_bootstrap.php
+++ b/dev/tests/functional/standalone_bootstrap.php
@@ -74,3 +74,9 @@ $debug_mode = $_ENV['MFTF_DEBUG'] ?? false;
 if (!(bool)$debug_mode && extension_loaded('xdebug')) {
     xdebug_disable();
 }
+
+// include suite php files
+$groupPath = PROJECT_ROOT . '/src/Magento/FunctionalTestingFramework/Group';
+foreach (glob($groupPath. '/*.php') as $suitePhpFile) {
+    include_once $suitePhpFile;
+}

--- a/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
+++ b/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
@@ -10,6 +10,7 @@ use Magento\FunctionalTestingFramework\Config\FileResolverInterface;
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Util\Iterator\File;
 use Magento\FunctionalTestingFramework\Util\Path\FilePathFormatter;
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 
 class Root extends Mask
 {
@@ -27,10 +28,8 @@ class Root extends Mask
     public function get($filename, $scope)
     {
         // First pick up the root level test suite dir
-        $rootSuitePath = defined('MAGENTO_BP') ? MAGENTO_BP . '/dev/tests/acceptance/' : TESTS_BP;
-
         $paths = glob(
-            FilePathFormatter::format($rootSuitePath) . self::ROOT_SUITE_DIR
+            FilePathFormatter::format($this->getRootSuiteDirPath()) . self::ROOT_SUITE_DIR
             . DIRECTORY_SEPARATOR . '*.xml'
         );
 
@@ -42,5 +41,26 @@ class Root extends Mask
         // create and return the iterator for these file paths
         $iterator = new File($paths);
         return $iterator;
+    }
+
+    /**
+     * Returns root suite directory _suite 's path
+     *
+     * @return string
+     * @throws TestFrameworkException
+     */
+    public function getRootSuiteDirPath()
+    {
+        if (FilePathFormatter::format(MAGENTO_BP, false)
+            === FilePathFormatter::format(FW_BP, false)) {
+            return TESTS_BP;
+        }
+        else {
+            if (MftfApplicationConfig::getConfig()->getPhase()
+                !== MftfApplicationConfig::UNIT_TEST_PHASE) {
+                return (MAGENTO_BP . DIRECTORY_SEPARATOR . 'dev/tests/acceptance');
+            }
+            return TESTS_BP;
+        }
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
+++ b/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
@@ -27,8 +27,10 @@ class Root extends Mask
     public function get($filename, $scope)
     {
         // First pick up the root level test suite dir
+        $rootSuitePath = defined('MAGENTO_BP') ? MAGENTO_BP . '/dev/tests/acceptance/' : TESTS_BP;
+
         $paths = glob(
-            FilePathFormatter::format(TESTS_BP) . self::ROOT_SUITE_DIR
+            FilePathFormatter::format($rootSuitePath) . self::ROOT_SUITE_DIR
             . DIRECTORY_SEPARATOR . '*.xml'
         );
 

--- a/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
+++ b/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
@@ -54,8 +54,7 @@ class Root extends Mask
         if (FilePathFormatter::format(MAGENTO_BP, false)
             === FilePathFormatter::format(FW_BP, false)) {
             return TESTS_BP;
-        }
-        else {
+        } else {
             if (MftfApplicationConfig::getConfig()->getPhase()
                 !== MftfApplicationConfig::UNIT_TEST_PHASE) {
                 return (MAGENTO_BP . DIRECTORY_SEPARATOR . 'dev/tests/acceptance');

--- a/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
+++ b/src/Magento/FunctionalTestingFramework/Config/FileResolver/Root.php
@@ -36,11 +36,13 @@ class Root extends Mask
         $altPath = MAGENTO_BP . DIRECTORY_SEPARATOR . 'dev/tests/acceptance';
 
         if (realpath($altPath) && ($altPath !== TESTS_BP)) {
-         $paths = array_merge($paths,
-             glob(FilePathFormatter::format($altPath) . self::ROOT_SUITE_DIR
-                 . DIRECTORY_SEPARATOR . '*.xml'
-             )
-         );
+            $paths = array_merge(
+                $paths,
+                glob(
+                    FilePathFormatter::format($altPath) . self::ROOT_SUITE_DIR
+                    . DIRECTORY_SEPARATOR . '*.xml'
+                )
+            );
         }
 
         // Then merge this path into the module based paths


### PR DESCRIPTION
Added dev/tests/acceptance path of _suite to file to getFileCollection() if it's a valid path

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests