### PR TITLE
MFTF-33305: Eliminate AspectMock from ObjectExtensionUtilTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ObjectExtensionUtilTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ObjectExtensionUtilTest.php
@@ -3,32 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace tests\unit\Magento\FunctionalTestFramework\Test\Util;
 
-use AspectMock\Proxy\Verifier;
-use AspectMock\Test as AspectMock;
-use Magento\FunctionalTestingFramework\ObjectManager\ObjectManager;
-use Magento\FunctionalTestingFramework\ObjectManagerFactory;
+use Exception;
+use Magento\FunctionalTestingFramework\ObjectManager;
 use Magento\FunctionalTestingFramework\Test\Handlers\ActionGroupObjectHandler;
 use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 use Magento\FunctionalTestingFramework\Test\Parsers\ActionGroupDataParser;
 use Magento\FunctionalTestingFramework\Test\Parsers\TestDataParser;
-use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
-use Monolog\Handler\TestHandler;
-use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use tests\unit\Util\MockModuleResolverBuilder;
 use tests\unit\Util\TestDataArrayBuilder;
 use tests\unit\Util\TestLoggingUtil;
-use tests\unit\Util\MockModuleResolverBuilder;
 
 class ObjectExtensionUtilTest extends TestCase
 {
     /**
-     * Before test functionality
+     * Before test functionality.
+     *
      * @return void
+     * @throws Exception
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         TestLoggingUtil::getInstance()->setMockLoggingUtil();
         $resolverMock = new MockModuleResolverBuilder();
@@ -36,7 +35,8 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * After class functionality
+     * After class functionality.
+     *
      * @return void
      */
     public static function tearDownAfterClass(): void
@@ -45,10 +45,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating a test that extends another test
-     * @throws \Exception
+     * Tests generating a test that extends another test.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateExtendedTest()
+    public function testGenerateExtendedTest(): void
     {
         $mockActions = [
             "mockStep" => ["nodeName" => "mockNode", "stepKey" => "mockStep"]
@@ -86,10 +88,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating a test that extends another test
-     * @throws \Exception
+     * Tests generating a test that extends another test.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateExtendedWithHooks()
+    public function testGenerateExtendedWithHooks(): void
     {
         $mockBeforeHooks = [
             "beforeHookAction" => ["nodeName" => "mockNodeBefore", "stepKey" => "mockStepBefore"]
@@ -132,10 +136,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating a test that extends another test
-     * @throws \Exception
+     * Tests generating a test that extends another test.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testExtendedTestNoParent()
+    public function testExtendedTestNoParent(): void
     {
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockExtendedTest = $testDataArrayBuilder
@@ -158,10 +164,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating a test that extends another test
-     * @throws \Exception
+     * Tests generating a test that extends another test.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testExtendingExtendedTest()
+    public function testExtendingExtendedTest(): void
     {
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockParentTest = $testDataArrayBuilder
@@ -200,10 +208,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating an action group that extends another action group
-     * @throws \Exception
+     * Tests generating an action group that extends another action group.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateExtendedActionGroup()
+    public function testGenerateExtendedActionGroup(): void
     {
         $mockSimpleActionGroup = [
             "nodeName" => "actionGroup",
@@ -259,10 +269,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating an action group that extends an action group that does not exist
-     * @throws \Exception
+     * Tests generating an action group that extends an action group that does not exist.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateExtendedActionGroupNoParent()
+    public function testGenerateExtendedActionGroupNoParent(): void
     {
         $mockExtendedActionGroup = [
             "nodeName" => "actionGroup",
@@ -292,10 +304,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating an action group that extends another action group that is already extended
-     * @throws \Exception
+     * Tests generating an action group that extends another action group that is already extended.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testExtendingExtendedActionGroup()
+    public function testExtendingExtendedActionGroup(): void
     {
         $mockParentActionGroup = [
             "nodeName" => "actionGroup",
@@ -333,7 +347,7 @@ class ObjectExtensionUtilTest extends TestCase
         // parse and generate test object with mocked data
         try {
             ActionGroupObjectHandler::getInstance()->getObject('mockExtendedActionGroup');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // validate log statement
             TestLoggingUtil::getInstance()->validateMockLogStatement(
                 'error',
@@ -347,11 +361,12 @@ class ObjectExtensionUtilTest extends TestCase
     }
 
     /**
-     * Tests generating a test that extends a skipped parent test
+     * Tests generating a test that extends a skipped parent test.
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testExtendedTestSkippedParent()
+    public function testExtendedTestSkippedParent(): void
     {
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockParentTest = $testDataArrayBuilder
@@ -384,43 +399,55 @@ class ObjectExtensionUtilTest extends TestCase
     /**
      * Function used to set mock for parser return and force init method to run between tests.
      *
-     * @param array $testData
-     * @throws \Exception
+     * @param array|null $testData
+     * @param array|null $actionGroupData
+     *
+     * @return void
+     * @throws Exception
      */
-    private function setMockTestOutput($testData = null, $actionGroupData = null)
+    private function setMockTestOutput(array $testData = null, array $actionGroupData = null): void
     {
         // clear test object handler value to inject parsed content
-        $property = new \ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
+        $property = new ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
         $property->setAccessible(true);
         $property->setValue(null);
 
         // clear test object handler value to inject parsed content
-        $property = new \ReflectionProperty(ActionGroupObjectHandler::class, 'instance');
+        $property = new ReflectionProperty(ActionGroupObjectHandler::class, 'instance');
         $property->setAccessible(true);
         $property->setValue(null);
 
-        $mockDataParser = AspectMock::double(TestDataParser::class, ['readTestData' => $testData])->make();
-        $mockActionGroupParser = AspectMock::double(
-            ActionGroupDataParser::class,
-            ['readActionGroupData' => $actionGroupData]
-        )->make();
-        $instance = AspectMock::double(
-            ObjectManager::class,
-            [
-                'create' => function ($className) use (
-                    $mockDataParser,
-                    $mockActionGroupParser
-                ) {
-                    if ($className == TestDataParser::class) {
-                        return $mockDataParser;
+        $mockDataParser = $this->createMock(TestDataParser::class);
+        $mockDataParser
+            ->method('readTestData')
+            ->willReturn($testData);
+
+        $mockActionGroupParser = $this->createMock(ActionGroupDataParser::class);
+        $mockActionGroupParser
+            ->method('readActionGroupData')
+            ->willReturn($actionGroupData);
+
+        $instance = $this->createMock(ObjectManager::class);
+        $instance
+            ->method('create')
+            ->will(
+                $this->returnCallback(
+                    function ($className) use ($mockDataParser, $mockActionGroupParser) {
+                        if ($className === TestDataParser::class) {
+                            return $mockDataParser;
+                        }
+
+                        if ($className === ActionGroupDataParser::class) {
+                            return $mockActionGroupParser;
+                        }
+
+                        return null;
                     }
-                    if ($className == ActionGroupDataParser::class) {
-                        return $mockActionGroupParser;
-                    }
-                }
-            ]
-        )->make();
-        // bypass the private constructor
-        AspectMock::double(ObjectManagerFactory::class, ['getObjectManager' => $instance]);
+                )
+            );
+        // clear object manager value to inject expected instance
+        $property = new ReflectionProperty(ObjectManager::class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue($instance);
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ObjectExtensionUtilTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ObjectExtensionUtilTest.php
@@ -15,7 +15,6 @@ use Magento\FunctionalTestingFramework\Test\Parsers\ActionGroupDataParser;
 use Magento\FunctionalTestingFramework\Test\Parsers\TestDataParser;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
-use tests\unit\Util\MockModuleResolverBuilder;
 use tests\unit\Util\TestDataArrayBuilder;
 use tests\unit\Util\TestLoggingUtil;
 
@@ -30,8 +29,6 @@ class ObjectExtensionUtilTest extends TestCase
     protected function setUp(): void
     {
         TestLoggingUtil::getInstance()->setMockLoggingUtil();
-        $resolverMock = new MockModuleResolverBuilder();
-        $resolverMock->setup();
     }
 
     /**
@@ -53,7 +50,7 @@ class ObjectExtensionUtilTest extends TestCase
     public function testGenerateExtendedTest(): void
     {
         $mockActions = [
-            "mockStep" => ["nodeName" => "mockNode", "stepKey" => "mockStep"]
+            'mockStep' => ['nodeName' => 'mockNode', 'stepKey' => 'mockStep']
         ];
 
         $testDataArrayBuilder = new TestDataArrayBuilder();
@@ -66,7 +63,7 @@ class ObjectExtensionUtilTest extends TestCase
         $mockExtendedTest = $testDataArrayBuilder
             ->withName('extendedTest')
             ->withAnnotations(['title' => [['value' => 'extendedTest']]])
-            ->withTestReference("simpleTest")
+            ->withTestReference('simpleTest')
             ->build();
 
         $mockTestData = array_merge($mockSimpleTest, $mockExtendedTest);
@@ -83,8 +80,8 @@ class ObjectExtensionUtilTest extends TestCase
         );
 
         // assert that expected test is generated
-        $this->assertEquals($testObject->getParentName(), "simpleTest");
-        $this->assertArrayHasKey("mockStep", $testObject->getOrderedActions());
+        $this->assertEquals($testObject->getParentName(), 'simpleTest');
+        $this->assertArrayHasKey('mockStep', $testObject->getOrderedActions());
     }
 
     /**
@@ -96,10 +93,10 @@ class ObjectExtensionUtilTest extends TestCase
     public function testGenerateExtendedWithHooks(): void
     {
         $mockBeforeHooks = [
-            "beforeHookAction" => ["nodeName" => "mockNodeBefore", "stepKey" => "mockStepBefore"]
+            'beforeHookAction' => ['nodeName' => 'mockNodeBefore', 'stepKey' => 'mockStepBefore']
         ];
         $mockAfterHooks = [
-            "afterHookAction" => ["nodeName" => "mockNodeAfter", "stepKey" => "mockStepAfter"]
+            'afterHookAction' => ['nodeName' => 'mockNodeAfter', 'stepKey' => 'mockStepAfter']
         ];
 
         $testDataArrayBuilder = new TestDataArrayBuilder();
@@ -113,7 +110,7 @@ class ObjectExtensionUtilTest extends TestCase
         $mockExtendedTest = $testDataArrayBuilder
             ->withName('extendedTest')
             ->withAnnotations(['title' => [['value' => 'extendedTest']]])
-            ->withTestReference("simpleTest")
+            ->withTestReference('simpleTest')
             ->build();
 
         $mockTestData = array_merge($mockSimpleTest, $mockExtendedTest);
@@ -130,9 +127,9 @@ class ObjectExtensionUtilTest extends TestCase
         );
 
         // assert that expected test is generated
-        $this->assertEquals($testObject->getParentName(), "simpleTest");
-        $this->assertArrayHasKey("mockStepBefore", $testObject->getHooks()['before']->getActions());
-        $this->assertArrayHasKey("mockStepAfter", $testObject->getHooks()['after']->getActions());
+        $this->assertEquals($testObject->getParentName(), 'simpleTest');
+        $this->assertArrayHasKey('mockStepBefore', $testObject->getHooks()['before']->getActions());
+        $this->assertArrayHasKey('mockStepAfter', $testObject->getHooks()['after']->getActions());
     }
 
     /**
@@ -146,7 +143,7 @@ class ObjectExtensionUtilTest extends TestCase
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockExtendedTest = $testDataArrayBuilder
             ->withName('extendedTest')
-            ->withTestReference("simpleTest")
+            ->withTestReference('simpleTest')
             ->build();
 
         $mockTestData = array_merge($mockExtendedTest);
@@ -158,7 +155,7 @@ class ObjectExtensionUtilTest extends TestCase
         // validate log statement
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'debug',
-            "parent test not defined. test will be skipped",
+            'parent test not defined. test will be skipped',
             ['parent' => 'simpleTest', 'test' => 'extendedTest']
         );
     }
@@ -181,19 +178,19 @@ class ObjectExtensionUtilTest extends TestCase
             ->withName('simpleTest')
             ->withAnnotations(['title' => [['value' => 'simpleTest']]])
             ->withTestActions()
-            ->withTestReference("anotherTest")
+            ->withTestReference('anotherTest')
             ->build();
 
         $mockExtendedTest = $testDataArrayBuilder
             ->withName('extendedTest')
             ->withAnnotations(['title' => [['value' => 'extendedTest']]])
-            ->withTestReference("simpleTest")
+            ->withTestReference('simpleTest')
             ->build();
 
         $mockTestData = array_merge($mockParentTest, $mockSimpleTest, $mockExtendedTest);
         $this->setMockTestOutput($mockTestData);
 
-        $this->expectExceptionMessage("Cannot extend a test that already extends another test. Test: simpleTest");
+        $this->expectExceptionMessage('Cannot extend a test that already extends another test. Test: simpleTest');
 
         // parse and generate test object with mocked data
         TestObjectHandler::getInstance()->getObject('extendedTest');
@@ -201,10 +198,10 @@ class ObjectExtensionUtilTest extends TestCase
         // validate log statement
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'debug',
-            "parent test not defined. test will be skipped",
+            'parent test not defined. test will be skipped',
             ['parent' => 'simpleTest', 'test' => 'extendedTest']
         );
-        $this->expectOutputString("Extending Test: anotherTest => simpleTest" . PHP_EOL);
+        $this->expectOutputString('Extending Test: anotherTest => simpleTest' . PHP_EOL);
     }
 
     /**
@@ -216,30 +213,30 @@ class ObjectExtensionUtilTest extends TestCase
     public function testGenerateExtendedActionGroup(): void
     {
         $mockSimpleActionGroup = [
-            "nodeName" => "actionGroup",
-            "name" => "mockSimpleActionGroup",
-            "filename" => "someFile",
-            "commentHere" => [
-                "nodeName" => "comment",
-                "selector" => "selector",
-                "stepKey" => "commentHere"
+            'nodeName' => 'actionGroup',
+            'name' => 'mockSimpleActionGroup',
+            'filename' => 'someFile',
+            'commentHere' => [
+                'nodeName' => 'comment',
+                'selector' => 'selector',
+                'stepKey' => 'commentHere'
             ],
-            "parentComment" => [
-                "nodeName" => "comment",
-                "selector" => "parentSelector",
-                "stepKey" => "parentComment"
+            'parentComment' => [
+                'nodeName' => 'comment',
+                'selector' => 'parentSelector',
+                'stepKey' => 'parentComment'
             ],
         ];
 
         $mockExtendedActionGroup = [
-            "nodeName" => "actionGroup",
-            "name" => "mockExtendedActionGroup",
-            "filename" => "someFile",
-            "extends" => "mockSimpleActionGroup",
-            "commentHere" => [
-                "nodeName" => "comment",
-                "selector" => "otherSelector",
-                "stepKey" => "commentHere"
+            'nodeName' => 'actionGroup',
+            'name' => 'mockExtendedActionGroup',
+            'filename' => 'someFile',
+            'extends' => 'mockSimpleActionGroup',
+            'commentHere' => [
+                'nodeName' => 'comment',
+                'selector' => 'otherSelector',
+                'stepKey' => 'commentHere'
             ],
         ];
 
@@ -262,10 +259,10 @@ class ObjectExtensionUtilTest extends TestCase
         );
 
         // assert that expected test is generated
-        $this->assertEquals("mockSimpleActionGroup", $actionGroupObject->getParentName());
+        $this->assertEquals('mockSimpleActionGroup', $actionGroupObject->getParentName());
         $actions = $actionGroupObject->getActions();
-        $this->assertEquals("otherSelector", $actions["commentHere"]->getCustomActionAttributes()["selector"]);
-        $this->assertEquals("parentSelector", $actions["parentComment"]->getCustomActionAttributes()["selector"]);
+        $this->assertEquals('otherSelector', $actions['commentHere']->getCustomActionAttributes()['selector']);
+        $this->assertEquals('parentSelector', $actions['parentComment']->getCustomActionAttributes()['selector']);
     }
 
     /**
@@ -277,14 +274,14 @@ class ObjectExtensionUtilTest extends TestCase
     public function testGenerateExtendedActionGroupNoParent(): void
     {
         $mockExtendedActionGroup = [
-            "nodeName" => "actionGroup",
-            "name" => "mockExtendedActionGroup",
-            "filename" => "someFile",
-            "extends" => "mockSimpleActionGroup",
-            "commentHere" => [
-                "nodeName" => "comment",
-                "selector" => "otherSelector",
-                "stepKey" => "commentHere"
+            'nodeName' => 'actionGroup',
+            'name' => 'mockExtendedActionGroup',
+            'filename' => 'someFile',
+            'extends' => 'mockSimpleActionGroup',
+            'commentHere' => [
+                'nodeName' => 'comment',
+                'selector' => 'otherSelector',
+                'stepKey' => 'commentHere'
             ],
         ];
 
@@ -296,7 +293,7 @@ class ObjectExtensionUtilTest extends TestCase
         $this->setMockTestOutput(null, $mockActionGroupData);
 
         $this->expectExceptionMessage(
-            "Parent Action Group mockSimpleActionGroup not defined for Test " . $mockExtendedActionGroup['name']
+            'Parent Action Group mockSimpleActionGroup not defined for Test ' . $mockExtendedActionGroup['name']
         );
 
         // parse and generate test object with mocked data
@@ -312,23 +309,23 @@ class ObjectExtensionUtilTest extends TestCase
     public function testExtendingExtendedActionGroup(): void
     {
         $mockParentActionGroup = [
-            "nodeName" => "actionGroup",
-            "name" => "mockParentActionGroup",
-            "filename" => "someFile"
+            'nodeName' => 'actionGroup',
+            'name' => 'mockParentActionGroup',
+            'filename' => 'someFile'
         ];
 
         $mockSimpleActionGroup = [
-            "nodeName" => "actionGroup",
-            "name" => "mockSimpleActionGroup",
-            "filename" => "someFile",
-            "extends" => "mockParentActionGroup",
+            'nodeName' => 'actionGroup',
+            'name' => 'mockSimpleActionGroup',
+            'filename' => 'someFile',
+            'extends' => 'mockParentActionGroup'
         ];
 
         $mockExtendedActionGroup = [
-            "nodeName" => "actionGroup",
-            "name" => "mockExtendedActionGroup",
-            "filename" => "someFile",
-            "extends" => "mockSimpleActionGroup",
+            'nodeName' => 'actionGroup',
+            'name' => 'mockExtendedActionGroup',
+            'filename' => 'someFile',
+            'extends' => 'mockSimpleActionGroup'
         ];
 
         $mockActionGroupData = [
@@ -341,22 +338,22 @@ class ObjectExtensionUtilTest extends TestCase
         $this->setMockTestOutput(null, $mockActionGroupData);
 
         $this->expectExceptionMessage(
-            "Cannot extend an action group that already extends another action group. " . $mockSimpleActionGroup['name']
+            'Cannot extend an action group that already extends another action group. ' . $mockSimpleActionGroup['name']
         );
 
         // parse and generate test object with mocked data
         try {
             ActionGroupObjectHandler::getInstance()->getObject('mockExtendedActionGroup');
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
             // validate log statement
             TestLoggingUtil::getInstance()->validateMockLogStatement(
                 'error',
-                "Cannot extend an action group that already extends another action group. " .
+                'Cannot extend an action group that already extends another action group. ' .
                 $mockSimpleActionGroup['name'],
                 ['parent' => $mockSimpleActionGroup['name'], 'actionGroup' => $mockExtendedActionGroup['name']]
             );
 
-            throw $e;
+            throw $exception;
         }
     }
 
@@ -379,7 +376,7 @@ class ObjectExtensionUtilTest extends TestCase
         $testDataArrayBuilder->reset();
         $mockExtendedTest = $testDataArrayBuilder
             ->withName('extendTest')
-            ->withTestReference("baseTest")
+            ->withTestReference('baseTest')
             ->build();
 
         $mockTestData = array_merge($mockParentTest, $mockExtendedTest);
@@ -391,7 +388,7 @@ class ObjectExtensionUtilTest extends TestCase
         // validate log statement
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'debug',
-            "extendTest is skipped due to ParentTestIsSkipped",
+            'extendTest is skipped due to ParentTestIsSkipped',
             []
         );
     }

--- a/dev/tests/unit/Util/MagentoTestCase.php
+++ b/dev/tests/unit/Util/MagentoTestCase.php
@@ -22,7 +22,6 @@ class MagentoTestCase extends TestCase
         // Should be used to clean AspectMock mocking before using PHPUnit mocking and Reflection.
         AspectMock::clean();
         parent::setUpBeforeClass();
-        parent::setUpBeforeClass();
     }
 
     /**

--- a/dev/tests/unit/Util/MagentoTestCase.php
+++ b/dev/tests/unit/Util/MagentoTestCase.php
@@ -19,6 +19,9 @@ class MagentoTestCase extends TestCase
         if (!self::fileExists(DOCS_OUTPUT_DIR)) {
             mkdir(DOCS_OUTPUT_DIR, 0755, true);
         }
+        // Should be used to clean AspectMock mocking before using PHPUnit mocking and Reflection.
+        AspectMock::clean();
+        parent::setUpBeforeClass();
         parent::setUpBeforeClass();
     }
 

--- a/dev/tests/unit/Util/MockModuleResolverBuilder.php
+++ b/dev/tests/unit/Util/MockModuleResolverBuilder.php
@@ -3,31 +3,35 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Util;
 
 use AspectMock\Test as AspectMock;
-use Magento\FunctionalTestingFramework\ObjectManager;
-use Magento\FunctionalTestingFramework\ObjectManagerFactory;
-use Magento\FunctionalTestingFramework\Util\ModuleResolver;
+use Exception;
 use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
+use Magento\FunctionalTestingFramework\ObjectManager;
+use Magento\FunctionalTestingFramework\Util\ModuleResolver;
+use ReflectionProperty;
 
 class MockModuleResolverBuilder
 {
     /**
-     * Default paths for mock ModuleResolver
+     * Default paths for mock ModuleResolver.
      *
      * @var array
      */
     private $defaultPaths = ['Magento_Module' => '/base/path/some/other/path/Magento/Module'];
 
     /**
-     * Mock ModuleResolver builder
+     * Mock ModuleResolver builder.
      *
-     * @param array $paths
+     * @param array|null $paths
+     *
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
-    public function setup($paths = null)
+    public function setup(array $paths = null): void
     {
         if (empty($paths)) {
             $paths = $this->defaultPaths;
@@ -35,9 +39,12 @@ class MockModuleResolverBuilder
 
         $mockConfig = AspectMock::double(MftfApplicationConfig::class, ['forceGenerateEnabled' => false]);
         $instance = AspectMock::double(ObjectManager::class, ['create' => $mockConfig->make(), 'get' => null])->make();
-        AspectMock::double(ObjectManagerFactory::class, ['getObjectManager' => $instance]);
+        // clear object manager value to inject expected instance
+        $property = new ReflectionProperty(ObjectManager::class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue($instance);
 
-        $property = new \ReflectionProperty(ModuleResolver::class, 'instance');
+        $property = new ReflectionProperty(ModuleResolver::class, 'instance');
         $property->setAccessible(true);
         $property->setValue(null);
 
@@ -51,10 +58,14 @@ class MockModuleResolverBuilder
         );
         $instance = AspectMock::double(ObjectManager::class, ['create' => $mockResolver->make(), 'get' => null])
             ->make();
-        AspectMock::double(ObjectManagerFactory::class, ['getObjectManager' => $instance]);
+
+        // clear object manager value to inject expected instance
+        $property = new ReflectionProperty(ObjectManager::class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue($instance);
 
         $resolver = ModuleResolver::getInstance();
-        $property = new \ReflectionProperty(ModuleResolver::class, 'enabledModuleNameAndPaths');
+        $property = new ReflectionProperty(ModuleResolver::class, 'enabledModuleNameAndPaths');
         $property->setAccessible(true);
         $property->setValue($resolver, $paths);
     }

--- a/dev/tests/unit/Util/MockModuleResolverBuilder.php
+++ b/dev/tests/unit/Util/MockModuleResolverBuilder.php
@@ -3,35 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-declare(strict_types=1);
-
 namespace tests\unit\Util;
 
 use AspectMock\Test as AspectMock;
-use Exception;
-use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\ObjectManager;
+use Magento\FunctionalTestingFramework\ObjectManagerFactory;
 use Magento\FunctionalTestingFramework\Util\ModuleResolver;
-use ReflectionProperty;
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 
 class MockModuleResolverBuilder
 {
     /**
-     * Default paths for mock ModuleResolver.
+     * Default paths for mock ModuleResolver
      *
      * @var array
      */
     private $defaultPaths = ['Magento_Module' => '/base/path/some/other/path/Magento/Module'];
 
     /**
-     * Mock ModuleResolver builder.
+     * Mock ModuleResolver builder
      *
-     * @param array|null $paths
-     *
+     * @param array $paths
      * @return void
-     * @throws Exception
+     * @throws \Exception
      */
-    public function setup(array $paths = null): void
+    public function setup($paths = null)
     {
         if (empty($paths)) {
             $paths = $this->defaultPaths;
@@ -39,12 +35,9 @@ class MockModuleResolverBuilder
 
         $mockConfig = AspectMock::double(MftfApplicationConfig::class, ['forceGenerateEnabled' => false]);
         $instance = AspectMock::double(ObjectManager::class, ['create' => $mockConfig->make(), 'get' => null])->make();
-        // clear object manager value to inject expected instance
-        $property = new ReflectionProperty(ObjectManager::class, 'instance');
-        $property->setAccessible(true);
-        $property->setValue($instance);
+        AspectMock::double(ObjectManagerFactory::class, ['getObjectManager' => $instance]);
 
-        $property = new ReflectionProperty(ModuleResolver::class, 'instance');
+        $property = new \ReflectionProperty(ModuleResolver::class, 'instance');
         $property->setAccessible(true);
         $property->setValue(null);
 
@@ -58,14 +51,10 @@ class MockModuleResolverBuilder
         );
         $instance = AspectMock::double(ObjectManager::class, ['create' => $mockResolver->make(), 'get' => null])
             ->make();
-
-        // clear object manager value to inject expected instance
-        $property = new ReflectionProperty(ObjectManager::class, 'instance');
-        $property->setAccessible(true);
-        $property->setValue($instance);
+        AspectMock::double(ObjectManagerFactory::class, ['getObjectManager' => $instance]);
 
         $resolver = ModuleResolver::getInstance();
-        $property = new ReflectionProperty(ModuleResolver::class, 'enabledModuleNameAndPaths');
+        $property = new \ReflectionProperty(ModuleResolver::class, 'enabledModuleNameAndPaths');
         $property->setAccessible(true);
         $property->setValue($resolver, $paths);
     }


### PR DESCRIPTION
### Description
Eliminated AspectMock usage in the \tests\unit\Magento\FunctionalTestFramework\Test\Util\ObjectExtensionUtilTest.

### Fixed Issues (if relevant)
1. magento/magento2#33305: [MFTF] Eliminate AspectMock from ObjectExtensionUtilTest (Complex!)

### Additional information
As the main idea of this issue to eliminate AspectMock usage in the ObjectExtensionUtilTest class, AspectMock usage eliminated only partially in the MockModuleResolverBuilder. It is a required action because in that class the \Magento\FunctionalTestingFramework\Util\ModuleResolver mocked instance hardcoded to be retrieved by the ObjectManager mocked object on its create method without any argument.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backwards-incompatible changes for tests or have related Pull Request with fixes to tests