### PR TITLE
33293: Eliminated AspectMock usage from PersistedObjectHandlerTest.php

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace tests\unit\Magento\FunctionalTestFramework\DataGenerator\Handlers;
 
 use Exception;
+use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
 use Magento\FunctionalTestingFramework\DataGenerator\Parsers\DataProfileSchemaParser;
 use Magento\FunctionalTestingFramework\DataGenerator\Persist\CurlHandler;
@@ -15,10 +16,8 @@ use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Exceptions\TestReferenceException;
 use Magento\FunctionalTestingFramework\ObjectManager;
 use Magento\FunctionalTestingFramework\ObjectManagerFactory;
-use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
 use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
-use tests\unit\Util\ObjectHandlerUtil;
 use tests\unit\Util\TestLoggingUtil;
 
 /**
@@ -261,15 +260,14 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         ";
 
         // Mock Classes
-        ObjectHandlerUtil::mockDataObjectHandlerWithData($parserOutput);
-        $this->mockCurlHandler($jsonResponse);
+        $this->mockCurlHandler($jsonResponse, $parserOutput);
         $handler = PersistedObjectHandler::getInstance();
         $handler->createEntity(
             $entityStepKey,
             $scope,
             $entityName
         );
-        $this->mockCurlHandler($updatedResponse);
+        $this->mockCurlHandler($updatedResponse, $parserOutput);
         
         // Call method
         $handler->updateEntity(

--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php
@@ -538,8 +538,8 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         $dataObjectHandler->setAccessible(true);
         $dataObjectHandler->setValue(null);
 
-        $mockDataProfileSchemaParser = $this->createMock(DataProfileSchemaParser::class);
-        $mockDataProfileSchemaParser
+        $dataProfileSchemaParser = $this->createMock(DataProfileSchemaParser::class);
+        $dataProfileSchemaParser
             ->method('readDataProfiles')
             ->willReturn($parserOutput);
 
@@ -554,26 +554,22 @@ class PersistedObjectHandlerTest extends MagentoTestCase
             ->method('isContentTypeJson')
             ->willReturn(true);
 
-        $objectManagerInstance = ObjectManagerFactory::getObjectManager();
+        $objectManager = ObjectManagerFactory::getObjectManager();
         $objectManagerMockInstance = $this->createMock(ObjectManager::class);
         $objectManagerMockInstance->expects($this->any())
             ->method('create')
             ->will(
                 $this->returnCallback(
-                    function (
-                        string $class,
-                        array $arguments = []
-                    ) use ($curlHandler, $objectManagerInstance, $mockDataProfileSchemaParser)
-                    {
+                    function ($class, $arguments = []) use ($curlHandler, $objectManager, $dataProfileSchemaParser) {
                         if ($class === CurlHandler::class) {
                             return $curlHandler;
                         }
 
                         if ($class === DataProfileSchemaParser::class) {
-                            return $mockDataProfileSchemaParser;
+                            return $dataProfileSchemaParser;
                         }
 
-                        return $objectManagerInstance->create($class, $arguments);
+                        return $objectManager->create($class, $arguments);
                     }
                 )
             );

--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php
@@ -3,18 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace tests\unit\Magento\FunctionalTestFramework\DataGenerator\Handlers;
 
-use AspectMock\Test as AspectMock;
-use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
+use Exception;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\PersistedObjectHandler;
-use Magento\FunctionalTestingFramework\DataGenerator\Parsers\DataProfileSchemaParser;
 use Magento\FunctionalTestingFramework\DataGenerator\Persist\CurlHandler;
-use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Exceptions\TestReferenceException;
-use Magento\FunctionalTestingFramework\ObjectManager;
-use Magento\FunctionalTestingFramework\ObjectManagerFactory;
+use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
 use tests\unit\Util\ObjectHandlerUtil;
 use tests\unit\Util\TestLoggingUtil;
@@ -25,28 +22,31 @@ use tests\unit\Util\TestLoggingUtil;
 class PersistedObjectHandlerTest extends MagentoTestCase
 {
     /**
-     * Before test functionality
-     * @return void
+     * @inheritDoc
      */
     public function setUp(): void
     {
         TestLoggingUtil::getInstance()->setMockLoggingUtil();
     }
 
-    public function testCreateEntityWithNonExistingName()
+    /**
+     * Validate testCreateEntityWithNonExistingName.
+     *
+     * @return void
+     * @throws TestReferenceException
+     */
+    public function testCreateEntityWithNonExistingName(): void
     {
         // Test Data and Variables
-        $entityName = "InvalidEntity";
-        $entityStepKey = "StepKey";
+        $entityName = 'InvalidEntity';
+        $entityStepKey = 'StepKey';
         $scope = PersistedObjectHandler::TEST_SCOPE;
 
         $exceptionMessage = "Entity \"" . $entityName . "\" does not exist." .
             "\nException occurred executing action at StepKey \"" . $entityStepKey . "\"";
 
         $this->expectException(TestReferenceException::class);
-
         $this->expectExceptionMessage($exceptionMessage);
-
         $handler = PersistedObjectHandler::getInstance();
 
         // Call method
@@ -57,13 +57,19 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         );
     }
 
-    public function testCreateSimpleEntity()
+    /**
+     * Validate testCreateSimpleEntity.
+     *
+     * @return void
+     * @throws TestReferenceException
+     */
+    public function testCreateSimpleEntity(): void
     {
         // Test Data and Variables
-        $entityName = "EntityOne";
-        $entityStepKey = "StepKey";
-        $dataKey = "testKey";
-        $dataValue = "testValue";
+        $entityName = 'EntityOne';
+        $entityStepKey = 'StepKey';
+        $dataKey = 'testKey';
+        $dataValue = 'testValue';
         $scope = PersistedObjectHandler::TEST_SCOPE;
         $parserOutput = [
             'entity' => [
@@ -78,7 +84,7 @@ class PersistedObjectHandlerTest extends MagentoTestCase
                 ]
             ]
         ];
-        $jsonResponse =  "
+        $jsonResponse = "
             {
                \"" . strtolower($dataKey) . "\" : \"{$dataValue}\"
             }
@@ -100,13 +106,19 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         $this->assertEquals($dataValue, $persistedValue);
     }
 
-    public function testDeleteSimpleEntity()
+    /**
+     * Validate testDeleteSimpleEntity.
+     *
+     * @return void
+     * @throws TestReferenceException
+     */
+    public function testDeleteSimpleEntity(): void
     {
         // Test Data and Variables
-        $entityName = "EntityOne";
-        $entityStepKey = "StepKey";
-        $dataKey = "testKey";
-        $dataValue = "testValue";
+        $entityName = 'EntityOne';
+        $entityStepKey = 'StepKey';
+        $dataKey = 'testKey';
+        $dataValue = 'testValue';
         $scope = PersistedObjectHandler::TEST_SCOPE;
         $parserOutput = [
             'entity' => [
@@ -121,7 +133,7 @@ class PersistedObjectHandlerTest extends MagentoTestCase
                 ]
             ]
         ];
-        $jsonResponse =  "
+        $jsonResponse = "
             {
                \"" . strtolower($dataKey) . "\" : \"{$dataValue}\"
             }
@@ -148,13 +160,19 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testGetSimpleEntity()
+    /**
+     * Validate testGetSimpleEntity.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testGetSimpleEntity(): void
     {
         // Test Data and Variables
-        $entityName = "EntityOne";
-        $entityStepKey = "StepKey";
-        $dataKey = "testKey";
-        $dataValue = "testValue";
+        $entityName = 'EntityOne';
+        $entityStepKey = 'StepKey';
+        $dataKey = 'testKey';
+        $dataValue = 'testValue';
         $scope = PersistedObjectHandler::TEST_SCOPE;
         $parserOutput = [
             'entity' => [
@@ -169,7 +187,7 @@ class PersistedObjectHandlerTest extends MagentoTestCase
                 ]
             ]
         ];
-        $jsonResponse =  "
+        $jsonResponse = "
             {
                \"" . strtolower($dataKey) . "\" : \"{$dataValue}\"
             }
@@ -191,16 +209,22 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         $this->assertEquals($dataValue, $persistedValue);
     }
 
-    public function testUpdateSimpleEntity()
+    /**
+     * Validate testUpdateSimpleEntity.
+     *
+     * @return void
+     * @throws TestReferenceException
+     */
+    public function testUpdateSimpleEntity(): void
     {
-        $this->markTestSkipped("Potential Bug in DataPersistenceHandler class");
+        $this->markTestSkipped('Potential Bug in DataPersistenceHandler class');
         // Test Data and Variables
-        $entityName = "EntityOne";
-        $entityStepKey = "StepKey";
-        $dataKey = "testKey";
-        $dataValue = "testValue";
-        $updateName = "EntityTwo";
-        $updateValue = "newValue";
+        $entityName = 'EntityOne';
+        $entityStepKey = 'StepKey';
+        $dataKey = 'testKey';
+        $dataValue = 'testValue';
+        $updateName = 'EntityTwo';
+        $updateValue = 'newValue';
         $scope = PersistedObjectHandler::TEST_SCOPE;
         $parserOutput = [
             'entity' => [
@@ -224,7 +248,7 @@ class PersistedObjectHandlerTest extends MagentoTestCase
                 ]
             ]
         ];
-        $jsonResponse =  "
+        $jsonResponse = "
             {
                \"" . strtolower($dataKey) . "\" : \"{$dataValue}\"
             }
@@ -257,21 +281,27 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         $this->assertEquals($updateValue, $persistedValue);
     }
 
-    public function testRetrieveEntityAcrossScopes()
+    /**
+     * Validate testRetrieveEntityAcrossScopes.
+     *
+     * @return void
+     * @throws TestReferenceException
+     */
+    public function testRetrieveEntityAcrossScopes(): void
     {
         // Test Data and Variables
-        $entityNameOne = "EntityOne";
-        $entityStepKeyOne = "StepKeyOne";
-        $dataKeyOne = "testKeyOne";
-        $dataValueOne = "testValueOne";
-        $entityNameTwo = "EntityTwo";
-        $entityStepKeyTwo = "StepKeyTwo";
-        $dataKeyTwo = "testKeyTwo";
-        $dataValueTwo = "testValueTwo";
-        $entityNameThree = "EntityThree";
-        $entityStepKeyThree = "StepKeyThree";
-        $dataKeyThree = "testKeyThree";
-        $dataValueThree = "testValueThree";
+        $entityNameOne = 'EntityOne';
+        $entityStepKeyOne = 'StepKeyOne';
+        $dataKeyOne = 'testKeyOne';
+        $dataValueOne = 'testValueOne';
+        $entityNameTwo = 'EntityTwo';
+        $entityStepKeyTwo = 'StepKeyTwo';
+        $dataKeyTwo = 'testKeyTwo';
+        $dataValueTwo = 'testValueTwo';
+        $entityNameThree = 'EntityThree';
+        $entityStepKeyThree = 'StepKeyThree';
+        $dataKeyThree = 'testKeyThree';
+        $dataValueThree = 'testValueThree';
 
         $parserOutputOne = [
             'entity' => [
@@ -368,6 +398,8 @@ class PersistedObjectHandlerTest extends MagentoTestCase
     }
 
     /**
+     * Validate testRetrieveEntityValidField.
+     *
      * @param string $name
      * @param string $key
      * @param string $value
@@ -375,9 +407,18 @@ class PersistedObjectHandlerTest extends MagentoTestCase
      * @param string $scope
      * @param string $stepKey
      * @dataProvider entityDataProvider
+     *
+     * @return void
+     * @throws TestReferenceException
      */
-    public function testRetrieveEntityValidField($name, $key, $value, $type, $scope, $stepKey)
-    {
+    public function testRetrieveEntityValidField(
+        string $name,
+        string $key,
+        string $value,
+        string $type,
+        string $scope,
+        string $stepKey
+    ): void {
         $parserOutputOne = [
             'entity' => [
                 $name => [
@@ -411,6 +452,8 @@ class PersistedObjectHandlerTest extends MagentoTestCase
     }
 
     /**
+     * Validate testRetrieveEntityInValidField.
+     *
      * @param string $name
      * @param string $key
      * @param string $value
@@ -418,14 +461,21 @@ class PersistedObjectHandlerTest extends MagentoTestCase
      * @param string $scope
      * @param string $stepKey
      * @dataProvider entityDataProvider
+     *
+     * @return void
      * @throws TestReferenceException
-     * @throws TestFrameworkException
      */
-    public function testRetrieveEntityInValidField($name, $key, $value, $type, $scope, $stepKey)
-    {
-        $invalidDataKey = "invalidDataKey";
+    public function testRetrieveEntityInValidField(
+        string $name,
+        string $key,
+        string $value,
+        string $type,
+        string $scope,
+        string $stepKey
+    ): void {
+        $invalidDataKey = 'invalidDataKey';
         $warnMsg = "Undefined field {$invalidDataKey} in entity object with a stepKey of {$stepKey}\n";
-        $warnMsg .= "Please fix the invalid reference. This will result in fatal error in next major release.";
+        $warnMsg .= 'Please fix the invalid reference. This will result in fatal error in next major release.';
 
         $parserOutputOne = [
             'entity' => [
@@ -465,8 +515,10 @@ class PersistedObjectHandlerTest extends MagentoTestCase
 
     /**
      * Data provider for testRetrieveEntityField
+     *
+     * @return array
      */
-    public static function entityDataProvider()
+    public static function entityDataProvider(): array
     {
         return [
             ['Entity1', 'testKey1', 'testValue1', 'testType', PersistedObjectHandler::HOOK_SCOPE, 'StepKey1'],
@@ -475,20 +527,37 @@ class PersistedObjectHandlerTest extends MagentoTestCase
         ];
     }
 
-    public function mockCurlHandler($response)
+    /**
+     * Create mock curl handler.
+     *
+     * @param string $response
+     * @throws Exception
+     */
+    public function mockCurlHandler(string $response): void
     {
-        AspectMock::double(CurlHandler::class, [
-            "__construct" => null,
-            "executeRequest" => $response,
-            "getRequestDataArray" => [],
-            "isContentTypeJson" => true
-        ]);
+        $mockCurlHandler = $this->createMock(CurlHandler::class);
+        $mockCurlHandler->expects($this->any())
+            ->method('executeRequest')
+            ->willReturn($response);
+        $mockCurlHandler->expects($this->once())
+            ->method('getRequestDataArray')
+            ->willReturn([]);
+        $mockCurlHandler->expects($this->once())
+            ->method('isContentTypeJson')
+            ->willReturn(true);
+
+        $property = new ReflectionProperty(CurlHandler::class, "INSTANCE");
+        $property->setAccessible(true);
+        $property->setValue($mockCurlHandler);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function tearDown(): void
     {
         // Clear out Singleton between tests
-        $property = new \ReflectionProperty(PersistedObjectHandler::class, "INSTANCE");
+        $property = new ReflectionProperty(PersistedObjectHandler::class, 'INSTANCE');
         $property->setAccessible(true);
         $property->setValue(null);
 
@@ -496,8 +565,7 @@ class PersistedObjectHandlerTest extends MagentoTestCase
     }
 
     /**
-     * After class functionality
-     * @return void
+     * @inheritDoc
      */
     public static function tearDownAfterClass(): void
     {

--- a/dev/tests/unit/Util/MagentoTestCase.php
+++ b/dev/tests/unit/Util/MagentoTestCase.php
@@ -19,6 +19,8 @@ class MagentoTestCase extends TestCase
         if (!self::fileExists(DOCS_OUTPUT_DIR)) {
             mkdir(DOCS_OUTPUT_DIR, 0755, true);
         }
+        // Should be used to clean AspectMock mocking before using PHPUnit mocking and Reflection.
+        AspectMock::clean();
         parent::setUpBeforeClass();
     }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
@@ -64,6 +64,13 @@ class CurlHandler
     private $isJson;
 
     /**
+     * Singleton CurlHandler Instance.
+     *
+     * @var CurlHandler
+     */
+    private static $INSTANCE;
+
+    /**
      * Operation to Curl method mapping.
      *
      * @var array
@@ -82,7 +89,7 @@ class CurlHandler
      * @param EntityDataObject $entityObject
      * @param string           $storeCode
      */
-    public function __construct($operation, $entityObject, $storeCode = null)
+    private function __construct($operation, $entityObject, $storeCode = null)
     {
         $this->operation = $operation;
         $this->entityObject = $entityObject;
@@ -93,6 +100,27 @@ class CurlHandler
             $this->entityObject->getType()
         );
         $this->isJson = false;
+    }
+
+    /**
+     * Get CurlHandler instance.
+     *
+     * @param string $operation
+     * @param EntityDataObject $entityObject
+     * @param string|null $storeCode
+     *
+     * @return CurlHandler
+     */
+    public static function getInstance(
+        string $operation,
+        EntityDataObject $entityObject,
+        ?string $storeCode = null
+    ) {
+        if (self::$INSTANCE === null) {
+            return new self($operation, $entityObject, $storeCode);
+        }
+
+        return self::$INSTANCE;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
@@ -105,9 +105,9 @@ class CurlHandler
     /**
      * Get CurlHandler instance.
      *
-     * @param string $operation
+     * @param string           $operation
      * @param EntityDataObject $entityObject
-     * @param string|null $storeCode
+     * @param string|null      $storeCode
      *
      * @return CurlHandler
      */

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/CurlHandler.php
@@ -64,13 +64,6 @@ class CurlHandler
     private $isJson;
 
     /**
-     * Singleton CurlHandler Instance.
-     *
-     * @var CurlHandler
-     */
-    private static $INSTANCE;
-
-    /**
      * Operation to Curl method mapping.
      *
      * @var array
@@ -89,7 +82,7 @@ class CurlHandler
      * @param EntityDataObject $entityObject
      * @param string           $storeCode
      */
-    private function __construct($operation, $entityObject, $storeCode = null)
+    public function __construct($operation, $entityObject, $storeCode = null)
     {
         $this->operation = $operation;
         $this->entityObject = $entityObject;
@@ -100,27 +93,6 @@ class CurlHandler
             $this->entityObject->getType()
         );
         $this->isJson = false;
-    }
-
-    /**
-     * Get CurlHandler instance.
-     *
-     * @param string           $operation
-     * @param EntityDataObject $entityObject
-     * @param string|null      $storeCode
-     *
-     * @return CurlHandler
-     */
-    public static function getInstance(
-        string $operation,
-        EntityDataObject $entityObject,
-        ?string $storeCode = null
-    ) {
-        if (self::$INSTANCE === null) {
-            return new self($operation, $entityObject, $storeCode);
-        }
-
-        return self::$INSTANCE;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/DataPersistenceHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/DataPersistenceHandler.php
@@ -9,6 +9,7 @@ namespace Magento\FunctionalTestingFramework\DataGenerator\Persist;
 use Magento\FunctionalTestingFramework\DataGenerator\Objects\EntityDataObject;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
+use Magento\FunctionalTestingFramework\ObjectManagerFactory;
 
 /**
  * Class DataPersistenceHandler
@@ -86,7 +87,10 @@ class DataPersistenceHandler
         if (!empty($storeCode)) {
             $this->storeCode = $storeCode;
         }
-        $curlHandler = CurlHandler::getInstance('create', $this->entityObject, $this->storeCode);
+        $curlHandler = ObjectManagerFactory::getObjectManager()->create(
+            CurlHandler::class,
+            ['create', $this->entityObject, $this->storeCode]
+        );
         $result = $curlHandler->executeRequest($this->dependentObjects);
         $this->setCreatedObject(
             $result,
@@ -111,7 +115,10 @@ class DataPersistenceHandler
             $this->dependentObjects[] = $dependentObject->getCreatedObject();
         }
         $updateEntityObject = DataObjectHandler::getInstance()->getObject($updateDataName);
-        $curlHandler = CurlHandler::getInstance('update', $updateEntityObject, $this->storeCode);
+        $curlHandler = ObjectManagerFactory::getObjectManager()->create(
+            CurlHandler::class,
+            ['update', $updateEntityObject, $this->storeCode]
+        );
         $result = $curlHandler->executeRequest(array_merge($this->dependentObjects, [$this->createdObject]));
         $this->setCreatedObject(
             $result,
@@ -134,7 +141,10 @@ class DataPersistenceHandler
         if (!empty($storeCode)) {
             $this->storeCode = $storeCode;
         }
-        $curlHandler = CurlHandler::getInstance('get', $this->entityObject, $this->storeCode);
+        $curlHandler = ObjectManagerFactory::getObjectManager()->create(
+            CurlHandler::class,
+            ['get', $this->entityObject, $this->storeCode]
+        );
         $result = $curlHandler->executeRequest($this->dependentObjects);
         $this->setCreatedObject(
             $result,
@@ -152,7 +162,11 @@ class DataPersistenceHandler
      */
     public function deleteEntity()
     {
-        $curlHandler = CurlHandler::getInstance('delete', $this->createdObject, $this->storeCode);
+        $curlHandler = ObjectManagerFactory::getObjectManager()->create(
+            CurlHandler::class,
+            ['delete', $this->createdObject, $this->storeCode]
+        );
+
         $curlHandler->executeRequest($this->dependentObjects);
     }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/DataPersistenceHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/DataPersistenceHandler.php
@@ -86,7 +86,7 @@ class DataPersistenceHandler
         if (!empty($storeCode)) {
             $this->storeCode = $storeCode;
         }
-        $curlHandler = new CurlHandler('create', $this->entityObject, $this->storeCode);
+        $curlHandler = CurlHandler::getInstance('create', $this->entityObject, $this->storeCode);
         $result = $curlHandler->executeRequest($this->dependentObjects);
         $this->setCreatedObject(
             $result,
@@ -111,7 +111,7 @@ class DataPersistenceHandler
             $this->dependentObjects[] = $dependentObject->getCreatedObject();
         }
         $updateEntityObject = DataObjectHandler::getInstance()->getObject($updateDataName);
-        $curlHandler = new CurlHandler('update', $updateEntityObject, $this->storeCode);
+        $curlHandler = CurlHandler::getInstance('update', $updateEntityObject, $this->storeCode);
         $result = $curlHandler->executeRequest(array_merge($this->dependentObjects, [$this->createdObject]));
         $this->setCreatedObject(
             $result,
@@ -134,7 +134,7 @@ class DataPersistenceHandler
         if (!empty($storeCode)) {
             $this->storeCode = $storeCode;
         }
-        $curlHandler = new CurlHandler('get', $this->entityObject, $this->storeCode);
+        $curlHandler = CurlHandler::getInstance('get', $this->entityObject, $this->storeCode);
         $result = $curlHandler->executeRequest($this->dependentObjects);
         $this->setCreatedObject(
             $result,
@@ -152,7 +152,7 @@ class DataPersistenceHandler
      */
     public function deleteEntity()
     {
-        $curlHandler = new CurlHandler('delete', $this->createdObject, $this->storeCode);
+        $curlHandler = CurlHandler::getInstance('delete', $this->createdObject, $this->storeCode);
         $curlHandler->executeRequest($this->dependentObjects);
     }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/DataPersistenceHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/DataPersistenceHandler.php
@@ -89,7 +89,7 @@ class DataPersistenceHandler
         }
         $curlHandler = ObjectManagerFactory::getObjectManager()->create(
             CurlHandler::class,
-            ['create', $this->entityObject, $this->storeCode]
+            ['operation' => 'create', 'entityObject' => $this->entityObject, 'storeCode' => $this->storeCode]
         );
         $result = $curlHandler->executeRequest($this->dependentObjects);
         $this->setCreatedObject(
@@ -117,7 +117,7 @@ class DataPersistenceHandler
         $updateEntityObject = DataObjectHandler::getInstance()->getObject($updateDataName);
         $curlHandler = ObjectManagerFactory::getObjectManager()->create(
             CurlHandler::class,
-            ['update', $updateEntityObject, $this->storeCode]
+            ['operation' => 'update', 'entityObject' => $updateEntityObject, 'storeCode' => $this->storeCode]
         );
         $result = $curlHandler->executeRequest(array_merge($this->dependentObjects, [$this->createdObject]));
         $this->setCreatedObject(
@@ -143,7 +143,7 @@ class DataPersistenceHandler
         }
         $curlHandler = ObjectManagerFactory::getObjectManager()->create(
             CurlHandler::class,
-            ['get', $this->entityObject, $this->storeCode]
+            ['operation' => 'get', 'entityObject' => $this->entityObject, 'storeCode' => $this->storeCode]
         );
         $result = $curlHandler->executeRequest($this->dependentObjects);
         $this->setCreatedObject(
@@ -164,7 +164,7 @@ class DataPersistenceHandler
     {
         $curlHandler = ObjectManagerFactory::getObjectManager()->create(
             CurlHandler::class,
-            ['delete', $this->createdObject, $this->storeCode]
+            ['operation' => 'delete', 'entityObject' => $this->createdObject, 'storeCode' => $this->storeCode]
         );
 
         $curlHandler->executeRequest($this->dependentObjects);


### PR DESCRIPTION
### Description

I've eliminated AspectMock usage from `dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Handlers/PersistedObjectHandlerTest.php`

### Fixed Issues (if relevant)

1. Fixes magento/magento2#33293:[MFTF] Replace AspectMock with PHPUnit for PersistedObjectHandlerTest

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests