### PR TITLE
Issue 33297: Eliminate AspectMock from DataExtensionUtilTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Util/DataExtensionUtilTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Util/DataExtensionUtilTest.php
@@ -3,37 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace tests\unit\Magento\FunctionalTestFramework\DataGenerator\Util;
 
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\DataObjectHandler;
 use Magento\FunctionalTestingFramework\DataGenerator\Parsers\DataProfileSchemaParser;
-use Magento\FunctionalTestingFramework\ObjectManager\ObjectManager;
-use Magento\FunctionalTestingFramework\ObjectManagerFactory;
+use Magento\FunctionalTestingFramework\ObjectManager;
+use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
-use AspectMock\Test as AspectMock;
 
 /**
  * Class DataExtensionUtilTest
  */
 class DataExtensionUtilTest extends MagentoTestCase
 {
-    /**
-     * Before method functionality
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        AspectMock::clean();
-    }
-
-    public function testNoParentData()
+    public function testNoParentData(): void
     {
         $extendedDataObject = [
             'entity' => [
                 'extended' => [
                     'type' => 'testType',
-                    'extends' => "parent",
+                    'extends' => 'parent',
                     'data' => [
                         0 => [
                             'key' => 'testKey',
@@ -46,21 +37,21 @@ class DataExtensionUtilTest extends MagentoTestCase
 
         $this->setMockEntities($extendedDataObject);
 
-        $this->expectExceptionMessage("Parent Entity parent not defined for Entity extended.");
-        DataObjectHandler::getInstance()->getObject("extended");
+        $this->expectExceptionMessage('Parent Entity parent not defined for Entity extended.');
+        DataObjectHandler::getInstance()->getObject('extended');
     }
 
-    public function testAlreadyExtendedParentData()
+    public function testAlreadyExtendedParentData(): void
     {
         $extendedDataObjects = [
             'entity' => [
                 'extended' => [
                     'type' => 'testType',
-                    'extends' => "parent"
+                    'extends' => 'parent'
                 ],
                 'parent' => [
                     'type' => 'type',
-                    'extends' => "grandparent"
+                    'extends' => 'grandparent'
                 ],
                 'grandparent' => [
                     'type' => 'grand'
@@ -71,18 +62,18 @@ class DataExtensionUtilTest extends MagentoTestCase
         $this->setMockEntities($extendedDataObjects);
 
         $this->expectExceptionMessage(
-            "Cannot extend an entity that already extends another entity. Entity: parent." . PHP_EOL
+            'Cannot extend an entity that already extends another entity. Entity: parent.' . PHP_EOL
         );
-        DataObjectHandler::getInstance()->getObject("extended");
+        DataObjectHandler::getInstance()->getObject('extended');
     }
 
-    public function testExtendedVarGetter()
+    public function testExtendedVarGetter(): void
     {
         $extendedDataObjects = [
             'entity' => [
                 'extended' => [
                     'type' => 'testType',
-                    'extends' => "parent"
+                    'extends' => 'parent'
                 ],
                 'parent' => [
                     'type' => 'type',
@@ -98,18 +89,18 @@ class DataExtensionUtilTest extends MagentoTestCase
         ];
 
         $this->setMockEntities($extendedDataObjects);
-        $resultextendedDataObject = DataObjectHandler::getInstance()->getObject("extended");
+        $resultextendedDataObject = DataObjectHandler::getInstance()->getObject('extended');
         // Perform Asserts
-        $this->assertEquals("someOtherEntity->id", $resultextendedDataObject->getVarReference("someOtherEntity"));
+        $this->assertEquals('someOtherEntity->id', $resultextendedDataObject->getVarReference('someOtherEntity'));
     }
 
-    public function testGetLinkedEntities()
+    public function testGetLinkedEntities(): void
     {
         $extendedDataObjects = [
             'entity' => [
                 'extended' => [
                     'type' => 'testType',
-                    'extends' => "parent"
+                    'extends' => 'parent'
                 ],
                 'parent' => [
                     'type' => 'type',
@@ -129,27 +120,36 @@ class DataExtensionUtilTest extends MagentoTestCase
 
         $this->setMockEntities($extendedDataObjects);
         // Perform Asserts
-        $resultextendedDataObject = DataObjectHandler::getInstance()->getObject("extended");
-        $this->assertEquals("linkedEntity1", $resultextendedDataObject->getLinkedEntitiesOfType("linkedEntityType")[0]);
-        $this->assertEquals("linkedEntity2", $resultextendedDataObject->getLinkedEntitiesOfType("otherEntityType")[0]);
+        $resultextendedDataObject = DataObjectHandler::getInstance()->getObject('extended');
+        $this->assertEquals('linkedEntity1', $resultextendedDataObject->getLinkedEntitiesOfType('linkedEntityType')[0]);
+        $this->assertEquals('linkedEntity2', $resultextendedDataObject->getLinkedEntitiesOfType('otherEntityType')[0]);
     }
 
-    private function setMockEntities($mockEntityData)
+    /**
+     * Prepare mock entites.
+     *
+     * @param $mockEntityData
+     *
+     * @return void
+     */
+    private function setMockEntities($mockEntityData): void
     {
-        $property = new \ReflectionProperty(DataObjectHandler::class, 'INSTANCE');
+        $property = new ReflectionProperty(DataObjectHandler::class, 'INSTANCE');
         $property->setAccessible(true);
         $property->setValue(null);
 
-        $mockDataProfileSchemaParser = AspectMock::double(DataProfileSchemaParser::class, [
-            'readDataProfiles' => $mockEntityData
-        ])->make();
+        $mockDataProfileSchemaParser = $this->createMock(DataProfileSchemaParser::class);
+        $mockDataProfileSchemaParser->expects($this->any())
+            ->method('readDataProfiles')
+            ->willReturn($mockEntityData);
 
-        $mockObjectManager = AspectMock::double(ObjectManager::class, [
-            'create' => $mockDataProfileSchemaParser
-        ])->make();
+        $mockObjectManager = $this->createMock(ObjectManager::class);
+        $mockObjectManager
+            ->method('create')
+            ->willReturn($mockDataProfileSchemaParser);
 
-        AspectMock::double(ObjectManagerFactory::class, [
-            'getObjectManager' => $mockObjectManager
-        ]);
+        $property = new ReflectionProperty(ObjectManager::class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue($mockObjectManager);
     }
 }

--- a/dev/tests/unit/Util/MagentoTestCase.php
+++ b/dev/tests/unit/Util/MagentoTestCase.php
@@ -19,6 +19,8 @@ class MagentoTestCase extends TestCase
         if (!self::fileExists(DOCS_OUTPUT_DIR)) {
             mkdir(DOCS_OUTPUT_DIR, 0755, true);
         }
+        // Should be used to clean AspectMock mocking before using PHPUnit mocking and Reflection.
+        AspectMock::clean();
         parent::setUpBeforeClass();
     }
 


### PR DESCRIPTION
### Description
Eliminated AspectMock usage from `dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Util/DataExtensionUtilTest.php`

### Fixed Issues (if relevant)
1. Fixes magento/magento2#33297: [MFTF] Eliminate AspectMock from DataExtensionUtilTest (Complex!)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests