### PR TITLE
MQE-2289: Cant generate urn catalog

### DIFF
--- a/docs/commands/mftf.md
+++ b/docs/commands/mftf.md
@@ -245,10 +245,10 @@ It also enables auto-completion in PhpStorm.
 #### Usage
 
 ```bash
-vendor/bin/mftf generate:urn-catalog [--force] [<path to the directory with misc.xml>]
+vendor/bin/mftf generate:urn-catalog [--force] [<path to misc.xml>]
 ```
 
-`misc.xml` is typically located in `<project root>/.idea/`.
+`misc.xml` is typically located at `<project root>/.idea/misc.xml`.
 
 #### Options
 
@@ -259,7 +259,7 @@ vendor/bin/mftf generate:urn-catalog [--force] [<path to the directory with misc
 #### Example
 
 ```bash
-vendor/bin/mftf generate:urn-catalog .idea/
+vendor/bin/mftf generate:urn-catalog .idea/misc.xml
 ```
 
 ### `reset`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,13 +170,13 @@ vendor/bin/mftf build:project
 If you use PhpStorm, generate a URN catalog:
 
 ```bash
-vendor/bin/mftf generate:urn-catalog .idea/
+vendor/bin/mftf generate:urn-catalog .idea/misc.xml
 ```
 
 If the file does not exist, add the `--force` option to create it:
 
 ```bash
-vendor/bin/mftf generate:urn-catalog --force .idea/
+vendor/bin/mftf generate:urn-catalog --force .idea/misc.xml
 ```
 
 See [`generate:urn-catalog`][] for more details.

--- a/docs/update.md
+++ b/docs/update.md
@@ -39,7 +39,7 @@ Takes place when **first** digit of version number changes.
 
 ## After updating
 
-1. It is a good idea to regenerate your IDE Schema Definition catalog with `vendor/bin/mftf generate:urn-catalog .idea/`
+1. It is a good idea to regenerate your IDE Schema Definition catalog with `vendor/bin/mftf generate:urn-catalog .idea/misc.xml`
 1. Update your tests, including data, metadata and other resources. Check if they contain tags that are unsupported in the newer version.
 1. Remove the references to resources (ActionGroups, Sections, Tests) marked as deprecated.
 


### PR DESCRIPTION
Fixes documentation to have correct `generate:urn-catalog` examples.