### PR TITLE
MQE-2161: Chrome 81 requires --ignore-certificate-errors flag

### DIFF
--- a/etc/config/functional.suite.dist.yml
+++ b/etc/config/functional.suite.dist.yml
@@ -37,4 +37,4 @@ modules:
             capabilities:
                 unhandledPromptBehavior: "ignore"
                 chromeOptions:
-                    args: ["--window-size=1280,1024", "--disable-extensions", "--enable-automation", "--disable-gpu", "--enable-Passthrough", "--disable-dev-shm-usage"]
+                    args: ["--window-size=1280,1024", "--disable-extensions", "--enable-automation", "--disable-gpu", "--enable-Passthrough", "--disable-dev-shm-usage", "--ignore-certificate-errors"]


### PR DESCRIPTION
This is required for Chrome 81.
It is also safe for Chrome 65 because Chrome 65 already launches with this new flag in Jenkins. Mike helped me confirm that.