### PR TITLE
33307: Removed not used mocked object

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/GenerationErrorHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/GenerationErrorHandlerTest.php
@@ -10,7 +10,6 @@ namespace tests\unit\Magento\FunctionalTestFramework\Util;
 use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
 use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
-use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 
 /**
  * Class GenerationErrorHandlerTest
@@ -20,12 +19,8 @@ class GenerationErrorHandlerTest extends MagentoTestCase
     /**
      * Test get errors when all errors are distinct
      */
-    public function testGetDistinctErrors()
+    public function testGetDistinctErrors():void
     {
-        $this->createMock(MftfApplicationConfig::class)
-            ->method('getPhase')
-            ->willReturn(MftfApplicationConfig::GENERATION_PHASE);
-
         $expectedAllErrors = [
             'test' => [
                 'Sameple1Test' => [
@@ -77,12 +72,8 @@ class GenerationErrorHandlerTest extends MagentoTestCase
     /**
      * Test get errors when some errors have the same key
      */
-    public function testGetErrorsWithSameKey()
+    public function testGetErrorsWithSameKey(): void
     {
-        $this->createMock(MftfApplicationConfig::class)
-            ->method('getPhase')
-            ->willReturn(MftfApplicationConfig::GENERATION_PHASE);
-
         $expectedAllErrors = [
             'test' => [
                 'Sameple1Test' => [
@@ -160,12 +151,8 @@ class GenerationErrorHandlerTest extends MagentoTestCase
     /**
      * Test get errors when some errors are duplicate
      */
-    public function testGetAllErrorsDuplicate()
+    public function testGetAllErrorsDuplicate(): void
     {
-        $this->createMock(MftfApplicationConfig::class)
-            ->method('getPhase')
-            ->willReturn(MftfApplicationConfig::GENERATION_PHASE);
-
         $expectedAllErrors = [
             'test' => [
                 'Sameple1Test' => [
@@ -245,9 +232,11 @@ class GenerationErrorHandlerTest extends MagentoTestCase
      *
      * @param string $expectedErrMessages
      * @param array  $errors
+     *
+     * @return void
      * @dataProvider getAllErrorMessagesDataProvider
      */
-    public function testGetAllErrorMessages($expectedErrMessages, $errors)
+    public function testGetAllErrorMessages(string $expectedErrMessages, array $errors): void
     {
         $handler = GenerationErrorHandler::getInstance();
         $handler->reset();
@@ -265,7 +254,7 @@ class GenerationErrorHandlerTest extends MagentoTestCase
      *
      * @return array
      */
-    public function getAllErrorMessagesDataProvider()
+    public function getAllErrorMessagesDataProvider(): array
     {
         return [
             ['', []],
@@ -330,12 +319,8 @@ class GenerationErrorHandlerTest extends MagentoTestCase
     /**
      * Test reset
      */
-    public function testResetError()
+    public function testResetError(): void
     {
-        $this->createMock(MftfApplicationConfig::class)
-            ->method('getPhase')
-            ->willReturn(MftfApplicationConfig::GENERATION_PHASE);
-
         GenerationErrorHandler::getInstance()->addError('something', 'some', 'error');
         GenerationErrorHandler::getInstance()->addError('otherthing', 'other', 'error');
         GenerationErrorHandler::getInstance()->reset();
@@ -348,6 +333,9 @@ class GenerationErrorHandlerTest extends MagentoTestCase
         $this->assertEquals([], GenerationErrorHandler::getInstance()->getErrorsByType('nothing'));
     }
 
+    /**
+     * @inheritdoc
+     */
     public function tearDown(): void
     {
         $property = new ReflectionProperty(GenerationErrorHandler::class, 'instance');


### PR DESCRIPTION
### Description

I've removed not used mock object from GenerationErrorHandlerTest.php

### Fixed Issues (if relevant)

1. Fixes magento/magento2#33307: Eliminated AspectMock usage from GenerationErrorHandlerTest.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests