### PR TITLE
MFTF-33301: Eliminated AspectMock usage for TestObjectHandlerTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Handlers/TestObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Handlers/TestObjectHandlerTest.php
@@ -3,29 +3,32 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace tests\unit\Magento\FunctionalTestFramework\Test\Handlers;
 
-use AspectMock\Test as AspectMock;
-
-use Magento\FunctionalTestingFramework\ObjectManager;
-use Magento\FunctionalTestingFramework\ObjectManagerFactory;
+use Exception;
 use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 use Magento\FunctionalTestingFramework\Test\Objects\ActionObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestHookObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
-use Magento\FunctionalTestingFramework\Test\Parsers\TestDataParser;
 use Magento\FunctionalTestingFramework\Test\Util\TestObjectExtractor;
+use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
 use tests\unit\Util\MagentoTestCase;
+use tests\unit\Util\MockModuleResolverBuilder;
 use tests\unit\Util\ObjectHandlerUtil;
 use tests\unit\Util\TestDataArrayBuilder;
-use tests\unit\Util\MockModuleResolverBuilder;
 use tests\unit\Util\TestLoggingUtil;
-use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
 
 class TestObjectHandlerTest extends MagentoTestCase
 {
-    public function setUp(): void
+    /**
+     * Before test functionality.
+     *
+     * @return void
+     * @throws Exception
+     */
+    protected function setUp(): void
     {
         TestLoggingUtil::getInstance()->setMockLoggingUtil();
     }
@@ -33,9 +36,10 @@ class TestObjectHandlerTest extends MagentoTestCase
     /**
      * Basic test to validate array => test object conversion.
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testGetTestObject()
+    public function testGetTestObject(): void
     {
         // set up mock data
         $testDataArrayBuilder = new TestDataArrayBuilder();
@@ -53,7 +57,6 @@ class TestObjectHandlerTest extends MagentoTestCase
 
         // run object handler method
         $toh = TestObjectHandler::getInstance();
-        $mockConfig = AspectMock::double(TestObjectHandler::class, ['initTestData' => false]);
         $actualTestObject = $toh->getObject($testDataArrayBuilder->testName);
 
         // perform asserts
@@ -114,9 +117,11 @@ class TestObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * Tests basic getting of a test that has a fileName
+     * Tests basic getting of a test that has a fileName.
+     *
+     * @return void
      */
-    public function testGetTestWithFileName()
+    public function testGetTestWithFileName(): void
     {
         $this->markTestIncomplete('TODO');
     }
@@ -124,9 +129,10 @@ class TestObjectHandlerTest extends MagentoTestCase
     /**
      * Tests the function used to get a series of relevant tests by group.
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testGetTestsByGroup()
+    public function testGetTestsByGroup(): void
     {
         // set up mock data with Exclude Test
         $includeTest = (new TestDataArrayBuilder())
@@ -155,11 +161,12 @@ class TestObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * Tests the function used to parse and determine a test's Module (used in allure Features annotation)
+     * Tests the function used to parse and determine a test's Module (used in allure Features annotation).
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testGetTestWithModuleName()
+    public function testGetTestWithModuleName(): void
     {
         // set up Test Data
         $moduleExpected = "SomeModuleName";
@@ -201,11 +208,12 @@ class TestObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * getObject should throw exception if test extends from itself
+     * getObject should throw exception if test extends from itself.
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testGetTestObjectWithInvalidExtends()
+    public function testGetTestObjectWithInvalidExtends(): void
     {
         // set up Test Data
         $testOne = (new TestDataArrayBuilder())
@@ -230,11 +238,12 @@ class TestObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * getAllObjects should throw exception if test extends from itself
+     * getAllObjects should throw exception if test extends from itself.
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testGetAllTestObjectsWithInvalidExtends()
+    public function testGetAllTestObjectsWithInvalidExtends(): void
     {
         // set up Test Data
         $testOne = (new TestDataArrayBuilder())
@@ -270,11 +279,12 @@ class TestObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * Validate test object when ENABLE_PAUSE is set to true
+     * Validate test object when ENABLE_PAUSE is set to true.
      *
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testGetTestObjectWhenEnablePause()
+    public function testGetTestObjectWhenEnablePause(): void
     {
         // set up mock data
         putenv('ENABLE_PAUSE=true');
@@ -293,7 +303,6 @@ class TestObjectHandlerTest extends MagentoTestCase
 
         // run object handler method
         $toh = TestObjectHandler::getInstance();
-        $mockConfig = AspectMock::double(TestObjectHandler::class, ['initTestData' => false]);
         $actualTestObject = $toh->getObject($testDataArrayBuilder->testName);
 
         // perform asserts
@@ -363,14 +372,13 @@ class TestObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * After method functionality
+     * After method functionality.
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         TestLoggingUtil::getInstance()->clearMockLoggingUtil();
-        AspectMock::clean();
         parent::tearDownAfterClass();
     }
 }


### PR DESCRIPTION
### Description
Eliminated AspectMock usage for the \tests\unit\Magento\FunctionalTestFramework\Test\Handlers\TestObjectHandlerTest.

### Fixed Issues (if relevant)
1. magento/magento2#33301: Eliminate AspectMock from TestObjectHandlerTest (Complex!)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backwards-incompatible changes for tests or have related Pull Request with fixes to tests