### PR TITLE
Enable an extending entity to overwrite a requiredEntity binding

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
@@ -477,7 +477,6 @@ class OperationDataArrayResolverTest extends MagentoTestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-
     public function testExtendedWithRequiredEntity()
     {
         $entityDataObjectBuilder = new EntityDataObjectBuilder();
@@ -517,7 +516,12 @@ class OperationDataArrayResolverTest extends MagentoTestCase
             ->build();
 
         $operationResolver = new OperationDataArrayResolver();
-        $result = $operationResolver->resolveOperationDataArray($extEntityDataObject,[$subentityOpElement], "create", false);
+        $result = $operationResolver->resolveOperationDataArray(
+            $extEntityDataObject,
+            [$subentityOpElement],
+            "create",
+            false
+        );
 
         $expected = [
             "sub" => [
@@ -526,7 +530,6 @@ class OperationDataArrayResolverTest extends MagentoTestCase
         ];
 
         $this->assertEquals($expected, $result);
-
     }
     /**
      * After class functionality

--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
@@ -477,6 +477,57 @@ class OperationDataArrayResolverTest extends MagentoTestCase
         $this->assertEquals($expectedResult, $result);
     }
 
+
+    public function testExtendedWithRequiredEntity()
+    {
+        $entityDataObjectBuilder = new EntityDataObjectBuilder();
+        $extEntityDataObject = $entityDataObjectBuilder
+            ->withName("extEntity")
+            ->withType("entity")
+            ->withLinkedEntities(["baseSubentity" => "subentity","extSubentity" => "subentity"])
+            ->build();
+
+        $mockDOHInstance = AspectMock::double(DataObjectHandler::class, ["getObject" => function ($name) {
+            $entityDataObjectBuilder = new EntityDataObjectBuilder();
+
+            if ($name == "baseSubentity") {
+                return $entityDataObjectBuilder
+                    ->withName("baseSubentity")
+                    ->withType("subentity")
+                    ->withDataFields(["subtest" => "BaseSubtest"])
+                    ->build();
+            }
+
+            if ($name == "extSubentity") {
+                return $entityDataObjectBuilder
+                    ->withName("extSubentity")
+                    ->withType("subentity")
+                    ->withDataFields(["subtest" => "ExtSubtest"])
+                    ->build();
+            }
+        }])->make();
+        AspectMock::double(DataObjectHandler::class, ['getInstance' => $mockDOHInstance]);
+
+        $subentityOpElementBuilder = new OperationElementBuilder();
+        $subentityOpElement = $subentityOpElementBuilder
+            ->withKey("sub")
+            ->withType("subentity")
+            ->withElementType("object")
+            ->withFields(["subtest" => "string"])
+            ->build();
+
+        $operationResolver = new OperationDataArrayResolver();
+        $result = $operationResolver->resolveOperationDataArray($extEntityDataObject,[$subentityOpElement], "create", false);
+
+        $expected = [
+            "sub" => [
+                "subtest" => "ExtSubtest"
+            ]
+        ];
+
+        $this->assertEquals($expected, $result);
+
+    }
     /**
      * After class functionality
      * @return void

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
@@ -245,10 +245,11 @@ class OperationDataArrayResolver
     private function resolveOperationObjectAndEntityData($entityObject, $operationElementValue)
     {
         if ($operationElementValue != $entityObject->getType()) {
-            // if we have a mismatch attempt to retrieve linked data and return just the first linkage
+            // if we have a mismatch attempt to retrieve linked data and return just the last linkage
+            // this enables overwriting of required entity fields
             $linkName = $entityObject->getLinkedEntitiesOfType($operationElementValue);
             if (!empty($linkName)) {
-                $linkName = $linkName[0];
+                $linkName = array_pop($linkName);
                 return DataObjectHandler::getInstance()->getObject($linkName);
             }
             return null;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
In case you extend an entity that has a requiredEntity and add a requiredEntity of the same type, then the requiredEntity of the
base entity is used.
This pull request changes this behaviour, so that the last requiredEntity of that specific type is used. This enables you to change
the content of a requiredEntity when extending an entity.

#### Sample
```xml
<entity name="BaseEntity" type="entity">
    <data key="test">Test</data>
    <requiredEntity type="subentity">BaseSubentity</requiredEntity>
</entity>
<entity name="BaseSubentity" type="subentity">
    <data key="subtest">BaseSubtest</data>
</entity>

<entity name="ExtEntity" type="entity" extends="BaseEntity">
    <requiredEntity type="subentity">ExtSubentity</requiredEntity>
</entity>
<entity name="ExtSubentity" type="subentity">
     <data key="subtest">ExtSubtest</data>
</entity>
```

##### Old Result for ExtEntity

```json
{
  "entity" : {
    "test" : "Test",
    "sub" : {
       "subtest" : "BaseSubtest"
    }  
  }
}
```

##### New Result for ExtEntity

```json
{
  "entity" : {
    "test" : "Test",
    "sub" : {
       "subtest" : "ExtSubtest"
    }  
  }
}
```

### Fixed Issues (if relevant)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests