### PR TITLE
Updated monolog/monolog to ^2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "csharpru/vault-php": "^4.1.0",
         "csharpru/vault-php-guzzle6-transport": "^2.0",
         "hoa/console": "~3.0",
-        "monolog/monolog": "^1.17",
+        "monolog/monolog": "^2.2",
         "mustache/mustache": "~2.5",
         "php-webdriver/webdriver": "^1.8.0",
         "spomky-labs/otphp": "^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec8d82a1a84dbf04502a26273da1cb0f",
+    "content-hash": "e37470453c311fc07a216b38b43e9e50",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",
@@ -2626,21 +2626,21 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.26.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "2209ddd84e7ef1256b7af205d0717fb62cfc9c33"
+                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/2209ddd84e7ef1256b7af205d0717fb62cfc9c33",
-                "reference": "2209ddd84e7ef1256b7af205d0717fb62cfc9c33",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
+                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
+                "php": ">=7.2",
+                "psr/log": "^1.0.1"
             },
             "provide": {
                 "psr/log-implementation": "1.0.0"
@@ -2648,29 +2648,39 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
+                "elasticsearch/elasticsearch": "^7",
+                "graylog2/gelf-php": "^1.4.2",
+                "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
+                "phpspec/prophecy": "^1.6.1",
                 "phpstan/phpstan": "^0.12.59",
-                "phpunit/phpunit": "~4.5",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90 <7.0.1",
                 "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                 "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Monolog\\": "src/Monolog"
@@ -2684,11 +2694,11 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
+            "homepage": "https://github.com/Seldaek/monolog",
             "keywords": [
                 "log",
                 "logging",
@@ -2696,7 +2706,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/1.26.0"
+                "source": "https://github.com/Seldaek/monolog/tree/2.2.0"
             },
             "funding": [
                 {
@@ -2708,7 +2718,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-14T12:56:38+00:00"
+            "time": "2020-12-14T13:15:25+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
@@ -210,7 +210,7 @@ class Filesystem implements \Magento\FunctionalTestingFramework\Config\ReaderInt
     {
         if (empty($content)) {
             if (MftfApplicationConfig::getConfig()->verboseEnabled()) {
-                LoggingUtil::getInstance()->getLogger(Filesystem::class)->warn(
+                LoggingUtil::getInstance()->getLogger(Filesystem::class)->warning(
                     "XML File is empty.",
                     ["File" => $fileName]
                 );

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/PersistedObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/PersistedObjectHandler.php
@@ -193,7 +193,7 @@ class PersistedObjectHandler
             $warnMsg = "Undefined field {$field} in entity object with a stepKey of {$stepKey}\n";
             $warnMsg .= "Please fix the invalid reference. This will result in fatal error in next major release.";
             //TODO: change this to throw an exception in next major release
-            LoggingUtil::getInstance()->getLogger(PersistedObjectHandler::class)->warn($warnMsg);
+            LoggingUtil::getInstance()->getLogger(PersistedObjectHandler::class)->warning($warnMsg);
             if (MftfApplicationConfig::getConfig()->verboseEnabled()
                 && MftfApplicationConfig::getConfig()->getPhase() !== MftfApplicationConfig::UNIT_TEST_PHASE) {
                 print("\n$warnMsg\n");

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionObjectExtractor.php
@@ -305,7 +305,7 @@ class ActionObjectExtractor extends BaseObjectExtractor
         });
 
         foreach ($atRiskStepRef as $stepKey => $stepRefs) {
-            LoggingUtil::getInstance()->getLogger(ActionObjectExtractor::class)->warn(
+            LoggingUtil::getInstance()->getLogger(ActionObjectExtractor::class)->warning(
                 'multiple actions referencing step key',
                 ['test' => $testName, 'stepKey' => $stepKey, 'ref' => $stepRefs]
             );

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -585,7 +585,7 @@ class ModuleResolver
         } else {
             $warnMsg = 'Path: ' . $value . ' is ignored by ModuleResolver. ' . PHP_EOL . 'Path: ';
             $warnMsg .= $inArray[$index] . ' is set for Module: ' . $index . PHP_EOL;
-            LoggingUtil::getInstance()->getLogger(ModuleResolver::class)->warn($warnMsg);
+            LoggingUtil::getInstance()->getLogger(ModuleResolver::class)->warning($warnMsg);
         }
         return $outArray;
     }

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -362,7 +362,7 @@ class TestGenerator
                         if (MftfApplicationConfig::getConfig()->verboseEnabled()) {
                             print("NOTICE: {$errMessage}");
                         }
-                        LoggingUtil::getInstance()->getLogger(self::class)->warn($errMessage);
+                        LoggingUtil::getInstance()->getLogger(self::class)->warning($errMessage);
                         continue;
                     }
                 }


### PR DESCRIPTION
### Description

Updated monolog/monolog to `^2.2` as part of the "Platform Health" updates in the main repo.

### Related Pull Requests

- https://github.com/magento/magento2/pull/33226
- https://github.com/magento/partners-magento2ee/pull/555

### Fixed Issues

- https://github.com/magento/magento2/issues/32868

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests