### PR TITLE
MQE-2078: [PHPUnit 9] assertContains and assertNotContains breaking c…

### DIFF
--- a/dev/tests/verification/Resources/AssertTest.txt
+++ b/dev/tests/verification/Resources/AssertTest.txt
@@ -101,6 +101,7 @@ class AssertTestCest
 		$I->assertLessThanOrEqual(5, 2, "pass"); // stepKey: assertLessThanOrEqualBackwardCompatible
 		$I->assertNotContains("bc", ['item1' => 'a', 'item2' => 'ab'], "pass"); // stepKey: assertNotContains1BackwardCompatible
 		$I->assertNotContains("bc", $text, "pass"); // stepKey: assertNotContains2BackwardCompatible
+		$I->assertNotContains("bc", "text", "pass"); // stepKey: assertStringNotContainsString
 		$I->assertNotEmpty([1, 2], "pass"); // stepKey: assertNotEmpty1BackwardCompatible
 		$I->assertNotEmpty($text, "pass"); // stepKey: assertNotEmpty2BackwardCompatible
 		$I->assertNotEquals(2, 5, "pass", 0); // stepKey: assertNotEqualsBackwardCompatible

--- a/dev/tests/verification/Resources/AssertTest.txt
+++ b/dev/tests/verification/Resources/AssertTest.txt
@@ -82,6 +82,7 @@ class AssertTestCest
 		$I->assertArrayNotHasKey("kiwi", ['orange' => 2, 'apple' => 1], "pass"); // stepKey: assertArrayNotHasKeyBackwardCompatible
 		$I->assertArraySubset([1, 2], [1, 2, 3, 5], "pass"); // stepKey: assertArraySubsetBackwardCompatible
 		$I->assertContains("ab", ['item1' => 'a', 'item2' => 'ab'], "pass"); // stepKey: assertContainsBackwardCompatible
+		$I->assertContains("foo", "foobar", "pass"); // stepKey: assertStringContainsString
 		$I->assertCount(2, ['a', 'b'], "pass"); // stepKey: assertCountBackwardCompatible
 		$I->assertEmpty([], "pass"); // stepKey: assertEmptyBackwardCompatible
 		$I->assertEquals($text, "Copyright © 2013-2017 Magento, Inc. All rights reserved.", "pass"); // stepKey: assertEquals1BackwardCompatible

--- a/dev/tests/verification/TestModule/Test/AssertTest.xml
+++ b/dev/tests/verification/TestModule/Test/AssertTest.xml
@@ -173,6 +173,10 @@
             <expectedResult type="string">ab</expectedResult>
             <actualResult type="const">['item1' => 'a', 'item2' => 'ab']</actualResult>
         </assertContains>
+        <assertContains stepKey="assertStringContainsString" message="pass">
+            <expectedResult type="string">foo</expectedResult>
+            <actualResult type="string">foobar</actualResult>
+        </assertContains>
         <assertCount stepKey="assertCountBackwardCompatible" message="pass">
             <actualResult type="const">['a', 'b']</actualResult>
             <expectedResult type="int">2</expectedResult>

--- a/dev/tests/verification/TestModule/Test/AssertTest.xml
+++ b/dev/tests/verification/TestModule/Test/AssertTest.xml
@@ -245,6 +245,10 @@
             <actualResult type="variable">text</actualResult>
             <expectedResult type="string">bc</expectedResult>
         </assertNotContains>
+        <assertNotContains stepKey="assertStringNotContainsString" message="pass">
+            <actualResult type="string">text</actualResult>
+            <expectedResult type="string">bc</expectedResult>
+        </assertNotContains>
         <assertNotEmpty stepKey="assertNotEmpty1BackwardCompatible" message="pass">
             <actualResult type="const">[1, 2]</actualResult>
         </assertNotEmpty>

--- a/etc/config/functional.suite.dist.yml
+++ b/etc/config/functional.suite.dist.yml
@@ -11,6 +11,7 @@ class_name: AcceptanceTester
 namespace: Magento\FunctionalTestingFramework
 modules:
     enabled:
+        - Asserts
         - \Magento\FunctionalTestingFramework\Module\MagentoWebDriver
         - \Magento\FunctionalTestingFramework\Module\MagentoSequence
         - \Magento\FunctionalTestingFramework\Module\MagentoAssert

--- a/etc/config/functional.suite.dist.yml
+++ b/etc/config/functional.suite.dist.yml
@@ -15,7 +15,6 @@ modules:
         - \Magento\FunctionalTestingFramework\Module\MagentoSequence
         - \Magento\FunctionalTestingFramework\Module\MagentoAssert
         - \Magento\FunctionalTestingFramework\Module\MagentoActionProxies
-        - Asserts
     config:
         \Magento\FunctionalTestingFramework\Module\MagentoWebDriver:
             url: "%MAGENTO_BASE_URL%"

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
@@ -48,4 +48,38 @@ class MagentoAssert extends \Codeception\Module
             }
         }
     }
+
+    /**
+     * Asserts that haystack contains needle.
+     *
+     * @param string $needle
+     * @param string $haystack
+     * @param string $message
+     * @return void
+     */
+    public function assertContains($needle, $haystack, $message = '')
+    {
+        if (is_string($haystack)) {
+            $this->assertStringContainsString($needle, $haystack, $message);
+        } else {
+            parent::assertContains(needle, $haystack, $message);
+        }
+    }
+
+    /**
+     * Asserts that haystack does not contain needle.
+     *
+     * @param string $needle
+     * @param string $haystack
+     * @param string $message
+     * @return void
+     */
+    public function assertNotContains($needle, $haystack, $message = '')
+    {
+        if (is_string($haystack)) {
+            $this->assertStringNotContainsString($needle, $haystack, $message);
+        } else {
+            parent::assertNotContains(needle, $haystack, $message);
+        }
+    }
 }

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
@@ -52,9 +52,9 @@ class MagentoAssert extends \Codeception\Module
     /**
      * Asserts that haystack contains needle.
      *
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
+     * @param string          $needle
+     * @param string|iterable $haystack
+     * @param string          $message
      * @return void
      */
     public function assertContains($needle, $haystack, $message = '')
@@ -69,9 +69,9 @@ class MagentoAssert extends \Codeception\Module
     /**
      * Asserts that haystack does not contain needle.
      *
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
+     * @param string          $needle
+     * @param string|iterable $haystack
+     * @param string          $message
      * @return void
      */
     public function assertNotContains($needle, $haystack, $message = '')

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
@@ -62,7 +62,7 @@ class MagentoAssert extends \Codeception\Module
         if (is_string($haystack)) {
             $this->assertStringContainsString($needle, $haystack, $message);
         } else {
-            parent::assertContains(needle, $haystack, $message);
+            parent::assertContains($needle, $haystack, $message);
         }
     }
 
@@ -79,7 +79,7 @@ class MagentoAssert extends \Codeception\Module
         if (is_string($haystack)) {
             $this->assertStringNotContainsString($needle, $haystack, $message);
         } else {
-            parent::assertNotContains(needle, $haystack, $message);
+            parent::assertNotContains($needle, $haystack, $message);
         }
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -256,7 +256,7 @@ class MagentoWebDriver extends WebDriver
         $actualUrl = $this->webDriver->getCurrentURL();
         $comparison = "Expected: $needle\nActual: $actualUrl";
         AllureHelper::addAttachmentToCurrentStep($comparison, 'Comparison');
-        $this->assertNotContains($needle, $actualUrl);
+        $this->assertStringContainsString($needle, $actualUrl);
     }
 
     /**
@@ -325,7 +325,7 @@ class MagentoWebDriver extends WebDriver
         $actualUrl = $this->webDriver->getCurrentURL();
         $comparison = "Expected: $needle\nActual: $actualUrl";
         AllureHelper::addAttachmentToCurrentStep($comparison, 'Comparison');
-        $this->assertContains($needle, $actualUrl);
+        $this->assertStringContainsString($needle, $actualUrl);
     }
 
     /**
@@ -692,6 +692,38 @@ class MagentoWebDriver extends WebDriver
     }
 
     /**
+     * Asserts that haystack contains needle.
+     *
+     * @param        $needle
+     * @param        $haystack
+     * @param string $message
+     */
+    public function assertContains($needle, $haystack, $message = null)
+    {
+        if (is_string($haystack)) {
+            $this->assertStringContainsString($needle, $haystack, $message = null);
+        } else {
+            parent::assertContains(needle, $haystack, $message = null);
+        }
+    }
+
+    /**
+     * Asserts that haystack does not contain needle.
+     *
+     * @param        $needle
+     * @param        $haystack
+     * @param string $message
+     */
+    public function assertNotContains($needle, $haystack, $message = null)
+    {
+        if (is_string($haystack)) {
+            $this->assertStringNotContainsString($needle, $haystack, $message = null);
+        } else {
+            parent::assertNotContains(needle, $haystack, $message = null);
+        }
+    }
+
+    /**
      * Assert that an element contains a given value for the specific attribute.
      *
      * @param string $selector
@@ -708,7 +740,7 @@ class MagentoWebDriver extends WebDriver
             // When an "attribute" is blank or null it returns "true" so we assert that "true" is present.
             $this->assertEquals($attributes, 'true');
         } else {
-            $this->assertContains($value, $attributes);
+            $this->assertStringNotContainsString($value, $attributes);
         }
     }
 

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -694,9 +694,10 @@ class MagentoWebDriver extends WebDriver
     /**
      * Asserts that haystack contains needle.
      *
-     * @param        $needle
-     * @param        $haystack
+     * @param string $needle
+     * @param string $haystack
      * @param string $message
+     * @return void
      */
     public function assertContains($needle, $haystack, $message = null)
     {
@@ -710,9 +711,10 @@ class MagentoWebDriver extends WebDriver
     /**
      * Asserts that haystack does not contain needle.
      *
-     * @param        $needle
-     * @param        $haystack
+     * @param string $needle
+     * @param string $haystack
      * @param string $message
+     * @return void
      */
     public function assertNotContains($needle, $haystack, $message = null)
     {

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -48,6 +48,7 @@ use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHan
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class MagentoWebDriver extends WebDriver
 {

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -708,7 +708,7 @@ class MagentoWebDriver extends WebDriver
             // When an "attribute" is blank or null it returns "true" so we assert that "true" is present.
             $this->assertEquals($attributes, 'true');
         } else {
-            $this->assertStringNotContainsString($value, $attributes);
+            $this->assertStringContainsString($value, $attributes);
         }
     }
 

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -256,7 +256,7 @@ class MagentoWebDriver extends WebDriver
         $actualUrl = $this->webDriver->getCurrentURL();
         $comparison = "Expected: $needle\nActual: $actualUrl";
         AllureHelper::addAttachmentToCurrentStep($comparison, 'Comparison');
-        $this->assertStringContainsString($needle, $actualUrl);
+        $this->assertStringNotContainsString($needle, $actualUrl);
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -48,7 +48,6 @@ use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHan
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class MagentoWebDriver extends WebDriver
 {
@@ -690,40 +689,6 @@ class MagentoWebDriver extends WebDriver
     public function clearField($selector)
     {
         $this->fillField($selector, "");
-    }
-
-    /**
-     * Asserts that haystack contains needle.
-     *
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     * @return void
-     */
-    public function assertContains($needle, $haystack, $message = null)
-    {
-        if (is_string($haystack)) {
-            $this->assertStringContainsString($needle, $haystack, $message = null);
-        } else {
-            parent::assertContains(needle, $haystack, $message = null);
-        }
-    }
-
-    /**
-     * Asserts that haystack does not contain needle.
-     *
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     * @return void
-     */
-    public function assertNotContains($needle, $haystack, $message = null)
-    {
-        if (is_string($haystack)) {
-            $this->assertStringNotContainsString($needle, $haystack, $message = null);
-        } else {
-            parent::assertNotContains(needle, $haystack, $message = null);
-        }
     }
 
     /**


### PR DESCRIPTION
Please review base PR https://github.com/magento/magento2-functional-testing-framework/pull/657 before proceeding to this PR.

Changes -

- Added methods `assertContains` and `assertNotContains` overriding original PHPUnit methods to include non iterable parameters. 
- Added overridden method proceedSeeInField to make `seeInField` less strict by using `assertContainsEquals` instead of `assertContains`.

Covered with unit tests



<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests