### PR TITLE
Fix command.php to work with symlink setups.

### DIFF
--- a/etc/config/command.php
+++ b/etc/config/command.php
@@ -20,7 +20,7 @@ if (!empty($_POST['token']) && !empty($_POST['command'])) {
     $tokenFromMagento = $tokenModel->loadByToken($tokenPassedIn)->getToken();
     if (!empty($tokenFromMagento) && ($tokenFromMagento == $tokenPassedIn)) {
         $php = PHP_BINDIR ? PHP_BINDIR . '/php' : 'php';
-        $magentoBinary = $php . ' -f ../../../../bin/magento';
+        $magentoBinary = $php . ' -f '. __DIR__ .'/../../../../bin/magento';
         $valid = validateCommand($magentoBinary, $command);
         if ($valid) {
             $fullCommand = escapeshellcmd($magentoBinary . " $command" . " $arguments");


### PR DESCRIPTION
### Description
Add `__DIR__` to /bin/magento commands executed using the command.php script.
This allows the command.php script to be executed if it is symlinked.

For example on a Magento installation where the mageroot folder points to `/pub` (as recommended by [devdocs](https://devdocs.magento.com/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.html)) and a symlink has been created from `/pub/dev/tests/acceptance/utils/command.php` to point to `dev/tests/acceptance/utils/command.php`