### PR TITLE
MQE-2150: group value "skip" no longer causes test to be skipped

### DIFF
--- a/dev/tests/verification/Resources/GroupSkipGenerationTest.txt
+++ b/dev/tests/verification/Resources/GroupSkipGenerationTest.txt
@@ -13,14 +13,14 @@ use Yandex\Allure\Adapter\Model\SeverityLevel;
 use Yandex\Allure\Adapter\Annotation\TestCaseId;
 
 /**
- * @Title("[NO TESTCASEID]: skippedNoIssuesTest")
- * @Description("<h3>Test files</h3>verification/TestModule/Test/SkippedTest/SkippedTestNoIssues.xml<br>")
+ * @Title("[NO TESTCASEID]: GroupSkipGenerationTestTitle")
+ * @Description("GroupSkipGenerationTestDescription<h3>Test files</h3>verification/TestModule/Test/GroupSkipGenerationTest.xml<br>")
  * @group skip
  */
-class SkippedTestNoIssuesCest
+class GroupSkipGenerationTestCest
 {
 	/**
-	 * @Stories({"skippedNo"})
+	 * @Stories({"GroupSkipGenerationTestStory"})
 	 * @Severity(level = SeverityLevel::MINOR)
 	 * @Features({"TestModule"})
 	 * @Parameter(name = "AcceptanceTester", value="$I")
@@ -28,8 +28,7 @@ class SkippedTestNoIssuesCest
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function SkippedTestNoIssues(AcceptanceTester $I, \Codeception\Scenario $scenario)
+	public function GroupSkipGenerationTest(AcceptanceTester $I)
 	{
-		$scenario->skip("This test is skipped due to the following issues:\nNo issues have been specified.");
 	}
 }

--- a/dev/tests/verification/TestModule/Test/GroupSkipGenerationTest.xml
+++ b/dev/tests/verification/TestModule/Test/GroupSkipGenerationTest.xml
@@ -7,11 +7,11 @@
 -->
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="SkippedTestNoIssues">
+    <test name="GroupSkipGenerationTest">
         <annotations>
-            <stories value="skippedNo"/>
-            <title value="skippedNoIssuesTest"/>
-            <description value=""/>
+            <stories value="GroupSkipGenerationTestStory"/>
+            <title value="GroupSkipGenerationTestTitle"/>
+            <description value="GroupSkipGenerationTestDescription"/>
             <severity value="AVERAGE"/>
             <group value="skip"/>
         </annotations>

--- a/dev/tests/verification/Tests/GroupSkipGenerationTest.php
+++ b/dev/tests/verification/Tests/GroupSkipGenerationTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace tests\verification\Tests;
+
+use tests\util\MftfTestCase;
+
+class GroupSkipGenerationTest extends MftfTestCase
+{
+    /**
+     * Tests group skip test generation
+     *
+     * @throws \Exception
+     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
+     */
+    public function testGroupSkipGenerationTest()
+    {
+        $this->generateAndCompareTest('GroupSkipGenerationTest');
+    }
+}

--- a/dev/tests/verification/Tests/SkippedGenerationTest.php
+++ b/dev/tests/verification/Tests/SkippedGenerationTest.php
@@ -41,15 +41,4 @@ class SkippedGenerationTest extends MftfTestCase
     {
         $this->generateAndCompareTest('SkippedTestTwoIssues');
     }
-
-    /**
-     * Tests skipped test generation with no specified issues. Will be deprecated after MFTF 3.0.0
-     *
-     * @throws \Exception
-     * @throws \Magento\FunctionalTestingFramework\Exceptions\TestReferenceException
-     */
-    public function testSkippedNoIssueGeneration()
-    {
-        $this->generateAndCompareTest('SkippedTestNoIssues');
-    }
 }

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -35,7 +35,7 @@ To add a `<test>`, create a new `*Test.xml` file or add a `<test>` node to an ex
 ## Remove a test
 
 Tests cannot be removed while merging.
-If a [`<test>`][tests] must be skipped due to a module completely invalidating a function, you can add the test to the `skip` group.
+If a [`<test>`][tests] must be skipped due to a module completely invalidating a function, you can use `skip` annotation to skip the test.
 
 Learn more about running tests with different options using [`mftf`] or [`codecept`] commands.
 

--- a/docs/suite.md
+++ b/docs/suite.md
@@ -46,7 +46,7 @@ The format of a suite:
     -  must not match any existing group value.
   For example, the suite `<suite name="ExampleTest">` will fail during test run if any test contains in annotations `<group value="ExampleTest">`.
     -  must not be `default` or `skip`. Tests that are not in any suite are generated under the `default` suite.
-       The suite name `skip` is synonymous to including a test in the `<group value="skip"/>`, which will be deprecated in MFTF 3.0.0.
+       The suite name `skip` is synonymous to including a test in the `<group value="skip"/>`.
     -  can contain letters, numbers, and underscores.
     -  should be upper camel case.
     

--- a/docs/test/annotations.md
+++ b/docs/test/annotations.md
@@ -87,7 +87,7 @@ Add `<skip>` to the test to skip it during test run.
 
 Attribute|Type|Use|Definition
 ---|---|---|---
-`value`|string|required|A value that is used to group tests. It should be lower case. `skip` is reserved to ignore content of the test and generate an empty test.
+`value`|string|required|A value that is used to group tests. It should be lower case.
 
 #### Example
 

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -161,10 +161,7 @@ class TestObject
      */
     public function isSkipped()
     {
-        // TODO deprecation|deprecate MFTF 3.0.0 remove elseif when group skip is no longer allowed
         if (array_key_exists('skip', $this->annotations)) {
-            return true;
-        } elseif (array_key_exists('group', $this->annotations) && (in_array("skip", $this->annotations['group']))) {
             return true;
         }
         return false;

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -92,13 +92,6 @@ class AnnotationExtractor extends BaseObjectExtractor
             foreach ($annotationData as $annotationValue) {
                 $annotationValues[] = $annotationValue[self::ANNOTATION_VALUE];
             }
-            // TODO deprecation|deprecate MFTF 3.0.0
-            if ($annotationKey == "group" && in_array("skip", $annotationValues)) {
-                LoggingUtil::getInstance()->getLogger(AnnotationExtractor::class)->warning(
-                    "Use of group skip will be deprecated in MFTF 3.0.0. Please update tests to use skip tags.",
-                    ["test" => $filename]
-                );
-            }
 
             $annotationObjects[$annotationKey] = $annotationValues;
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests