### PR TITLE
33299: Eliminated AspectMock usage from SuiteGeneratorTest.php

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Magento\FunctionalTestFramework\Suite;
 
-use AspectMock\Test as AspectMock;
+use Exception;
 use Magento\FunctionalTestingFramework\Exceptions\TestReferenceException;
-use Magento\FunctionalTestingFramework\ObjectManager\ObjectManager;
+use Magento\FunctionalTestingFramework\ObjectManager;
 use Magento\FunctionalTestingFramework\ObjectManagerFactory;
+use Magento\FunctionalTestingFramework\Suite\Service\SuiteGeneratorService;
 use Magento\FunctionalTestingFramework\Suite\SuiteGenerator;
 use Magento\FunctionalTestingFramework\Suite\Generators\GroupClassGenerator;
 use Magento\FunctionalTestingFramework\Suite\Handlers\SuiteObjectHandler;
@@ -18,41 +21,31 @@ use Magento\FunctionalTestingFramework\Test\Util\TestObjectExtractor;
 use Magento\FunctionalTestingFramework\Test\Parsers\TestDataParser;
 use Magento\FunctionalTestingFramework\Util\GenerationErrorHandler;
 use Magento\FunctionalTestingFramework\Util\Manifest\DefaultTestManifest;
+use ReflectionProperty;
 use tests\unit\Util\MagentoTestCase;
 use Magento\FunctionalTestingFramework\Util\Manifest\TestManifestFactory;
 use tests\unit\Util\SuiteDataArrayBuilder;
 use tests\unit\Util\TestDataArrayBuilder;
 use tests\unit\Util\TestLoggingUtil;
-use tests\unit\Util\MockModuleResolverBuilder;
 
 class SuiteGeneratorTest extends MagentoTestCase
 {
     /**
-     * Setup entry append and clear for Suite Generator
-     */
-    public static function setUpBeforeClass(): void
-    {
-        AspectMock::double(SuiteGenerator::class, [
-            'clearPreviousSessionConfigEntries' => null,
-            'appendEntriesToConfig' => null
-        ]);
-    }
-
-    /**
      * Before test functionality
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         TestLoggingUtil::getInstance()->setMockLoggingUtil();
-        $resolverMock = new MockModuleResolverBuilder();
-        $resolverMock->setup();
     }
 
     /**
-     * Tests generating a single suite given a set of parsed test data
+     * Tests generating a single suite given a set of parsed test data.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateSuite()
+    public function testGenerateSuite(): void
     {
         $suiteDataArrayBuilder = new SuiteDataArrayBuilder();
         $mockData = $suiteDataArrayBuilder
@@ -74,20 +67,23 @@ class SuiteGeneratorTest extends MagentoTestCase
 
         // parse and generate suite object with mocked data
         $mockSuiteGenerator = SuiteGenerator::getInstance();
-        $mockSuiteGenerator->generateSuite("basicTestSuite");
+        $mockSuiteGenerator->generateSuite('basicTestSuite');
 
         // assert that expected suite is generated
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'info',
-            "suite generated",
-            ['suite' => 'basicTestSuite', 'relative_path' => "_generated" . DIRECTORY_SEPARATOR . "basicTestSuite"]
+            'suite generated',
+            ['suite' => 'basicTestSuite', 'relative_path' => '_generated' . DIRECTORY_SEPARATOR . 'basicTestSuite']
         );
     }
 
     /**
-     * Tests generating all suites given a set of parsed test data
+     * Tests generating all suites given a set of parsed test data.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateAllSuites()
+    public function testGenerateAllSuites(): void
     {
         $suiteDataArrayBuilder = new SuiteDataArrayBuilder();
         $mockData = $suiteDataArrayBuilder
@@ -108,22 +104,25 @@ class SuiteGeneratorTest extends MagentoTestCase
         $this->setMockTestAndSuiteParserOutput($mockTestData, $mockData);
 
         // parse and retrieve suite object with mocked data
-        $exampleTestManifest = new DefaultTestManifest([], "sample" . DIRECTORY_SEPARATOR . "path");
+        $exampleTestManifest = new DefaultTestManifest([], 'sample' . DIRECTORY_SEPARATOR . 'path');
         $mockSuiteGenerator = SuiteGenerator::getInstance();
         $mockSuiteGenerator->generateAllSuites($exampleTestManifest);
 
         // assert that expected suites are generated
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'info',
-            "suite generated",
-            ['suite' => 'basicTestSuite', 'relative_path' => "_generated" . DIRECTORY_SEPARATOR . "basicTestSuite"]
+            'suite generated',
+            ['suite' => 'basicTestSuite', 'relative_path' => '_generated' . DIRECTORY_SEPARATOR . 'basicTestSuite']
         );
     }
 
     /**
-     * Tests attempting to generate a suite with no included/excluded tests and no hooks
+     * Tests attempting to generate a suite with no included/excluded tests and no hooks.
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testGenerateEmptySuite()
+    public function testGenerateEmptySuite(): void
     {
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockTestData = $testDataArrayBuilder
@@ -142,17 +141,20 @@ class SuiteGeneratorTest extends MagentoTestCase
         $this->setMockTestAndSuiteParserOutput($mockTestData, $mockData);
 
         // set expected error message
-        $this->expectExceptionMessage("Suite basicTestSuite is not defined in xml or is invalid");
+        $this->expectExceptionMessage('Suite basicTestSuite is not defined in xml or is invalid');
 
         // parse and generate suite object with mocked data
         $mockSuiteGenerator = SuiteGenerator::getInstance();
-        $mockSuiteGenerator->generateSuite("basicTestSuite");
+        $mockSuiteGenerator->generateSuite('basicTestSuite');
     }
 
     /**
-     * Tests generating all suites with a suite containing invalid test reference
+     * Tests generating all suites with a suite containing invalid test reference.
+     *
+     * @return void
+     * @throws TestReferenceException
      */
-    public function testInvalidSuiteTestPair()
+    public function testInvalidSuiteTestPair(): void
     {
         // Mock Suite1 => Test1 and Suite2 => Test2
         $suiteDataArrayBuilder = new SuiteDataArrayBuilder();
@@ -198,9 +200,12 @@ class SuiteGeneratorTest extends MagentoTestCase
     }
 
     /**
-     * Tests generating all suites with a non-existing suite
+     * Tests generating all suites with a non-existing suite.
+     *
+     * @return void
+     * @throws TestReferenceException
      */
-    public function testNonExistentSuiteTestPair()
+    public function testNonExistentSuiteTestPair(): void
     {
         $testDataArrayBuilder = new TestDataArrayBuilder();
         $mockSimpleTest = $testDataArrayBuilder
@@ -227,9 +232,12 @@ class SuiteGeneratorTest extends MagentoTestCase
     }
 
     /**
-     * Tests generating split suites for parallel test generation
+     * Tests generating split suites for parallel test generation.
+     *
+     * @return void
+     * @throws TestReferenceException
      */
-    public function testGenerateSplitSuiteFromTest()
+    public function testGenerateSplitSuiteFromTest(): void
     {
         $suiteDataArrayBuilder = new SuiteDataArrayBuilder();
         $mockSuiteData = $suiteDataArrayBuilder
@@ -272,8 +280,8 @@ class SuiteGeneratorTest extends MagentoTestCase
         // assert last split suite group generated
         TestLoggingUtil::getInstance()->validateMockLogStatement(
             'info',
-            "suite generated",
-            ['suite' => 'mockSuite_1_G', 'relative_path' => "_generated" . DIRECTORY_SEPARATOR . "mockSuite_1_G"]
+            'suite generated',
+            ['suite' => 'mockSuite_1_G', 'relative_path' => '_generated' . DIRECTORY_SEPARATOR . 'mockSuite_1_G']
         );
     }
 
@@ -282,75 +290,117 @@ class SuiteGeneratorTest extends MagentoTestCase
      *
      * @param array $testData
      * @param array $suiteData
-     * @throws \Exception
+     * @throws Exception
      */
-    private function setMockTestAndSuiteParserOutput($testData, $suiteData)
+    private function setMockTestAndSuiteParserOutput(array $testData, array $suiteData): void
     {
-        $property = new \ReflectionProperty(SuiteGenerator::class, 'instance');
+        $this->clearMockResolverProperties();
+        $mockSuiteGeneratorService = $this->createMock(SuiteGeneratorService::class);
+        $mockSuiteGeneratorService
+            ->method('clearPreviousSessionConfigEntries')
+            ->willReturn(null);
+
+        $mockSuiteGeneratorService
+            ->method('appendEntriesToConfig')
+            ->willReturn(null);
+
+        $suiteGeneratorServiceProperty = new ReflectionProperty(SuiteGeneratorService::class, 'INSTANCE');
+        $suiteGeneratorServiceProperty->setAccessible(true);
+        $suiteGeneratorServiceProperty->setValue($mockSuiteGeneratorService);
+
+        $mockDataParser = $this->createMock(TestDataParser::class);
+        $mockDataParser
+            ->method('readTestData')
+            ->willReturn($testData);
+
+        $mockSuiteDataParser = $this->createMock(SuiteDataParser::class);
+        $mockSuiteDataParser
+            ->method('readSuiteData')
+            ->willReturn($suiteData);
+
+        $mockGroupClass = $this->createMock(GroupClassGenerator::class);
+        $mockGroupClass
+            ->method('generateGroupClass')
+            ->willReturn('namespace');
+
+        $objectManager = ObjectManagerFactory::getObjectManager();
+
+        $objectManagerMockInstance = $this->createMock(ObjectManager::class);
+        $objectManagerMockInstance
+            ->method('create')
+            ->will(
+                $this->returnCallback(
+                    function (string $class, array $arguments = []) use (
+                        $mockDataParser,
+                        $mockSuiteDataParser,
+                        $mockGroupClass,
+                        $objectManager
+                    ) {
+                        if ($class == TestDataParser::class) {
+                            return $mockDataParser;
+                        }
+                        if ($class == SuiteDataParser::class) {
+                            return $mockSuiteDataParser;
+                        }
+                        if ($class == GroupClassGenerator::class) {
+                            return $mockGroupClass;
+                        }
+
+                        return $objectManager->create($class, $arguments);
+                    }
+                )
+            );
+
+        $objectManagerProperty = new ReflectionProperty(ObjectManager::class, 'instance');
+        $objectManagerProperty->setAccessible(true);
+        $objectManagerProperty->setValue($objectManagerMockInstance);
+    }
+
+    /**
+     * Function used to clear mock properties.
+     *
+     * @return void
+     */
+    private function clearMockResolverProperties(): void
+    {
+        $property = new ReflectionProperty(SuiteGenerator::class, 'instance');
         $property->setAccessible(true);
         $property->setValue(null);
 
         // clear test object handler value to inject parsed content
-        $property = new \ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
+        $property = new ReflectionProperty(TestObjectHandler::class, 'testObjectHandler');
         $property->setAccessible(true);
         $property->setValue(null);
 
         // clear suite object handler value to inject parsed content
-        $property = new \ReflectionProperty(SuiteObjectHandler::class, 'instance');
+        $property = new ReflectionProperty(SuiteObjectHandler::class, 'instance');
         $property->setAccessible(true);
         $property->setValue(null);
-
-        $mockDataParser = AspectMock::double(TestDataParser::class, ['readTestData' => $testData])->make();
-        $mockSuiteDataParser = AspectMock::double(SuiteDataParser::class, ['readSuiteData' => $suiteData])->make();
-        $mockGroupClass = AspectMock::double(
-            GroupClassGenerator::class,
-            ['generateGroupClass' => 'namespace']
-        )->make();
-        $mockSuiteClass = AspectMock::double(SuiteGenerator::class, ['generateRelevantGroupTests' => null])->make();
-        $instance = AspectMock::double(
-            ObjectManager::class,
-            ['create' => function ($clazz) use (
-                $mockDataParser,
-                $mockSuiteDataParser,
-                $mockGroupClass,
-                $mockSuiteClass
-            ) {
-                if ($clazz == TestDataParser::class) {
-                    return $mockDataParser;
-                }
-                if ($clazz == SuiteDataParser::class) {
-                    return $mockSuiteDataParser;
-                }
-                if ($clazz == GroupClassGenerator::class) {
-                    return $mockGroupClass;
-                }
-                if ($clazz == SuiteGenerator::class) {
-                    return $mockSuiteClass;
-                }
-            }]
-        )->make();
-        // bypass the private constructor
-        AspectMock::double(ObjectManagerFactory::class, ['getObjectManager' => $instance]);
-
-        $property = new \ReflectionProperty(SuiteGenerator::class, 'groupClassGenerator');
-        $property->setAccessible(true);
-        $property->setValue($instance, $instance);
     }
 
     /**
-     * clean up function runs after each test
+     * @inheritDoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         GenerationErrorHandler::getInstance()->reset();
     }
 
     /**
-     * clean up function runs after all tests
+     * @inheritDoc
      */
     public static function tearDownAfterClass(): void
     {
-        TestLoggingUtil::getInstance()->clearMockLoggingUtil();
         parent::tearDownAfterClass();
+
+        $objectManagerProperty = new ReflectionProperty(ObjectManager::class, 'instance');
+        $objectManagerProperty->setAccessible(true);
+        $objectManagerProperty->setValue(null);
+
+        $suiteGeneratorServiceProperty = new ReflectionProperty(SuiteGeneratorService::class, 'INSTANCE');
+        $suiteGeneratorServiceProperty->setAccessible(true);
+        $suiteGeneratorServiceProperty->setValue(null);
+
+        TestLoggingUtil::getInstance()->clearMockLoggingUtil();
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
@@ -31,7 +31,8 @@ use tests\unit\Util\TestLoggingUtil;
 class SuiteGeneratorTest extends MagentoTestCase
 {
     /**
-     * Before test functionality
+     * Before test functionality.
+     *
      * @return void
      */
     protected function setUp(): void
@@ -290,19 +291,27 @@ class SuiteGeneratorTest extends MagentoTestCase
      *
      * @param array $testData
      * @param array $suiteData
+     *
+     * @return void
      * @throws Exception
      */
     private function setMockTestAndSuiteParserOutput(array $testData, array $suiteData): void
     {
         $this->clearMockResolverProperties();
         $mockSuiteGeneratorService = $this->createMock(SuiteGeneratorService::class);
+        $mockVoidReturnCallback = function () {};// phpcs:ignore
+
         $mockSuiteGeneratorService
             ->method('clearPreviousSessionConfigEntries')
-            ->willReturn(null);
+            ->will($this->returnCallback($mockVoidReturnCallback));
 
         $mockSuiteGeneratorService
             ->method('appendEntriesToConfig')
-            ->willReturn(null);
+            ->will($this->returnCallback($mockVoidReturnCallback));
+
+        $mockSuiteGeneratorService
+            ->method('generateRelevantGroupTests')
+            ->will($this->returnCallback($mockVoidReturnCallback));
 
         $suiteGeneratorServiceProperty = new ReflectionProperty(SuiteGeneratorService::class, 'INSTANCE');
         $suiteGeneratorServiceProperty->setAccessible(true);
@@ -324,7 +333,6 @@ class SuiteGeneratorTest extends MagentoTestCase
             ->willReturn('namespace');
 
         $objectManager = ObjectManagerFactory::getObjectManager();
-
         $objectManagerMockInstance = $this->createMock(ObjectManager::class);
         $objectManagerMockInstance
             ->method('create')

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
@@ -330,7 +330,10 @@ class SuiteGeneratorTest extends MagentoTestCase
             ->method('create')
             ->will(
                 $this->returnCallback(
-                    function (string $class, array $arguments = []) use (
+                    function (
+                        string $class,
+                        array $arguments = []
+                    ) use (
                         $mockDataParser,
                         $mockSuiteDataParser,
                         $mockGroupClass,

--- a/src/Magento/FunctionalTestingFramework/Suite/Service/SuiteGeneratorService.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Service/SuiteGeneratorService.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\FunctionalTestingFramework\Suite\Service;
+
+use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
+use Magento\FunctionalTestingFramework\Util\Path\FilePathFormatter;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Class SuiteGeneratorService
+ */
+class SuiteGeneratorService
+{
+    const YAML_CODECEPTION_DIST_FILENAME = 'codeception.dist.yml';
+    const YAML_CODECEPTION_CONFIG_FILENAME = 'codeception.yml';
+    const YAML_GROUPS_TAG = 'groups';
+    const YAML_EXTENSIONS_TAG = 'extensions';
+    const YAML_ENABLED_TAG = 'enabled';
+    const YAML_COPYRIGHT_TEXT =
+        "# Copyright © Magento, Inc. All rights reserved.\n# See COPYING.txt for license details.\n";
+
+
+    /**
+     * Singleton SuiteGeneratorService Instance.
+     *
+     * @var SuiteGeneratorService
+     */
+    private static $INSTANCE;
+
+    /**
+     * SuiteGeneratorService constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Get CestFileCreatorUtil instance.
+     *
+     * @return SuiteGeneratorService
+     */
+    public static function getInstance(): SuiteGeneratorService
+    {
+        if (!self::$INSTANCE) {
+            self::$INSTANCE = new SuiteGeneratorService();
+        }
+
+        return self::$INSTANCE;
+    }
+
+    /**
+     * Function which takes the current config.yml array and clears any previous configuration for suite group object
+     * files.
+     *
+     * @return void
+     * @throws TestFrameworkException
+     */
+    public function clearPreviousSessionConfigEntries()
+    {
+        $ymlArray = self::getYamlFileContents();
+        $newYmlArray = $ymlArray;
+        // if the yaml entries haven't already been cleared
+        if (array_key_exists(self::YAML_EXTENSIONS_TAG, $ymlArray)) {
+            foreach ($ymlArray[self::YAML_EXTENSIONS_TAG][self::YAML_ENABLED_TAG] as $key => $entry) {
+                if (preg_match('/(Group\\\\.*)/', $entry)) {
+                    unset($newYmlArray[self::YAML_EXTENSIONS_TAG][self::YAML_ENABLED_TAG][$key]);
+                }
+            }
+
+            // needed for proper yml file generation based on indices
+            $newYmlArray[self::YAML_EXTENSIONS_TAG][self::YAML_ENABLED_TAG] =
+                array_values($newYmlArray[self::YAML_EXTENSIONS_TAG][self::YAML_ENABLED_TAG]);
+        }
+
+        if (array_key_exists(self::YAML_GROUPS_TAG, $newYmlArray)) {
+            unset($newYmlArray[self::YAML_GROUPS_TAG]);
+        }
+
+        $ymlText = self::YAML_COPYRIGHT_TEXT . Yaml::dump($newYmlArray, 10);
+        file_put_contents(self::getYamlConfigFilePath() . self::YAML_CODECEPTION_CONFIG_FILENAME, $ymlText);
+    }
+
+
+    /**
+     * Function which accepts a suite name and suite path and appends a new group entry to the codeception.yml.dist
+     * file in order to register the set of tests as a new group. Also appends group object location if required
+     * by suite.
+     *
+     * @param string $suiteName
+     * @param string $suitePath
+     * @param string $groupNamespace
+     *
+     * @return void
+     * @throws TestFrameworkException
+     */
+    public function appendEntriesToConfig(string $suiteName, string $suitePath, string $groupNamespace)
+    {
+        $relativeSuitePath = substr($suitePath, strlen(TESTS_BP));
+        $relativeSuitePath = ltrim($relativeSuitePath, DIRECTORY_SEPARATOR);
+        $ymlArray = self::getYamlFileContents();
+
+        if (!array_key_exists(self::YAML_GROUPS_TAG, $ymlArray)) {
+            $ymlArray[self::YAML_GROUPS_TAG]= [];
+        }
+
+        if ($groupNamespace) {
+            $ymlArray[self::YAML_EXTENSIONS_TAG][self::YAML_ENABLED_TAG][] = $groupNamespace;
+        }
+
+        $ymlArray[self::YAML_GROUPS_TAG][$suiteName] = [$relativeSuitePath];
+        $ymlText = self::YAML_COPYRIGHT_TEXT . Yaml::dump($ymlArray, 10);
+        file_put_contents(self::getYamlConfigFilePath() . self::YAML_CODECEPTION_CONFIG_FILENAME, $ymlText);
+    }
+
+    /**
+     * Function to return contents of codeception.yml file for config changes.
+     *
+     * @return array
+     * @throws TestFrameworkException
+     */
+    private static function getYamlFileContents(): array
+    {
+        $configYmlFile = self::getYamlConfigFilePath() . self::YAML_CODECEPTION_CONFIG_FILENAME;
+        $defaultConfigYmlFile = self::getYamlConfigFilePath() . self::YAML_CODECEPTION_DIST_FILENAME;
+        $ymlContents = null;
+
+        if (file_exists($configYmlFile)) {
+            $ymlContents = file_get_contents($configYmlFile);
+        } else {
+            $ymlContents = file_get_contents($defaultConfigYmlFile);
+        }
+
+        return Yaml::parse($ymlContents) ?? [];
+    }
+
+    /**
+     * Static getter for the Config yml filepath (as path cannot be stored in a const).
+     *
+     * @return string
+     * @throws TestFrameworkException
+     */
+    private static function getYamlConfigFilePath()
+    {
+        return FilePathFormatter::format(TESTS_BP);
+    }
+}

--- a/src/Magento/FunctionalTestingFramework/Suite/SuiteGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/SuiteGenerator.php
@@ -29,6 +29,14 @@ use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
  */
 class SuiteGenerator
 {
+    const YAML_CODECEPTION_DIST_FILENAME = 'codeception.dist.yml';
+    const YAML_CODECEPTION_CONFIG_FILENAME = 'codeception.yml';
+    const YAML_GROUPS_TAG = 'groups';
+    const YAML_EXTENSIONS_TAG = 'extensions';
+    const YAML_ENABLED_TAG = 'enabled';
+    const YAML_COPYRIGHT_TEXT =
+        "# Copyright © Magento, Inc. All rights reserved.\n# See COPYING.txt for license details.\n";
+
     /**
      * Singelton Variable Instance.
      *

--- a/src/Magento/FunctionalTestingFramework/Suite/SuiteGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/SuiteGenerator.php
@@ -346,18 +346,18 @@ class SuiteGenerator
 
     /**
      * Function which takes a string which is the desired output directory (under _generated) and an array of tests
-     * relevant to the suite to be generated. The function takes this information and creates a new instance of the test
-     * generator which is then called to create all the test files for the suite.
+     * relevant to the suite to be generated. The function takes this information and creates a new instance of the
+     * test generator which is then called to create all the test files for the suite.
      *
      * @param string $path
      * @param array  $tests
+     *
      * @return void
      * @throws TestReferenceException
      */
     private function generateRelevantGroupTests($path, $tests)
     {
-        $testGenerator = TestGenerator::getInstance($path, $tests);
-        $testGenerator->createAllTestFiles(null, []);
+        SuiteGeneratorService::getInstance()->generateRelevantGroupTests($path, $tests);
     }
 
     /**


### PR DESCRIPTION
### Description

I've eliminated AspectMock usage from `dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php`

### Fixed Issues (if relevant)

1. Fixes magento/magento2#33299:[MFTF] Eliminate AspectMock from SuiteGeneratorTest (Complex!)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests