### PR TITLE
33294 eliminate aspectmock from allureHelperTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Allure/AllureHelperTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Allure/AllureHelperTest.php
@@ -106,7 +106,6 @@ class AllureHelperTest extends TestCase
     {
         $expectedData = 'string';
         $expectedCaption = 'caption';
-        $this->mockCopyFile($expectedData, $expectedCaption);
 
         //Prepare Allure lifecycle
         Allure::lifecycle()->fire(new StepStartedEvent('firstStep'));
@@ -141,31 +140,6 @@ class AllureHelperTest extends TestCase
         $mockInstance
             ->method('getAttachmentFileName')
             ->willReturn(self::MOCK_FILENAME);
-
-        $instanceProperty = new ReflectionProperty(AddUniqueAttachmentEvent::class, 'instance');
-        $instanceProperty->setAccessible(true);
-        $instanceProperty->setValue($mockInstance, $mockInstance);
-    }
-
-    /**
-     * Mock only file writing mechanism.
-     *
-     * @param string $filePathOrContents
-     * @param string $caption
-     *
-     * @return void
-     */
-    private function mockCopyFile(string $filePathOrContents, string $caption): void
-    {
-        $mockInstance = $this->getMockBuilder(AddUniqueAttachmentEvent::class)
-            ->setConstructorArgs([$filePathOrContents, $caption])
-            ->disallowMockingUnknownTypes()
-            ->onlyMethods(['copyFile'])
-            ->getMock();
-
-        $mockInstance
-            ->method('copyFile')
-            ->willReturn(true);
 
         $instanceProperty = new ReflectionProperty(AddUniqueAttachmentEvent::class, 'instance');
         $instanceProperty->setAccessible(true);

--- a/src/Magento/FunctionalTestingFramework/Allure/AllureHelper.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/AllureHelper.php
@@ -3,34 +3,40 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\FunctionalTestingFramework\Allure;
 
 use Magento\FunctionalTestingFramework\Allure\Event\AddUniqueAttachmentEvent;
 use Yandex\Allure\Adapter\Allure;
-use Yandex\Allure\Adapter\Event\AddAttachmentEvent;
+use Yandex\Allure\Adapter\AllureException;
 
 class AllureHelper
 {
     /**
-     * Adds attachment to the current step
+     * Adds attachment to the current step.
+     *
      * @param mixed  $data
      * @param string $caption
-     * @throws \Yandex\Allure\Adapter\AllureException
+     *
      * @return void
+     * @throws AllureException
      */
-    public static function addAttachmentToCurrentStep($data, $caption)
+    public static function addAttachmentToCurrentStep($data, $caption): void
     {
-        Allure::lifecycle()->fire(new AddUniqueAttachmentEvent($data, $caption));
+        Allure::lifecycle()->fire(AddUniqueAttachmentEvent::getInstance($data, $caption));
     }
 
     /**
      * Adds Attachment to the last executed step.
      * Use this when adding attachments outside of an $I->doSomething() step/context.
+     *
      * @param mixed  $data
      * @param string $caption
+     *
      * @return void
      */
-    public static function addAttachmentToLastStep($data, $caption)
+    public static function addAttachmentToLastStep($data, $caption): void
     {
         $rootStep = Allure::lifecycle()->getStepStorage()->getLast();
         $trueLastStep = array_last($rootStep->getSteps());
@@ -40,7 +46,7 @@ class AllureHelper
             return;
         }
         
-        $attachmentEvent = new AddUniqueAttachmentEvent($data, $caption);
+        $attachmentEvent = AddUniqueAttachmentEvent::getInstance($data, $caption);
         $attachmentEvent->process($trueLastStep);
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Allure/AllureHelper.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/AllureHelper.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\FunctionalTestingFramework\Allure;
 
 use Magento\FunctionalTestingFramework\Allure\Event\AddUniqueAttachmentEvent;
+use Magento\FunctionalTestingFramework\ObjectManagerFactory;
 use Yandex\Allure\Adapter\Allure;
 use Yandex\Allure\Adapter\AllureException;
 
@@ -24,7 +25,15 @@ class AllureHelper
      */
     public static function addAttachmentToCurrentStep($data, $caption): void
     {
-        Allure::lifecycle()->fire(AddUniqueAttachmentEvent::getInstance($data, $caption));
+        /** @var AddUniqueAttachmentEvent $event */
+        $event = ObjectManagerFactory::getObjectManager()->create(
+            AddUniqueAttachmentEvent::class,
+            [
+                'filePathOrContents' => $data,
+                'caption' => $caption
+            ]
+        );
+        Allure::lifecycle()->fire($event);
     }
 
     /**
@@ -45,8 +54,15 @@ class AllureHelper
             // Nothing to attach to; do not fire off allure event
             return;
         }
-        
-        $attachmentEvent = AddUniqueAttachmentEvent::getInstance($data, $caption);
+
+        /** @var AddUniqueAttachmentEvent $attachmentEvent */
+        $attachmentEvent = ObjectManagerFactory::getObjectManager()->create(
+            AddUniqueAttachmentEvent::class,
+            [
+                'filePathOrContents' => $data,
+                'caption' => $caption
+            ]
+        );
         $attachmentEvent->process($trueLastStep);
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Magento\FunctionalTestingFramework\Allure\Event;
 
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
+use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Symfony\Component\Mime\MimeTypes;
 use Yandex\Allure\Adapter\AllureException;
 use Yandex\Allure\Adapter\Event\AddAttachmentEvent;
@@ -57,19 +59,6 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
     }
 
     /**
-     * Copies file from one path to another. Wrapper for mocking in unit test.
-     *
-     * @param string $filePath
-     * @param string $outputPath
-     *
-     * @return boolean
-     */
-    public function copyFile(string $filePath, string $outputPath): bool
-    {
-        return copy($filePath, $outputPath);
-    }
-
-    /**
      * Unit test helper function.
      *
      * @param mixed       $filePathOrContents
@@ -91,6 +80,23 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
             );
         }
         return self::$instance;
+    }
+
+    /**
+     * Copies file from one path to another. Wrapper for mocking in unit test.
+     *
+     * @param string $filePath
+     * @param string $outputPath
+     *
+     * @return boolean
+     * @throws TestFrameworkException
+     */
+    private function copyFile(string $filePath, string $outputPath): bool
+    {
+        if (MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::UNIT_TEST_PHASE) {
+            return true;
+        }
+        return copy($filePath, $outputPath);
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
@@ -31,7 +31,7 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
     {
         $filePath = $filePathOrContents;
 
-        if (!file_exists($filePath) || !is_file($filePath)) {
+        if (!is_string($filePath) || !file_exists($filePath) || !is_file($filePath)) {
             //Save contents to temporary file
             $filePath = tempnam(sys_get_temp_dir(), 'allure-attachment');
             if (!file_put_contents($filePath, $filePathOrContents)) {

--- a/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
@@ -19,11 +19,6 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
     private const DEFAULT_MIME_TYPE = 'text/plain';
 
     /**
-     * @var AddUniqueAttachmentEvent|null
-     */
-    private static $instance;
-
-    /**
      * Near copy of parent function, added uniqid call for filename to prevent buggy allure behavior.
      *
      * @param mixed  $filePathOrContents
@@ -56,30 +51,6 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
         }
 
         return $this->getOutputFileName($fileSha1, $fileExtension);
-    }
-
-    /**
-     * Unit test helper function.
-     *
-     * @param mixed       $filePathOrContents
-     * @param string      $caption
-     * @param string|null $type
-     *
-     * @return AddUniqueAttachmentEvent
-     */
-    public static function getInstance(
-        $filePathOrContents,
-        string $caption,
-        ?string $type = null
-    ): AddUniqueAttachmentEvent {
-        if (!self::$instance) {
-            self::$instance = new AddUniqueAttachmentEvent(
-                $filePathOrContents,
-                $caption,
-                $type
-            );
-        }
-        return self::$instance;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Event/AddUniqueAttachmentEvent.php
@@ -22,30 +22,6 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
     private static $instance;
 
     /**
-     * An alternative way to instantiate an instance of this class. Used to mock this class object in unit tests.
-     *
-     * @param mixed       $filePathOrContents
-     * @param string      $caption
-     * @param string|null $type
-     *
-     * @return AddUniqueAttachmentEvent
-     */
-    public static function getInstance(
-        $filePathOrContents,
-        string $caption,
-        ?string $type = null
-    ): AddUniqueAttachmentEvent {
-        if (!self::$instance) {
-            self::$instance = new AddUniqueAttachmentEvent(
-                $filePathOrContents,
-                $caption,
-                $type
-            );
-        }
-        return self::$instance;
-    }
-
-    /**
      * Near copy of parent function, added uniqid call for filename to prevent buggy allure behavior.
      *
      * @param mixed  $filePathOrContents
@@ -91,6 +67,30 @@ class AddUniqueAttachmentEvent extends AddAttachmentEvent
     public function copyFile(string $filePath, string $outputPath): bool
     {
         return copy($filePath, $outputPath);
+    }
+
+    /**
+     * Unit test helper function.
+     *
+     * @param mixed       $filePathOrContents
+     * @param string      $caption
+     * @param string|null $type
+     *
+     * @return AddUniqueAttachmentEvent
+     */
+    public static function getInstance(
+        $filePathOrContents,
+        string $caption,
+        ?string $type = null
+    ): AddUniqueAttachmentEvent {
+        if (!self::$instance) {
+            self::$instance = new AddUniqueAttachmentEvent(
+                $filePathOrContents,
+                $caption,
+                $type
+            );
+        }
+        return self::$instance;
     }
 
     /**


### PR DESCRIPTION
### Description
Eliminate AspectMock usage from `dev/tests/unit/Magento/FunctionalTestFramework/Allure/AllureHelperTest.php`

### Fixed Issues
1. magento/magento2#33294: [MFTF] Eliminate AspectMock from AllureHelperTest (Complex!) #33294

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests