### PR TITLE
33306: Eliminated AspectMock from the ParallelGroupSorterTest class

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Sorter/ParallelGroupSorterTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Sorter/ParallelGroupSorterTest.php
@@ -64,7 +64,7 @@ class ParallelGroupSorterTest extends MagentoTestCase
     public function testTestsAndSuitesSplitByTime(): void
     {
         // mock tests for test object handler.
-        $this->createMockForTest(0);
+        $this->createMockForTest(0, [300, 275]);
 
         // create test to size array
         $sampleTestArray = [
@@ -421,17 +421,17 @@ class ParallelGroupSorterTest extends MagentoTestCase
      * Mock test object and test object handler.
      *
      * @param int $numberOfCalls
+     * @param array $actionCount
      *
      * @return void
      */
-    private function createMockForTest(int $numberOfCalls): void
+    private function createMockForTest(int $numberOfCalls, array $actionCount = [300, 275, 300, 275]): void
     {
         $mockTest1 = $this->createMock(TestObject::class);
         $mockTest1
             ->method('getEstimatedDuration')
             ->willReturnCallback(
-                function () use (&$numberOfCalls) {
-                    $actionCount = [300, 275, 300, 275];
+                function () use (&$numberOfCalls, $actionCount) {
                     $result = $actionCount[$numberOfCalls];
                     $numberOfCalls++;
 

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Sorter/ParallelGroupSorterTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Sorter/ParallelGroupSorterTest.php
@@ -3,23 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Magento\FunctionalTestFramework\Util\Sorter;
 
-use AspectMock\Test as AspectMock;
 use Magento\FunctionalTestingFramework\Exceptions\FastFailException;
-use Magento\FunctionalTestingFramework\Suite\Handlers\SuiteObjectHandler;
-use Magento\FunctionalTestingFramework\Suite\Objects\SuiteObject;
 use Magento\FunctionalTestingFramework\Test\Handlers\TestObjectHandler;
 use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
 use Magento\FunctionalTestingFramework\Util\Sorter\ParallelGroupSorter;
+use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
 
 class ParallelGroupSorterTest extends MagentoTestCase
 {
     /**
-     * Test a basic sort of available tests based on size
+     * Test a basic sort of available tests based on size.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testBasicTestsSplitByTime()
+    public function testBasicTestsSplitByTime(): void
     {
         $sampleTestArray = [
             'test1' => 100,
@@ -44,7 +47,6 @@ class ParallelGroupSorterTest extends MagentoTestCase
 
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedBySize([], $sampleTestArray, 200);
-
         $this->assertCount(5, $actualResult);
 
         foreach ($actualResult as $gropuNumber => $actualTests) {
@@ -54,31 +56,15 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test a sort of both tests and a suite which is larger than the given line limitation
+     * Test a sort of both tests and a suite which is larger than the given line limitation.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testTestsAndSuitesSplitByTime()
+    public function testTestsAndSuitesSplitByTime(): void
     {
         // mock tests for test object handler.
-        $numberOfCalls = 0;
-        $mockTest1 = AspectMock::double(
-            TestObject::class,
-            ['getEstimatedDuration' => function () use (&$numberOfCalls) {
-                $actionCount = [300, 275];
-                $result = $actionCount[$numberOfCalls];
-                $numberOfCalls++;
-
-                return $result;
-            }]
-        )->make();
-
-        $mockHandler = AspectMock::double(
-            TestObjectHandler::class,
-            ['getObject' => function () use ($mockTest1) {
-                    return $mockTest1;
-            }]
-        )->make();
-
-        AspectMock::double(TestObjectHandler::class, ['getInstance' => $mockHandler])->make();
+        $this->createMockForTest(0);
 
         // create test to size array
         $sampleTestArray = [
@@ -115,9 +101,12 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests based on a fixed group number
+     * Test splitting tests based on a fixed group number.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testBasicTestsSplitByGroup()
+    public function testBasicTestsSplitByGroup(): void
     {
         $sampleTestArray = [
             'test1' => 100,
@@ -140,7 +129,7 @@ class ParallelGroupSorterTest extends MagentoTestCase
             'test18' => 34,
             'test19' => 45,
             'test20' => 58,
-            'test21' => 9,
+            'test21' => 9
         ];
 
         $expectedResult = [
@@ -153,7 +142,6 @@ class ParallelGroupSorterTest extends MagentoTestCase
 
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedByFixedGroupCount([], $sampleTestArray, 5);
-
         $this->assertCount(5, $actualResult);
 
         foreach ($actualResult as $gropuNumber => $actualTests) {
@@ -163,16 +151,19 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests based a group number bigger than ever needed
+     * Test splitting tests based a group number bigger than ever needed.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testBasicTestsSplitByBigGroupNumber()
+    public function testBasicTestsSplitByBigGroupNumber(): void
     {
         $sampleTestArray = [
             'test1' => 100,
             'test2' => 300,
             'test3' => 50,
             'test4' => 60,
-            'test5' => 25,
+            'test5' => 25
         ];
 
         $expectedResult = [
@@ -185,7 +176,6 @@ class ParallelGroupSorterTest extends MagentoTestCase
 
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedByFixedGroupCount([], $sampleTestArray, 10);
-
         $this->assertCount(5, $actualResult);
 
         foreach ($actualResult as $gropuNumber => $actualTests) {
@@ -195,9 +185,12 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests based a minimum group number
+     * Test splitting tests based a minimum group number.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testBasicTestsSplitByMinGroupNumber()
+    public function testBasicTestsSplitByMinGroupNumber(): void
     {
         $sampleTestArray = [
             'test1' => 100,
@@ -213,7 +206,6 @@ class ParallelGroupSorterTest extends MagentoTestCase
 
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedByFixedGroupCount([], $sampleTestArray, 1);
-
         $this->assertCount(1, $actualResult);
 
         foreach ($actualResult as $gropuNumber => $actualTests) {
@@ -223,31 +215,15 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests and suites based on a fixed group number
+     * Test splitting tests and suites based on a fixed group number.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testTestsAndSuitesSplitByGroup()
+    public function testTestsAndSuitesSplitByGroup(): void
     {
         // mock tests for test object handler.
-        $numberOfCalls = 0;
-        $mockTest1 = AspectMock::double(
-            TestObject::class,
-            ['getEstimatedDuration' => function () use (&$numberOfCalls) {
-                $actionCount = [300, 275, 300, 275];
-                $result = $actionCount[$numberOfCalls];
-                $numberOfCalls++;
-
-                return $result;
-            }]
-        )->make();
-
-        $mockHandler = AspectMock::double(
-            TestObjectHandler::class,
-            ['getObject' => function () use ($mockTest1) {
-                return $mockTest1;
-            }]
-        )->make();
-
-        AspectMock::double(TestObjectHandler::class, ['getInstance' => $mockHandler])->make();
+        $this->createMockForTest(0);
 
         // create test to size array
         $sampleTestArray = [
@@ -283,7 +259,7 @@ class ParallelGroupSorterTest extends MagentoTestCase
             'test30' => 93,
             'test31' => 330,
             'test32' => 85,
-            'test33' => 291,
+            'test33' => 291
         ];
 
         // create mock suite references
@@ -294,7 +270,6 @@ class ParallelGroupSorterTest extends MagentoTestCase
         // perform sort
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedByFixedGroupCount($sampleSuiteArray, $sampleTestArray, 15);
-
         // verify the resulting groups
         $this->assertCount(15, $actualResult);
 
@@ -313,7 +288,7 @@ class ParallelGroupSorterTest extends MagentoTestCase
             12 => ['test28', 'test2', 'test15'],
             13 => ['test19', 'test16', 'test20'],
             14 => ['mockSuite1_0_G'],
-            15 => ['mockSuite1_1_G'],
+            15 => ['mockSuite1_1_G']
         ];
 
         foreach ($actualResult as $groupNum => $group) {
@@ -322,37 +297,21 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests and suites based a group number bigger than ever needed
+     * Test splitting tests and suites based a group number bigger than ever needed.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testTestsAndSuitesSplitByBigGroupNumber()
+    public function testTestsAndSuitesSplitByBigGroupNumber(): void
     {
         // mock tests for test object handler.
-        $numberOfCalls = 0;
-        $mockTest1 = AspectMock::double(
-            TestObject::class,
-            ['getEstimatedDuration' => function () use (&$numberOfCalls) {
-                $actionCount = [300, 275, 300, 275];
-                $result = $actionCount[$numberOfCalls];
-                $numberOfCalls++;
-
-                return $result;
-            }]
-        )->make();
-
-        $mockHandler = AspectMock::double(
-            TestObjectHandler::class,
-            ['getObject' => function () use ($mockTest1) {
-                return $mockTest1;
-            }]
-        )->make();
-
-        AspectMock::double(TestObjectHandler::class, ['getInstance' => $mockHandler])->make();
+        $this->createMockForTest(0);
 
         // create test to size array
         $sampleTestArray = [
             'test1' => 275,
             'test2' => 190,
-            'test3' => 200,
+            'test3' => 200
         ];
 
         // create mock suite references
@@ -363,7 +322,6 @@ class ParallelGroupSorterTest extends MagentoTestCase
         // perform sort
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedByFixedGroupCount($sampleSuiteArray, $sampleTestArray, 10);
-
         // verify the resulting groups
         $this->assertCount(5, $actualResult);
 
@@ -381,37 +339,21 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests and suites based a minimum group number
+     * Test splitting tests and suites based a minimum group number.
+     *
+     * @return void
+     * @throws FastFailException
      */
-    public function testTestsAndSuitesSplitByMinGroupNumber()
+    public function testTestsAndSuitesSplitByMinGroupNumber(): void
     {
         // mock tests for test object handler.
-        $numberOfCalls = 0;
-        $mockTest1 = AspectMock::double(
-            TestObject::class,
-            ['getEstimatedDuration' => function () use (&$numberOfCalls) {
-                $actionCount = [300, 275, 300, 275];
-                $result = $actionCount[$numberOfCalls];
-                $numberOfCalls++;
-
-                return $result;
-            }]
-        )->make();
-
-        $mockHandler = AspectMock::double(
-            TestObjectHandler::class,
-            ['getObject' => function () use ($mockTest1) {
-                return $mockTest1;
-            }]
-        )->make();
-
-        AspectMock::double(TestObjectHandler::class, ['getInstance' => $mockHandler])->make();
+        $this->createMockForTest(0);
 
         // create test to size array
         $sampleTestArray = [
             'test1' => 1,
             'test2' => 125,
-            'test3' => 35,
+            'test3' => 35
         ];
 
         // create mock suite references
@@ -422,14 +364,13 @@ class ParallelGroupSorterTest extends MagentoTestCase
         // perform sort
         $testSorter = new ParallelGroupSorter();
         $actualResult = $testSorter->getTestsGroupedByFixedGroupCount($sampleSuiteArray, $sampleTestArray, 3);
-
         // verify the resulting groups
         $this->assertCount(3, $actualResult);
 
         $expectedResults =  [
             1 => ['test2', 'test3', 'test1'],
             2 => ['mockSuite1_0_G'],
-            3 => ['mockSuite1_1_G'],
+            3 => ['mockSuite1_1_G']
         ];
 
         foreach ($actualResult as $groupNum => $group) {
@@ -438,39 +379,21 @@ class ParallelGroupSorterTest extends MagentoTestCase
     }
 
     /**
-     * Test splitting tests and suites with invalid group number
+     * Test splitting tests and suites with invalid group number.
+     *
+     * @return void
      */
-    public function testTestsAndSuitesSplitByInvalidGroupNumber()
+    public function testTestsAndSuitesSplitByInvalidGroupNumber(): void
     {
         // mock tests for test object handler.
-        $numberOfCalls = 0;
-        $mockTest1 = AspectMock::double(
-            TestObject::class,
-            ['getEstimatedDuration' => function () use (&$numberOfCalls) {
-                $actionCount = [300, 275, 300, 275];
-                $result = $actionCount[$numberOfCalls];
-                $numberOfCalls++;
-
-                return $result;
-            }]
-        )->make();
-
-        $mockHandler = AspectMock::double(
-            TestObjectHandler::class,
-            ['getObject' => function () use ($mockTest1) {
-                return $mockTest1;
-            }]
-        )->make();
-
-        AspectMock::double(TestObjectHandler::class, ['getInstance' => $mockHandler])->make();
+        $this->createMockForTest(0);
 
         // create test to size array
         $sampleTestArray = [
             'test1' => 1,
             'test2' => 125,
-            'test3' => 35,
+            'test3' => 35
         ];
-
         // create mock suite references
         $sampleSuiteArray = [
             'mockSuite1' => ['mockTest1', 'mockTest2']
@@ -482,5 +405,47 @@ class ParallelGroupSorterTest extends MagentoTestCase
         // perform sort
         $testSorter = new ParallelGroupSorter();
         $testSorter->getTestsGroupedByFixedGroupCount($sampleSuiteArray, $sampleTestArray, 1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        $instanceProperty = new ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue(null);
+    }
+
+    /**
+     * Mock test object and test object handler.
+     *
+     * @param int $numberOfCalls
+     *
+     * @return void
+     */
+    private function createMockForTest(int $numberOfCalls): void
+    {
+        $mockTest1 = $this->createMock(TestObject::class);
+        $mockTest1
+            ->method('getEstimatedDuration')
+            ->willReturnCallback(
+                function () use (&$numberOfCalls) {
+                    $actionCount = [300, 275, 300, 275];
+                    $result = $actionCount[$numberOfCalls];
+                    $numberOfCalls++;
+
+                    return $result;
+                }
+            );
+
+        $mockHandler = $this->createMock(TestObjectHandler::class);
+        $mockHandler
+            ->method('getObject')
+            ->willReturn($mockTest1);
+
+        $instanceProperty = new ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue($mockHandler, $mockHandler);
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/TestGeneratorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/TestGeneratorTest.php
@@ -11,11 +11,13 @@ use Exception;
 use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\Exceptions\TestReferenceException;
 use Magento\FunctionalTestingFramework\Filter\FilterList;
+use Magento\FunctionalTestingFramework\ObjectManager;
 use Magento\FunctionalTestingFramework\Test\Objects\ActionObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestHookObject;
 use Magento\FunctionalTestingFramework\Test\Objects\TestObject;
 use Magento\FunctionalTestingFramework\Util\Filesystem\CestFileCreatorUtil;
 use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
+use Magento\FunctionalTestingFramework\Util\ModuleResolver;
 use Magento\FunctionalTestingFramework\Util\TestGenerator;
 use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
@@ -23,6 +25,22 @@ use tests\unit\Util\TestLoggingUtil;
 
 class TestGeneratorTest extends MagentoTestCase
 {
+    /**
+     * @inheritdoc
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $property = new ReflectionProperty(ObjectManager::class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue(null);
+
+        $property = new ReflectionProperty(ModuleResolver::class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue(null);
+    }
+
     /**
      * Before method functionality.
      *


### PR DESCRIPTION
### Description
Eliminated usage of AspectMock from the \tests\unit\Magento\FunctionalTestFramework\Util\Sorter\ParallelGroupSorterTest.

### Fixed Issues (if relevant)
1. magento/magento2#33306: [MFTF] Replace AspectMock with PHPUnit for ParallelGroupSorterTest

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backwards-incompatible changes for tests or have related Pull Request with fixes to tests