### PR TITLE
33292 replace AspectMock from BaseGenerateCommandTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php
@@ -5,7 +5,6 @@
  */
 namespace tests\unit\Magento\FunctionalTestFramework\Console;
 
-use AspectMock\Test as AspectMock;
 use PHPUnit\Framework\TestCase;
 use Magento\FunctionalTestingFramework\Console\BaseGenerateCommand;
 use Magento\FunctionalTestingFramework\Suite\Objects\SuiteObject;
@@ -15,11 +14,6 @@ use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 
 class BaseGenerateCommandTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        AspectMock::clean();
-    }
-
     public function testOneTestOneSuiteConfig()
     {
         $testOne = new TestObject('Test1', [], [], []);
@@ -182,13 +176,25 @@ class BaseGenerateCommandTest extends TestCase
      */
     public function mockHandlers($testArray, $suiteArray)
     {
-        AspectMock::double(TestObjectHandler::class, ['initTestData' => ''])->make();
+        $testObjectHandler = TestObjectHandler::getInstance();
+        $reflection = new \ReflectionClass(TestObjectHandler::class);
+        $reflectionMethod = $reflection->getMethod('initTestData');
+        $reflectionMethod->setAccessible(true);
+        $output = $reflectionMethod->invoke($testObjectHandler);
+        $this->assertEquals('', $output);
+
         $handler = TestObjectHandler::getInstance();
         $property = new \ReflectionProperty(TestObjectHandler::class, 'tests');
         $property->setAccessible(true);
         $property->setValue($handler, $testArray);
 
-        AspectMock::double(SuiteObjectHandler::class, ['initSuiteData' => ''])->make();
+        $suiteObjectHandler = SuiteObjectHandler::getInstance();
+        $reflection = new \ReflectionClass(SuiteObjectHandler::class);
+        $reflectionMethod = $reflection->getMethod('initSuiteData');
+        $reflectionMethod->setAccessible(true);
+        $output = $reflectionMethod->invoke($suiteObjectHandler);
+        $this->assertEquals('', $output);
+
         $handler = SuiteObjectHandler::getInstance();
         $property = new \ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');
         $property->setAccessible(true);

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php
@@ -14,6 +14,18 @@ use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 
 class BaseGenerateCommandTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        $handler = TestObjectHandler::getInstance();
+        $property = new \ReflectionProperty(TestObjectHandler::class, 'tests');
+        $property->setAccessible(true);
+        $property->setValue($handler, []);
+
+        $handler = SuiteObjectHandler::getInstance();
+        $property = new \ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');
+        $property->setAccessible(true);
+        $property->setValue($handler, []);
+    }
     public function testOneTestOneSuiteConfig()
     {
         $testOne = new TestObject('Test1', [], [], []);
@@ -176,24 +188,10 @@ class BaseGenerateCommandTest extends TestCase
      */
     public function mockHandlers($testArray, $suiteArray)
     {
-        $testObjectHandler = TestObjectHandler::getInstance();
-        $reflection = new \ReflectionClass(TestObjectHandler::class);
-        $reflectionMethod = $reflection->getMethod('initTestData');
-        $reflectionMethod->setAccessible(true);
-        $output = $reflectionMethod->invoke($testObjectHandler);
-        $this->assertEquals('', $output);
-
         $handler = TestObjectHandler::getInstance();
         $property = new \ReflectionProperty(TestObjectHandler::class, 'tests');
         $property->setAccessible(true);
         $property->setValue($handler, $testArray);
-
-        $suiteObjectHandler = SuiteObjectHandler::getInstance();
-        $reflection = new \ReflectionClass(SuiteObjectHandler::class);
-        $reflectionMethod = $reflection->getMethod('initSuiteData');
-        $reflectionMethod->setAccessible(true);
-        $output = $reflectionMethod->invoke($suiteObjectHandler);
-        $this->assertEquals('', $output);
 
         $handler = SuiteObjectHandler::getInstance();
         $property = new \ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php
@@ -3,30 +3,46 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Magento\FunctionalTestFramework\Console;
 
-use PHPUnit\Framework\TestCase;
+use Exception;
 use Magento\FunctionalTestingFramework\Console\BaseGenerateCommand;
-use Magento\FunctionalTestingFramework\Suite\Objects\SuiteObject;
 use Magento\FunctionalTestingFramework\Suite\Handlers\SuiteObjectHandler;
-use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
+use Magento\FunctionalTestingFramework\Suite\Objects\SuiteObject;
 use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
+use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
 
 class BaseGenerateCommandTest extends TestCase
 {
-    public function tearDown(): void
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
     {
         $handler = TestObjectHandler::getInstance();
-        $property = new \ReflectionProperty(TestObjectHandler::class, 'tests');
-        $property->setAccessible(true);
-        $property->setValue($handler, []);
+        $testsProperty = new ReflectionProperty(TestObjectHandler::class, 'tests');
+        $testsProperty->setAccessible(true);
+        $testsProperty->setValue($handler, []);
+        $testObjectHandlerProperty = new ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
+        $testObjectHandlerProperty->setAccessible(true);
+        $testObjectHandlerProperty->setValue($handler);
 
         $handler = SuiteObjectHandler::getInstance();
-        $property = new \ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');
-        $property->setAccessible(true);
-        $property->setValue($handler, []);
+        $suiteObjectsProperty = new ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');
+        $suiteObjectsProperty->setAccessible(true);
+        $suiteObjectsProperty->setValue($handler, []);
+        $suiteObjectHandlerProperty = new ReflectionProperty(SuiteObjectHandler::class, 'instance');
+        $suiteObjectHandlerProperty->setAccessible(true);
+        $suiteObjectHandlerProperty->setValue($handler);
     }
-    public function testOneTestOneSuiteConfig()
+
+    public function testOneTestOneSuiteConfig(): void
     {
         $testOne = new TestObject('Test1', [], [], []);
         $suiteOne = new SuiteObject('Suite1', ['Test1' => $testOne], [], []);
@@ -41,7 +57,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testOneTestTwoSuitesConfig()
+    public function testOneTestTwoSuitesConfig(): void
     {
         $testOne = new TestObject('Test1', [], [], []);
         $suiteOne = new SuiteObject('Suite1', ['Test1' => $testOne], [], []);
@@ -57,7 +73,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testOneTestOneGroup()
+    public function testOneTestOneGroup(): void
     {
         $testOne = new TestObject('Test1', [], ['group' => ['Group1']], []);
 
@@ -71,7 +87,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testThreeTestsTwoGroup()
+    public function testThreeTestsTwoGroup(): void
     {
         $testOne = new TestObject('Test1', [], ['group' => ['Group1']], []);
         $testTwo = new TestObject('Test2', [], ['group' => ['Group1']], []);
@@ -87,7 +103,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testOneTestOneSuiteOneGroupConfig()
+    public function testOneTestOneSuiteOneGroupConfig(): void
     {
         $testOne = new TestObject('Test1', [], ['group' => ['Group1']], []);
         $suiteOne = new SuiteObject('Suite1', ['Test1' => $testOne], [], []);
@@ -102,7 +118,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testTwoTestOneSuiteTwoGroupConfig()
+    public function testTwoTestOneSuiteTwoGroupConfig(): void
     {
         $testOne = new TestObject('Test1', [], ['group' => ['Group1']], []);
         $testTwo = new TestObject('Test2', [], ['group' => ['Group2']], []);
@@ -118,7 +134,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testTwoTestTwoSuiteOneGroupConfig()
+    public function testTwoTestTwoSuiteOneGroupConfig(): void
     {
         $testOne = new TestObject('Test1', [], ['group' => ['Group1']], []);
         $testTwo = new TestObject('Test2', [], ['group' => ['Group1']], []);
@@ -137,10 +153,12 @@ class BaseGenerateCommandTest extends TestCase
 
     /**
      * Test specific usecase of a test that is in a group with the group being called along with the suite
-     * i.e. run:group Group1 Suite1
-     * @throws \Exception
+     * i.e. run:group Group1 Suite1.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testThreeTestOneSuiteOneGroupMix()
+    public function testThreeTestOneSuiteOneGroupMix(): void
     {
         $testOne = new TestObject('Test1', [], [], []);
         $testTwo = new TestObject('Test2', [], [], []);
@@ -162,7 +180,7 @@ class BaseGenerateCommandTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testSuiteToTestSyntax()
+    public function testSuiteToTestSyntax(): void
     {
         $testOne = new TestObject('Test1', [], [], []);
         $suiteOne = new SuiteObject(
@@ -181,49 +199,82 @@ class BaseGenerateCommandTest extends TestCase
     }
 
     /**
-     * Mock handlers to skip parsing
+     * Mock handlers to skip parsing.
+     *
      * @param array $testArray
      * @param array $suiteArray
-     * @throws \Exception
+     *
+     * @return void
+     * @throws Exception
      */
-    public function mockHandlers($testArray, $suiteArray)
+    public function mockHandlers(array $testArray, array $suiteArray): void
     {
+        // bypass the initTestData method
+        $testObjectHandlerClass = new ReflectionClass(TestObjectHandler::class);
+        $constructor = $testObjectHandlerClass->getConstructor();
+        $constructor->setAccessible(true);
+        $testObjectHandlerObject = $testObjectHandlerClass->newInstanceWithoutConstructor();
+        $constructor->invoke($testObjectHandlerObject);
+
+        $testObjectHandlerProperty = new ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
+        $testObjectHandlerProperty->setAccessible(true);
+        $testObjectHandlerProperty->setValue($testObjectHandlerObject);
+
         $handler = TestObjectHandler::getInstance();
-        $property = new \ReflectionProperty(TestObjectHandler::class, 'tests');
+        $property = new ReflectionProperty(TestObjectHandler::class, 'tests');
         $property->setAccessible(true);
         $property->setValue($handler, $testArray);
 
+        // bypass the initTestData method
+        $suiteObjectHandlerClass = new ReflectionClass(SuiteObjectHandler::class);
+        $constructor = $suiteObjectHandlerClass->getConstructor();
+        $constructor->setAccessible(true);
+        $suiteObjectHandlerObject = $suiteObjectHandlerClass->newInstanceWithoutConstructor();
+        $constructor->invoke($suiteObjectHandlerObject);
+
+        $suiteObjectHandlerProperty = new ReflectionProperty(SuiteObjectHandler::class, 'instance');
+        $suiteObjectHandlerProperty->setAccessible(true);
+        $suiteObjectHandlerProperty->setValue($suiteObjectHandlerObject);
+
         $handler = SuiteObjectHandler::getInstance();
-        $property = new \ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');
+        $property = new ReflectionProperty(SuiteObjectHandler::class, 'suiteObjects');
         $property->setAccessible(true);
         $property->setValue($handler, $suiteArray);
     }
 
     /**
-     * Changes visibility and runs getTestAndSuiteConfiguration
+     * Changes visibility and runs getTestAndSuiteConfiguration.
+     *
      * @param array $testArray
+     *
      * @return string
+     * @throws ReflectionException
      */
-    public function callTestConfig($testArray)
+    public function callTestConfig(array $testArray): string
     {
         $command = new BaseGenerateCommand();
-        $class = new \ReflectionClass($command);
+        $class = new ReflectionClass($command);
         $method = $class->getMethod('getTestAndSuiteConfiguration');
         $method->setAccessible(true);
+
         return $method->invokeArgs($command, [$testArray]);
     }
 
     /**
-     * Changes visibility and runs getGroupAndSuiteConfiguration
+     * Changes visibility and runs getGroupAndSuiteConfiguration.
+     *
      * @param array $groupArray
+     *
      * @return string
+     * @throws ReflectionException
      */
-    public function callGroupConfig($groupArray)
+    public function callGroupConfig(array $groupArray): string
     {
         $command = new BaseGenerateCommand();
-        $class = new \ReflectionClass($command);
+        $class = new ReflectionClass($command);
         $method = $class->getMethod('getGroupAndSuiteConfiguration');
         $method->setAccessible(true);
+
         return $method->invokeArgs($command, [$groupArray]);
     }
 }


### PR DESCRIPTION
### Description
Eliminate AspectMock usage from `dev/tests/unit/Magento/FunctionalTestFramework/Console/BaseGenerateCommandTest.php`

### Fixed Issues (if relevant)
1. magento/magento2#33292: [MFTF] Replace AspectMock with PHPUnit for BaseGenerateCommandTest #33292

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests