### PR TITLE
Update csharpru/vault-php to  ^4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "codeception/module-sequence": "^1.0",
         "codeception/module-webdriver": "^1.0",
         "composer/composer": "^1.9",
-        "csharpru/vault-php": "~3.5.3",
+        "csharpru/vault-php": "^4",
         "csharpru/vault-php-guzzle6-transport": "^2.0",
         "monolog/monolog": "^1.17",
         "mustache/mustache": "~2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bebbc11e36de2f68821cbeebeafe04ad",
+    "content-hash": "0389a3d19633ce6ec0d533a9e5d68c87",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",
@@ -1065,32 +1065,35 @@
         },
         {
             "name": "csharpru/vault-php",
-            "version": "3.5.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CSharpRU/vault-php.git",
-                "reference": "04be9776310fe7d1afb97795645f95c21e6b4fcf"
+                "reference": "22f47588f50dfc6ee750393c4c381caa79df1f80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CSharpRU/vault-php/zipball/04be9776310fe7d1afb97795645f95c21e6b4fcf",
-                "reference": "04be9776310fe7d1afb97795645f95c21e6b4fcf",
+                "url": "https://api.github.com/repos/CSharpRU/vault-php/zipball/22f47588f50dfc6ee750393c4c381caa79df1f80",
+                "reference": "22f47588f50dfc6ee750393c4c381caa79df1f80",
                 "shasum": ""
             },
             "require": {
                 "cache/cache": "^0.4.0",
-                "doctrine/inflector": "~1.1.0",
-                "guzzlehttp/promises": "^1.3",
-                "guzzlehttp/psr7": "^1.4",
+                "doctrine/inflector": "~1.1",
+                "ext-json": "*",
+                "php": "^7.2",
                 "psr/cache": "^1.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
                 "psr/log": "^1.0",
                 "weew/helpers-array": "^1.3"
             },
             "require-dev": {
+                "alextartan/guzzle-psr18-adapter": "^1.2",
                 "codacy/coverage": "^1.1",
                 "codeception/codeception": "^2.2",
-                "csharpru/vault-php-guzzle6-transport": "~2.0",
-                "php-vcr/php-vcr": "^1.3"
+                "php-vcr/php-vcr": "^1.3",
+                "zendframework/zend-diactoros": "^2.0"
             },
             "type": "library",
             "autoload": {
@@ -1109,7 +1112,7 @@
                 }
             ],
             "description": "Best Vault client for PHP that you can find",
-            "time": "2018-04-28T04:52:17+00:00"
+            "time": "2019-09-10T08:42:19+00:00"
         },
         {
             "name": "csharpru/vault-php-guzzle6-transport",
@@ -3299,6 +3302,107 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "496a823ef742b632934724bf769560c2a5c7c44e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/496a823ef742b632934724bf769560c2a5c7c44e",
+                "reference": "496a823ef742b632934724bf769560c2a5c7c44e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2018-10-30T23:29:13+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -6798,5 +6902,6 @@
         "ext-json": "*",
         "ext-openssl": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR updates `csharpru/vault-php` to ^4.

### Description


In versions below  ^4 `csharpru/vault-php` requires cache/cache. The repo for that package clearly states:

> This library is for development use.

In addition, the composer.json for cache/cache has conflicts with all individual cache adapters (see https://github.com/php-cache/cache/blob/master/composer.json), which causes all packages that correctly use these adapters to conflict with `cache/cache`, `csharpru/vault-php` and `magento/magento2-functional-testing-framework`. Essentially no M2 installs may follow the intended best practices as described by the php-cache team.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests