### PR TITLE
Add ability to configure multiple OTPs

### DIFF
--- a/dev/tests/verification/Resources/BasicFunctionalTest.txt
+++ b/dev/tests/verification/Resources/BasicFunctionalTest.txt
@@ -113,6 +113,7 @@ class BasicFunctionalTestCest
 		$generateDateKey2 = $date->format("H:i:s");
 
 		$getOtp = $I->getOTP(); // stepKey: getOtp
+		$getOtpWithInput = $I->getOTP("someInput"); // stepKey: getOtpWithInput
 		$grabAttributeFromKey1 = $I->grabAttributeFrom(".functionalTestSelector", "someInput"); // stepKey: grabAttributeFromKey1
 		$grabCookieKey1 = $I->grabCookie("grabCookieInput", ['domain' => 'www.google.com']); // stepKey: grabCookieKey1
 		$grabFromCurrentUrlKey1 = $I->grabFromCurrentUrl("/grabCurrentUrl"); // stepKey: grabFromCurrentUrlKey1

--- a/dev/tests/verification/TestModule/Test/BasicFunctionalTest/BasicFunctionalTest.xml
+++ b/dev/tests/verification/TestModule/Test/BasicFunctionalTest/BasicFunctionalTest.xml
@@ -69,6 +69,7 @@
         <generateDate date="Now" format="H:i:s" stepKey="generateDateKey"/>
         <generateDate date="Now" format="H:i:s" stepKey="generateDateKey2" timezone="UTC"/>
         <getOTP stepKey="getOtp"/>
+        <getOTP stepKey="getOtpWithInput" userInput="someInput"/>
         <grabAttributeFrom selector=".functionalTestSelector" userInput="someInput" stepKey="grabAttributeFromKey1" />
         <grabCookie userInput="grabCookieInput" parameterArray="['domain' => 'www.google.com']" stepKey="grabCookieKey1" />
         <grabFromCurrentUrl regex="/grabCurrentUrl" stepKey="grabFromCurrentUrlKey1" />

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -970,12 +970,13 @@ class MagentoWebDriver extends WebDriver
     /**
      * Return OTP based on a shared secret
      *
+     * @param string|null $secretsPath
      * @return string
      * @throws TestFrameworkException
      */
-    public function getOTP()
+    public function getOTP($secretsPath = null)
     {
-        return OTP::getOTP();
+        return OTP::getOTP($secretsPath);
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Test/etc/Actions/customActions.xsd
+++ b/src/Magento/FunctionalTestingFramework/Test/etc/Actions/customActions.xsd
@@ -335,6 +335,7 @@
         </xs:annotation>
         <xs:simpleContent>
             <xs:extension base="xs:string">
+                <xs:attribute ref="userInput"/>
                 <xs:attributeGroup ref="commonActionAttributes"/>
             </xs:extension>
         </xs:simpleContent>

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -1262,7 +1262,8 @@ class TestGenerator
                     $testSteps .= $this->wrapFunctionCallWithReturnValue(
                         $stepKey,
                         $actor,
-                        $actionObject
+                        $actionObject,
+                        $input
                     );
                     break;
                 case "resizeWindow":


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Improve Extendability of OTP implementation. 

The current implementation of the OTP works well for use with Magento's admin. It can even be used for other use cases. What is not possible in its current form is accessing multiple OTPs within the same test run. This is for example needed when trying to configure a Magento admin setting based on a value provided by a 3rd party also behind a 2FA.

Even changing the shared secret on the fly with something like   `<magentoCLI command="security:tfa:google:set-secret admin {{_CREDS.fooman/other/OTP_SHARED_SECRET}}" stepKey="setSecret"/>`  
does not work as the OTP is only initialised once.

This PR allows providing a separate secret 
`<getOTP stepKey="getOtherOtp" userInput="fooman/other/OTP_SHARED_SECRET"/>`  
with  
`<getOTP stepKey="getOtp" />`  
retaining the default implementation for Magento's Admin 2FA.

### Fixed Issues (if relevant)
1. N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests