### PR TITLE
Interrupt Suite execution when there is a connection issue

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Suite/views/SuiteClass.mustache
+++ b/src/Magento/FunctionalTestingFramework/Suite/views/SuiteClass.mustache
@@ -51,6 +51,9 @@ class {{suiteName}} extends \Codeception\GroupObject
                 $webDriver->webDriver = null;
 
             } catch (\Exception $exception) {
+                if ($exception instanceof \Codeception\Exception\ConnectionException) {
+                    throw $exception;
+                }
                 $this->preconditionFailure = $exception->getMessage();
             }
 


### PR DESCRIPTION
### Description
This is a bugfix for the issue https://github.com/magento/magento2-functional-testing-framework/issues/700 that causes execution of the whole suite even if the Webdriver is unable to connect Selenium Hub.

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#700

### CC
@okolesnyk @KevinBKozan @jilu1 

### After change
```
StorefrontVerifySecureURLRedirectCheckoutTestCest: Storefront verify secure url redirect checkout test
Signature: Magento\AcceptanceTest\_SecureStorefrontURLSuite\Backend\StorefrontVerifySecureURLRedirectCheckoutTestCest:StorefrontVerifySecureURLRedirectCheckoutTest
Test: tests/functional/Magento/_generated/SecureStorefrontURLSuite/StorefrontVerifySecureURLRedirectCheckoutTestCest.php:StorefrontVerifySecureURLRedirectCheckoutTest
Scenario --

/******** Beginning execution of SecureStorefrontURLSuite suite before block ********/
--------------------------------------------------------------------------------

In MagentoWebDriver.php line 830:
                                                                               
  [RuntimeException]                                                           
  Suite condition failure:                                                     
  Can't connect to Webdriver at http://selenium-hub:4444/wd/hub. Please make   
  sure that Selenium Server or PhantomJS is running.                           
                                                                               

Exception trace:
  at /var/www/html/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php:830
 Magento\FunctionalTestingFramework\Module\MagentoWebDriver->_failed() at /var/www/html/vendor/codeception/codeception/src/Codeception/Subscriber/Module.php:77
 Codeception\Subscriber\Module->failed() at /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php:264
 Symfony\Component\EventDispatcher\EventDispatcher->doDispatch() at /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php:239
 Symfony\Component\EventDispatcher\EventDispatcher->callListeners() at /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php:73
 Symfony\Component\EventDispatcher\EventDispatcher->dispatch() at /var/www/html/vendor/codeception/phpunit-wrapper/src/DispatcherWrapper.php:25
 Codeception\PHPUnit\Listener->dispatch() at /var/www/html/vendor/codeception/phpunit-wrapper/src/Listener.php:134
 Codeception\PHPUnit\Listener->fire() at /var/www/html/vendor/codeception/phpunit-wrapper/src/Listener.php:51
 Codeception\PHPUnit\Listener->addError() at /var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php:300
 PHPUnit\Framework\TestResult->addError() at /var/www/html/vendor/codeception/phpunit-wrapper/src/Listener.php:109
 Codeception\PHPUnit\Listener->startTest() at /var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php:407
 PHPUnit\Framework\TestResult->startTest() at /var/www/html/vendor/codeception/codeception/src/Codeception/Test/Test.php:75
 Codeception\Test\Test->run() at /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php:639
 PHPUnit\Framework\TestSuite->run() at /var/www/html/vendor/codeception/phpunit-wrapper/src/Runner.php:117
 Codeception\PHPUnit\Runner->doEnhancedRun() at /var/www/html/vendor/codeception/codeception/src/Codeception/SuiteManager.php:161
 Codeception\SuiteManager->run() at /var/www/html/vendor/codeception/codeception/src/Codeception/Codecept.php:196
 Codeception\Codecept->runSuite() at /var/www/html/vendor/codeception/codeception/src/Codeception/Codecept.php:163
 Codeception\Codecept->run() at /var/www/html/vendor/codeception/codeception/src/Codeception/Command/Run.php:503
 Codeception\Command\Run->runSuites() at /var/www/html/vendor/codeception/codeception/src/Codeception/Command/Run.php:397
 Codeception\Command\Run->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:1001
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:271
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:147
 Symfony\Component\Console\Application->run() at /var/www/html/vendor/codeception/codeception/src/Codeception/Application.php:117
 Codeception\Application->run() at /var/www/html/vendor/codeception/codeception/app.php:46
 {closure}() at /var/www/html/vendor/codeception/codeception/app.php:47
 require() at /var/www/html/vendor/codeception/codeception/codecept:7

```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests