### PR TITLE
33309: Eliminated AspectMock usage from TestGeneratorTest.php

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/TestGeneratorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/TestGeneratorTest.php
@@ -8,25 +8,27 @@ declare(strict_types=1);
 namespace tests\unit\Magento\FunctionalTestFramework\Util;
 
 use Exception;
+use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Exceptions\TestReferenceException;
 use Magento\FunctionalTestingFramework\Filter\FilterList;
 use Magento\FunctionalTestingFramework\Test\Objects\ActionObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestHookObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
 use Magento\FunctionalTestingFramework\Util\Filesystem\CestFileCreatorUtil;
+use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
+use Magento\FunctionalTestingFramework\Util\TestGenerator;
 use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
-use Magento\FunctionalTestingFramework\Util\TestGenerator;
-use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use tests\unit\Util\TestLoggingUtil;
-use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
 
 class TestGeneratorTest extends MagentoTestCase
 {
     /**
      * Before method functionality.
+     *
+     * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         TestLoggingUtil::getInstance()->setMockLoggingUtil();
     }
@@ -36,7 +38,7 @@ class TestGeneratorTest extends MagentoTestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GenerationErrorHandler::getInstance()->reset();
     }
@@ -53,12 +55,12 @@ class TestGeneratorTest extends MagentoTestCase
             'userInput' => '{{someEntity.entity}}'
         ]);
 
-        $testObject = new TestObject("sampleTest", ["merge123" => $actionObject], [], [], "filename");
-        $testGeneratorObject = TestGenerator::getInstance("", ["sampleTest" => $testObject]);
+        $testObject = new TestObject('sampleTest', ['merge123' => $actionObject], [], [], 'filename');
+        $testGeneratorObject = TestGenerator::getInstance('', ['sampleTest' => $testObject]);
         $testGeneratorObject->createAllTestFiles(null, []);
 
         // assert that no exception for createAllTestFiles and generation error is stored in GenerationErrorHandler
-        $errorMessage = '/' . preg_quote("Removed invalid test object sampleTest") . '/';
+        $errorMessage = '/' . preg_quote('Removed invalid test object sampleTest') . '/';
         TestLoggingUtil::getInstance()->validateMockLogStatmentRegex('error', $errorMessage, []);
         $testErrors = GenerationErrorHandler::getInstance()->getErrorsByType('test');
         $this->assertArrayHasKey('sampleTest', $testErrors);
@@ -78,9 +80,9 @@ class TestGeneratorTest extends MagentoTestCase
         ]);
 
         $annotations = ['skip' => ['issue']];
-        $testObject = new TestObject("sampleTest", ["merge123" => $actionObject], $annotations, [], "filename");
+        $testObject = new TestObject('sampleTest', ['merge123' => $actionObject], $annotations, [], 'filename');
 
-        $testGeneratorObject = TestGenerator::getInstance("", ["sampleTest" => $testObject]);
+        $testGeneratorObject = TestGenerator::getInstance('', ['sampleTest' => $testObject]);
         $output = $testGeneratorObject->assembleTestPhp($testObject);
 
         $this->assertStringContainsString('This test is skipped', $output);
@@ -97,7 +99,7 @@ class TestGeneratorTest extends MagentoTestCase
     {
         // Mock allowSkipped for TestGenerator
         $mockConfig = $this->createMock(MftfApplicationConfig::class);
-        $mockConfig->expects($this->any())
+        $mockConfig
             ->method('allowSkipped')
             ->willReturn(true);
 
@@ -115,16 +117,16 @@ class TestGeneratorTest extends MagentoTestCase
         ]);
 
         $annotations = ['skip' => ['issue']];
-        $beforeHook = new TestHookObject("before", "sampleTest", ['beforeAction' => $beforeActionObject]);
+        $beforeHook = new TestHookObject('before', 'sampleTest', ['beforeAction' => $beforeActionObject]);
         $testObject = new TestObject(
-            "sampleTest",
-            ["fakeAction" => $actionObject],
+            'sampleTest',
+            ['fakeAction' => $actionObject],
             $annotations,
-            ["before" => $beforeHook],
-            "filename"
+            ['before' => $beforeHook],
+            'filename'
         );
 
-        $testGeneratorObject = TestGenerator::getInstance("", ["sampleTest" => $testObject]);
+        $testGeneratorObject = TestGenerator::getInstance('', ['sampleTest' => $testObject]);
         $output = $testGeneratorObject->assembleTestPhp($testObject);
 
         $this->assertStringNotContainsString('This test is skipped', $output);
@@ -141,8 +143,10 @@ class TestGeneratorTest extends MagentoTestCase
     public function testFilter(): void
     {
         $mockConfig = $this->createMock(MftfApplicationConfig::class);
-        $fileList = new FilterList(['severity' => ["CRITICAL"]]);
-        $mockConfig->expects($this->once())->method('getFilterList')->willReturn($fileList);
+        $fileList = new FilterList(['severity' => ['CRITICAL']]);
+        $mockConfig
+            ->method('getFilterList')
+            ->willReturn($fileList);
 
         $property = new ReflectionProperty(MftfApplicationConfig::class, 'MFTF_APPLICATION_CONTEXT');
         $property->setAccessible(true);
@@ -156,24 +160,24 @@ class TestGeneratorTest extends MagentoTestCase
         $annotation1 = ['severity' => ['CRITICAL']];
         $annotation2 = ['severity' => ['MINOR']];
         $test1 = new TestObject(
-            "test1",
-            ["fakeAction" => $actionObject],
+            'test1',
+            ['fakeAction' => $actionObject],
             $annotation1,
             [],
-            "filename"
+            'filename'
         );
         $test2 = new TestObject(
-            "test2",
-            ["fakeAction" => $actionObject],
+            'test2',
+            ['fakeAction' => $actionObject],
             $annotation2,
             [],
-            "filename"
+            'filename'
         );
 
         // Mock createCestFile to return name of tests that testGenerator tried to create
         $generatedTests = [];
         $cestFileCreatorUtil = $this->createMock(CestFileCreatorUtil::class);
-        $cestFileCreatorUtil->expects($this->once())
+        $cestFileCreatorUtil
             ->method('create')
             ->will(
                 $this->returnCallback(
@@ -187,11 +191,27 @@ class TestGeneratorTest extends MagentoTestCase
         $property->setAccessible(true);
         $property->setValue($cestFileCreatorUtil);
 
-        $testGeneratorObject = TestGenerator::getInstance("", ["sampleTest" => $test1, "test2" => $test2]);
+        $testGeneratorObject = TestGenerator::getInstance('', ['sampleTest' => $test1, 'test2' => $test2]);
         $testGeneratorObject->createAllTestFiles();
 
         // Ensure Test1 was Generated but not Test 2
         $this->assertArrayHasKey('test1Cest', $generatedTests);
         $this->assertArrayNotHasKey('test2Cest', $generatedTests);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        $cestFileCreatorUtilInstance = new ReflectionProperty(CestFileCreatorUtil::class, 'INSTANCE');
+        $cestFileCreatorUtilInstance->setAccessible(true);
+        $cestFileCreatorUtilInstance->setValue(null);
+
+        $mftfAppConfigInstance = new ReflectionProperty(MftfApplicationConfig::class, 'MFTF_APPLICATION_CONTEXT');
+        $mftfAppConfigInstance->setAccessible(true);
+        $mftfAppConfigInstance->setValue(null);
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Util/Filesystem/CestFileCreatorUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Filesystem/CestFileCreatorUtil.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\FunctionalTestingFramework\Util\Filesystem;
+
+use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
+
+class CestFileCreatorUtil
+{
+    /**
+     * Singleton CestFileCreatorUtil Instance.
+     *
+     * @var CestFileCreatorUtil
+     */
+    private static $INSTANCE;
+
+    /**
+     * CestFileCreatorUtil constructor.
+     */
+    private function __construct(){}
+
+    /**
+     * Get CestFileCreatorUtil instance.
+     *
+     * @return CestFileCreatorUtil
+     */
+    public static function getInstance()
+    {
+        if (self::$INSTANCE === null) {
+            return new self();
+        }
+
+        return self::$INSTANCE;
+    }
+
+    /**
+     * Create a single PHP file containing the $cestPhp using the $filename.
+     * If the _generated directory doesn't exist it will be created.
+     *
+     * @param string $exportDirectory
+     * @param string $testPhp
+     * @param string $filename
+     *
+     * @return void
+     * @throws TestFrameworkException
+     */
+    public function create(string $filename, string $exportDirectory, string $testPhp): void
+    {
+        DirSetupUtil::createGroupDir($exportDirectory);
+        $exportFilePath = $exportDirectory . DIRECTORY_SEPARATOR . $filename . '.php';
+        $file = fopen($exportFilePath, 'w');
+
+        if (!$file) {
+            throw new TestFrameworkException(
+                sprintf('Could not open test file: "%s"', $exportFilePath)
+            );
+        }
+
+        fwrite($file, $testPhp);
+        fclose($file);
+    }
+}

--- a/src/Magento/FunctionalTestingFramework/Util/Filesystem/CestFileCreatorUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Filesystem/CestFileCreatorUtil.php
@@ -21,7 +21,9 @@ class CestFileCreatorUtil
     /**
      * CestFileCreatorUtil constructor.
      */
-    private function __construct(){}
+    private function __construct()
+    {
+    }
 
     /**
      * Get CestFileCreatorUtil instance.
@@ -41,9 +43,9 @@ class CestFileCreatorUtil
      * Create a single PHP file containing the $cestPhp using the $filename.
      * If the _generated directory doesn't exist it will be created.
      *
+     * @param string $filename
      * @param string $exportDirectory
      * @param string $testPhp
-     * @param string $filename
      *
      * @return void
      * @throws TestFrameworkException

--- a/src/Magento/FunctionalTestingFramework/Util/Filesystem/CestFileCreatorUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Filesystem/CestFileCreatorUtil.php
@@ -30,10 +30,10 @@ class CestFileCreatorUtil
      *
      * @return CestFileCreatorUtil
      */
-    public static function getInstance()
+    public static function getInstance(): CestFileCreatorUtil
     {
-        if (self::$INSTANCE === null) {
-            return new self();
+        if (!self::$INSTANCE) {
+            self::$INSTANCE = new CestFileCreatorUtil();
         }
 
         return self::$INSTANCE;

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -22,6 +22,7 @@ use Magento\FunctionalTestingFramework\Test\Objects\ActionObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestHookObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
 use Magento\FunctionalTestingFramework\Test\Util\BaseObjectExtractor;
+use Magento\FunctionalTestingFramework\Util\Filesystem\CestFileCreatorUtil;
 use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
 use Magento\FunctionalTestingFramework\Util\Manifest\BaseTestManifest;
 use Magento\FunctionalTestingFramework\Test\Util\ActionObjectExtractor;
@@ -207,21 +208,13 @@ class TestGenerator
      *
      * @param string $testPhp
      * @param string $filename
+     *
      * @return void
      * @throws TestFrameworkException
      */
     private function createCestFile(string $testPhp, string $filename)
     {
-        DirSetupUtil::createGroupDir($this->exportDirectory);
-        $exportFilePath = $this->exportDirectory . DIRECTORY_SEPARATOR . $filename . ".php";
-        $file = fopen($exportFilePath, 'w');
-
-        if (!$file) {
-            throw new TestFrameworkException(sprintf('Could not open test file: "%s"', $exportFilePath));
-        }
-
-        fwrite($file, $testPhp);
-        fclose($file);
+        CestFileCreatorUtil::getInstance()->create($filename, $this->exportDirectory, $testPhp);
     }
 
     /**


### PR DESCRIPTION
### Description
I've eliminated AspectMock usage from 
`dev/tests/unit/Magento/FunctionalTestFramework/Util/TestGeneratorTest.php`.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#33309: [MFTF] Eliminate AspectMock from TestGeneratorTest (Complex!)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests