### PR TITLE
MQE-2042: Port MFTF Coverage to Jenkins

### DIFF
--- a/etc/codecoverage/index.php
+++ b/etc/codecoverage/index.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Application entry point
+ *
+ * Example - run a particular store or website:
+ * --------------------------------------------
+ * require __DIR__ . '/app/bootstrap.php';
+ * $params = $_SERVER;
+ * $params[\Magento\Store\Model\StoreManager::PARAM_RUN_CODE] = 'website2';
+ * $params[\Magento\Store\Model\StoreManager::PARAM_RUN_TYPE] = 'website';
+ * $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $params);
+ * \/** @var \Magento\Framework\App\Http $app *\/
+ * $app = $bootstrap->createApplication(\Magento\Framework\App\Http::class);
+ * $bootstrap->run($app);
+ * --------------------------------------------
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+try {
+    require __DIR__ . '/app/bootstrap.php';
+} catch (\Exception $e) {
+    echo <<<HTML
+<div style="font:12px/1.35em arial, helvetica, sans-serif;">
+    <div style="margin:0 0 25px 0; border-bottom:1px solid #ccc;">
+        <h3 style="margin:0;font-size:1.7em;font-weight:normal;text-transform:none;text-align:left;color:#2f2f2f;">
+        Autoload error</h3>
+    </div>
+    <p>{$e->getMessage()}</p>
+</div>
+HTML;
+    exit(1);
+}
+
+//Patch start
+$driver = new pcov\Clobber\Driver\PHPUnit6();
+$coverage = new \SebastianBergmann\CodeCoverage\CodeCoverage($driver);
+$coverage->filter()->addDirectoryToWhitelist("app/code/Magento/*");
+$coverage->filter()->removeDirectoryFromWhitelist("app/code/Magento/*/Test");
+$testName = "NO_TEST_NAME";
+if (file_exists(__DIR__ . '/CURRENT_TEST')) {
+    $testName = file_get_contents(__DIR__ . '/CURRENT_TEST');
+}
+$id = !empty($testName) ? $testName : "NO_TEST_NAME";
+$coverage->start($id);
+//Patch end
+
+$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+/** @var \Magento\Framework\App\Http $app */
+$app = $bootstrap->createApplication(\Magento\Framework\App\Http::class);
+$bootstrap->run($app);
+
+// Patch start
+$coverage->stop();
+$writer = new \SebastianBergmann\CodeCoverage\Report\PHP();
+$writer->process($coverage, '/var/www/html/coverage/reports/' . $id . "_" . md5(mt_rand()) . '.cov');
+// Patch end

--- a/etc/codecoverage/test.php
+++ b/etc/codecoverage/test.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
 $test = $_GET['test'] ?? "NO_TEST_SPECIFIED";
 file_put_contents('CURRENT_TEST', $test);
 echo 'SET CURRENT TEST TO ' . $test;

--- a/etc/codecoverage/test.php
+++ b/etc/codecoverage/test.php
@@ -1,0 +1,4 @@
+<?php
+$test = $_GET['test'] ?? "NO_TEST_SPECIFIED";
+file_put_contents('CURRENT_TEST', $test);
+echo 'SET CURRENT TEST TO ' . $test;

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -33,6 +33,12 @@ class TestContextExtension extends BaseExtension
     public static $events;
 
     /**
+     * The name of the currently running test
+     * @var string
+     */
+    public $currentTest;
+
+    /**
      * Initialize local vars
      *
      * @return void
@@ -55,8 +61,20 @@ class TestContextExtension extends BaseExtension
      * @throws \Exception
      * @return void
      */
-    public function testStart()
+    public function testStart(\Codeception\Event\TestEvent $e)
     {
+        if (getenv('ENABLE_CODE_COVERAGE') === 'true') {
+            // Curl against test.php and pass in the test name. Used when gathering code coverage.
+            $this->currentTest = $e->getTest()->getMetadata()->getName();
+            $cURLConnection = curl_init();
+            curl_setopt_array($cURLConnection, [
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_URL => getenv('MAGENTO_BASE_URL') . "/test.php?test=" . $this->currentTest,
+            ]);
+            curl_exec($cURLConnection);
+            curl_close($cURLConnection);
+        }
+
         PersistedObjectHandler::getInstance()->clearHookObjects();
         PersistedObjectHandler::getInstance()->clearTestObjects();
     }


### PR DESCRIPTION
Modify TestContextExtension to call test.php file to keep track of test name during code coverage gathering.
Controlled by a new environment variable called `ENABLE_CODE_COVERAGE`.