### PR TITLE
33295: Eliminate AspectMock from FileStorageTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/SecretStorage/FileStorageTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/SecretStorage/FileStorageTest.php
@@ -3,29 +3,38 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace tests\unit\Magento\FunctionalTestFramework\DataGenerator\Handlers\SecretStorage;
 
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\SecretStorage\FileStorage;
+use ReflectionClass;
 use tests\unit\Util\MagentoTestCase;
-use AspectMock\Test as AspectMock;
 
 class FileStorageTest extends MagentoTestCase
 {
-
     /**
      * Test basic encryption/decryption functionality in FileStorage class.
      */
-    public function testBasicEncryptDecrypt()
+    public function testBasicEncryptDecrypt(): void
     {
         $testKey = 'magento/myKey';
         $testValue = 'myValue';
-
-        AspectMock::double(FileStorage::class, [
-            'readInCredentialsFile' => ["$testKey=$testValue"]
-        ]);
+        $creds = ["$testKey=$testValue"];
 
         $fileStorage = new FileStorage();
+        $reflection = new ReflectionClass(FileStorage::class);
+
+        // Emulate initialize() function result with the test credentials
+        $reflectionMethod = $reflection->getMethod('encryptCredFileContents');
+        $reflectionMethod->setAccessible(true);
+        $secretData = $reflectionMethod->invokeArgs($fileStorage, [$creds]);
+
+        // Set encrypted test credentials to the private 'secretData' property
+        $reflectionProperty = $reflection->getProperty('secretData');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($fileStorage, $secretData);
+
         $encryptedCred = $fileStorage->getEncryptedValue($testKey);
 
         // assert the value we've gotten is in fact not identical to our test value

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/CredentialStore.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/CredentialStore.php
@@ -221,11 +221,13 @@ class CredentialStore
      *
      * @return void
      */
-    private function initializeFileStorage()
+    private function initializeFileStorage(): void
     {
         // Initialize file storage
         try {
-            $this->credStorage[self::ARRAY_KEY_FOR_FILE]  = new FileStorage();
+            $fileStorage = new FileStorage();
+            $fileStorage->initialize();
+            $this->credStorage[self::ARRAY_KEY_FOR_FILE]  = $fileStorage;
         } catch (TestFrameworkException $e) {
             // Print error message in console
             print_r($e->getMessage());

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/SecretStorage/FileStorage.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/SecretStorage/FileStorage.php
@@ -21,14 +21,17 @@ class FileStorage extends BaseStorage
     private $secretData = [];
 
     /**
-     * FileStorage constructor
+     * Initialize secret data value which represents encrypted credentials
+     *
+     * @return void
      * @throws TestFrameworkException
      */
-    public function __construct()
+    private function initialize(): void
     {
-        parent::__construct();
-        $creds = $this->readInCredentialsFile();
-        $this->secretData = $this->encryptCredFileContents($creds);
+        if (!$this->secretData) {
+            $creds = $this->readInCredentialsFile();
+            $this->secretData = $this->encryptCredFileContents($creds);
+        }
     }
 
     /**
@@ -36,10 +39,12 @@ class FileStorage extends BaseStorage
      *
      * @param string $key
      * @return string|null
+     * @throws TestFrameworkException
      */
-    public function getEncryptedValue($key)
+    public function getEncryptedValue($key): ?string
     {
-        $value = null;
+        $this->initialize();
+
         // Check if secret is in cached array
         if (null !== ($value = parent::getEncryptedValue($key))) {
             return $value;

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/SecretStorage/FileStorage.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/SecretStorage/FileStorage.php
@@ -26,7 +26,7 @@ class FileStorage extends BaseStorage
      * @return void
      * @throws TestFrameworkException
      */
-    private function initialize(): void
+    public function initialize(): void
     {
         if (!$this->secretData) {
             $creds = $this->readInCredentialsFile();


### PR DESCRIPTION
Eliminated AspectMock usage from `dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/SecretStorage/FileStorageTest.php`

note: in this case, main complexity is in a private functions calls rather than static

### Fixed Issues (if relevant)
1. Fixes magento/magento2#33295: [MFTF] Eliminate AspectMock from FileStorageTest (Complex!)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests