### PR TITLE
Removed usage of AspectMock in DeprecatedEntityUsageCheckTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/StaticCheck/DeprecatedEntityUsageCheckTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/StaticCheck/DeprecatedEntityUsageCheckTest.php
@@ -6,7 +6,6 @@
 
 namespace tests\unit\Magento\FunctionalTestFramework\StaticCheck;
 
-use AspectMock\Test as AspectMock;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\OperationDefinitionObjectHandler;
 use Magento\FunctionalTestingFramework\DataGenerator\Objects\EntityDataObject;
 use Magento\FunctionalTestingFramework\Page\Objects\ElementObject;
@@ -32,11 +31,6 @@ class DeprecatedEntityUsageCheckTest extends MagentoTestCase
     {
         $this->staticCheck = new DeprecatedEntityUsageCheck();
         $this->staticCheckClass = new \ReflectionClass($this->staticCheck);
-    }
-
-    public function tearDown(): void
-    {
-        AspectMock::clean();
     }
 
     public function testInvalidPathOption()


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Removed usage of AspectMock in `\tests\unit\Magento\FunctionalTestFramework\StaticCheck\DeprecatedEntityUsageCheckTest`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/33298

Resolves https://github.com/magento/magento2/issues/33298

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests