### PR TITLE
Eliminated Aspect Mock usage from FilesystemTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Config/Reader/FilesystemTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Config/Reader/FilesystemTest.php
@@ -3,20 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Magento\FunctionalTestFramework\Config\Reader;
 
+use Magento\FunctionalTestingFramework\Config\ConverterInterface;
 use Magento\FunctionalTestingFramework\Config\FileResolver\Module;
 use Magento\FunctionalTestingFramework\Config\Reader\Filesystem;
+use Magento\FunctionalTestingFramework\Config\SchemaLocatorInterface;
 use Magento\FunctionalTestingFramework\Config\ValidationState;
 use Magento\FunctionalTestingFramework\Util\Iterator\File;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use AspectMock\Test as AspectMock;
 use tests\unit\Util\TestLoggingUtil;
 
 class FilesystemTest extends TestCase
 {
     /**
-     * Before test functionality
      * @return void
      */
     public function setUp(): void
@@ -25,79 +28,80 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * Test Reading Empty Files
      * @throws \Exception
      */
     public function testEmptyXmlFile()
     {
-        // create mocked items and read the file
-        $someFile = $this->setMockFile("somepath.xml", "");
-        $filesystem = $this->createPseudoFileSystem($someFile);
-        $filesystem->read();
+        $filesystem = $this->getFilesystem($this->getFileIterator('somepath.xml', ''));
+        $this->assertEquals([], $filesystem->read());
 
-        // validate log statement
         TestLoggingUtil::getInstance()->validateMockLogStatement(
-            "warning",
-            "XML File is empty.",
-            ["File" => "somepath.xml"]
+            'warning',
+            'XML File is empty.',
+            ['File' => 'somepath.xml']
         );
     }
 
     /**
-     * Function used to set mock for File created in test
+     * Retrieve mocked file iterator
      *
      * @param string $fileName
      * @param string $content
-     * @return object
+     * @return File|MockObject
      * @throws \Exception
      */
-    public function setMockFile($fileName, $content)
+    public function getFileIterator(string $fileName, string $content): File
     {
-        $file = AspectMock::double(
-            File::class,
-            [
-                'current' => "",
-                'count' => 1,
-                'getFilename' => $fileName
-            ]
-        )->make();
+        $iterator = new \ArrayIterator([$content]);
 
-        //set mocked data property for File
-        $property = new \ReflectionProperty(File::class, 'data');
-        $property->setAccessible(true);
-        $property->setValue($file, [$fileName => $content]);
+        $file = $this->createMock(File::class);
+
+        $file->method('current')
+            ->willReturn($content);
+        $file->method('getFilename')
+            ->willReturn($fileName);
+        $file->method('count')
+            ->willReturn(1);
+
+        $file->method('next')
+            ->willReturnCallback(function () use ($iterator): void {
+                $iterator->next();
+            });
+
+        $file->method('valid')
+            ->willReturnCallback(function () use ($iterator): bool {
+                return $iterator->valid();
+            });
 
         return $file;
     }
 
     /**
-     * Function used to set mock for filesystem class during test
+     * Get real instance of Filesystem class with mocked dependencies
      *
-     * @param string $fileList
-     * @return object
-     * @throws \Exception
+     * @param File $fileIterator
+     * @return Filesystem
      */
-    public function createPseudoFileSystem($fileList)
+    public function getFilesystem(File $fileIterator): Filesystem
     {
-        $filesystem = AspectMock::double(Filesystem::class)->make();
-
-        //set resolver to use mocked resolver
-        $mockFileResolver = AspectMock::double(Module::class, ['get' => $fileList])->make();
-        $property = new \ReflectionProperty(Filesystem::class, 'fileResolver');
-        $property->setAccessible(true);
-        $property->setValue($filesystem, $mockFileResolver);
-
-        //set validator to use mocked validator
-        $mockValidation = AspectMock::double(ValidationState::class, ['isValidationRequired' => false])->make();
-        $property = new \ReflectionProperty(Filesystem::class, 'validationState');
-        $property->setAccessible(true);
-        $property->setValue($filesystem, $mockValidation);
+        $fileResolver = $this->createMock(Module::class);
+        $fileResolver->method('get')
+            ->willReturn($fileIterator);
+        $validationState = $this->createMock(ValidationState::class);
+        $validationState->method('isValidationRequired')
+            ->willReturn(false);
+        $filesystem = new Filesystem(
+            $fileResolver,
+            $this->createMock(ConverterInterface::class),
+            $this->createMock(SchemaLocatorInterface::class),
+            $validationState,
+            ''
+        );
 
         return $filesystem;
     }
 
     /**
-     * After class functionality
      * @return void
      */
     public static function tearDownAfterClass(): void

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
@@ -148,7 +148,7 @@ class Filesystem implements \Magento\FunctionalTestingFramework\Config\ReaderInt
         /** @var \Magento\FunctionalTestingFramework\Config\Dom $configMerger */
         $configMerger = null;
         $debugLevel = MftfApplicationConfig::getConfig()->getDebugLevel();
-        foreach ($fileList as $key => $content) {
+        foreach ($fileList as $content) {
             //check if file is empty and continue to next if it is
             if (!$this->verifyFileEmpty($content, $fileList->getFilename())) {
                 continue;


### PR DESCRIPTION
### Goal

`codeception/aspect-mock` library is still not compatible with PHP 8.0 at the time of the creation of this ticket.

To speed up Magento compatibility with new PHP versions we'd like to eliminate `codeception/aspect-mock` dependency from MFTF. This will make MFTF compatible with PHP 8.0 that is required for declaring the Magento core PHP 8 compatible as well.

In order to do this existing unit tests using AspectMock should be refactored to use PHPUnit instead.

### Task

Resolves https://github.com/magento/magento2/issues/33291

Replace AspectMock with PHPUnit for `dev/tests/unit/Magento/FunctionalTestFramework/Config/Reader/FilesystemTest.php` in https://github.com/magento/magento2-functional-testing-framework repository.

### Example

Mocking an object using AspectMock (current):

```
        $mock = AspectMock::double(
            MockedClass::class,
            [
                'mockedMethodName' => 'methodReturnValue',
            ]
        )->make();
```

Mocking an object using PHPUnit (refactored code):

```
        $mock = $this->createMock(File::class);
        $file->expects($this->any())
            ->method('mockedMethodName')
            ->willReturn('methodReturnValue');
```
