### PR TITLE
MFTF-33782: Added empty query and fragment testing to the UrlFormatterTest

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/FilePathFormatterTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/FilePathFormatterTest.php
@@ -16,21 +16,29 @@ class FilePathFormatterTest extends MagentoTestCase
     /**
      * Test file format.
      *
-     * @param string $path
-     * @param bool $withTrailingSeparator
+     * @param string      $path
+     * @param bool|null   $withTrailingSeparator
      * @param string|null $expectedPath
      *
      * @return void
      * @throws TestFrameworkException
      * @dataProvider formatDataProvider
      */
-    public function testFormat(string $path, bool $withTrailingSeparator, ?string $expectedPath): void
+    public function testFormat(string $path, ?bool $withTrailingSeparator, ?string $expectedPath): void
     {
         if (null !== $expectedPath) {
+            if ($withTrailingSeparator === null) {
+                $this->assertEquals($expectedPath, FilePathFormatter::format($path));
+                return;
+            }
             $this->assertEquals($expectedPath, FilePathFormatter::format($path, $withTrailingSeparator));
         } else {
             // Assert no exception
-            FilePathFormatter::format($path, $withTrailingSeparator);
+            if ($withTrailingSeparator === null) {
+                FilePathFormatter::format($path);
+            } else {
+                FilePathFormatter::format($path, $withTrailingSeparator);
+            }
             $this->assertTrue(true);
         }
     }
@@ -38,17 +46,22 @@ class FilePathFormatterTest extends MagentoTestCase
     /**
      * Test file format with exception.
      *
-     * @param string $path
-     * @param bool $withTrailingSeparator
+     * @param string    $path
+     * @param bool|null $withTrailingSeparator
      *
      * @return void
      * @throws TestFrameworkException
      * @dataProvider formatExceptionDataProvider
      */
-    public function testFormatWithException(string $path, bool $withTrailingSeparator): void
+    public function testFormatWithException(string $path, ?bool $withTrailingSeparator): void
     {
         $this->expectException(TestFrameworkException::class);
         $this->expectExceptionMessage("Invalid or non-existing file: $path\n");
+
+        if ($withTrailingSeparator === null) {
+            FilePathFormatter::format($path);
+            return;
+        }
         FilePathFormatter::format($path, $withTrailingSeparator);
     }
 
@@ -63,14 +76,14 @@ class FilePathFormatterTest extends MagentoTestCase
         $path2 = $path1 . DIRECTORY_SEPARATOR;
 
         return [
-            [$path1, false, $path1],
+            [$path1, null, $path2],
             [$path1, false, $path1],
             [$path1, true, $path2],
-            [$path2, false, $path1],
+            [$path2, null, $path2],
             [$path2, false, $path1],
             [$path2, true, $path2],
-            [__DIR__. DIRECTORY_SEPARATOR . basename(__FILE__), false, __FILE__],
-            ['', false, null] // Empty string is valid
+            [__DIR__ . DIRECTORY_SEPARATOR . basename(__FILE__), null, __FILE__ . DIRECTORY_SEPARATOR],
+            ['', null, null] // Empty string is valid
         ];
     }
 
@@ -82,8 +95,8 @@ class FilePathFormatterTest extends MagentoTestCase
     public function formatExceptionDataProvider(): array
     {
         return [
-            ['abc', false],
-            ['X://some\dir/@', false]
+            ['abc', null],
+            ['X://some\dir/@', null]
         ];
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/FilePathFormatterTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/FilePathFormatterTest.php
@@ -3,25 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Magento\FunctionalTestFramework\Util\Path;
 
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
-use tests\unit\Util\MagentoTestCase;
 use Magento\FunctionalTestingFramework\Util\Path\FilePathFormatter;
+use tests\unit\Util\MagentoTestCase;
 
 class FilePathFormatterTest extends MagentoTestCase
 {
     /**
-     * Test file format
+     * Test file format.
      *
-     * @dataProvider formatDataProvider
      * @param string $path
-     * @param boolean $withTrailingSeparator
-     * @param mixed string|boolean $expectedPath
+     * @param bool $withTrailingSeparator
+     * @param string|null $expectedPath
+     *
      * @return void
      * @throws TestFrameworkException
+     * @dataProvider formatDataProvider
      */
-    public function testFormat($path, $withTrailingSeparator, $expectedPath)
+    public function testFormat(string $path, bool $withTrailingSeparator, ?string $expectedPath): void
     {
         if (null !== $expectedPath) {
             $this->assertEquals($expectedPath, FilePathFormatter::format($path, $withTrailingSeparator));
@@ -33,15 +36,16 @@ class FilePathFormatterTest extends MagentoTestCase
     }
 
     /**
-     * Test file format with exception
+     * Test file format with exception.
      *
-     * @dataProvider formatExceptionDataProvider
      * @param string $path
-     * @param boolean $withTrailingSeparator
+     * @param bool $withTrailingSeparator
+     *
      * @return void
      * @throws TestFrameworkException
+     * @dataProvider formatExceptionDataProvider
      */
-    public function testFormatWithException($path, $withTrailingSeparator)
+    public function testFormatWithException(string $path, bool $withTrailingSeparator): void
     {
         $this->expectException(TestFrameworkException::class);
         $this->expectExceptionMessage("Invalid or non-existing file: $path\n");
@@ -49,36 +53,37 @@ class FilePathFormatterTest extends MagentoTestCase
     }
 
     /**
-     * Data input
+     * Data input.
      *
      * @return array
      */
-    public function formatDataProvider()
+    public function formatDataProvider(): array
     {
         $path1 = rtrim(TESTS_BP, '/');
         $path2 = $path1 . DIRECTORY_SEPARATOR;
+
         return [
-            [$path1, null, $path1],
+            [$path1, false, $path1],
             [$path1, false, $path1],
             [$path1, true, $path2],
-            [$path2, null, $path1],
+            [$path2, false, $path1],
             [$path2, false, $path1],
             [$path2, true, $path2],
-            [__DIR__. DIRECTORY_SEPARATOR . basename(__FILE__), null, __FILE__],
-            ['', null, null] // Empty string is valid
+            [__DIR__. DIRECTORY_SEPARATOR . basename(__FILE__), false, __FILE__],
+            ['', false, null] // Empty string is valid
         ];
     }
 
     /**
-     * Invalid data input
+     * Invalid data input.
      *
      * @return array
      */
-    public function formatExceptionDataProvider()
+    public function formatExceptionDataProvider(): array
     {
         return [
-            ['abc', null],
-            ['X://some\dir/@', null],
+            ['abc', false],
+            ['X://some\dir/@', false]
         ];
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/UrlFormatterTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/UrlFormatterTest.php
@@ -17,14 +17,18 @@ class UrlFormatterTest extends MagentoTestCase
      * Test url format.
      *
      * @param string $path
-     * @param bool $withTrailingSeparator
+     * @param bool|null $withTrailingSeparator
      * @param string $expectedPath
      *
      * @return void
      * @dataProvider formatDataProvider
      */
-    public function testFormat(string $path, bool $withTrailingSeparator, string $expectedPath): void
+    public function testFormat(string $path, ?bool $withTrailingSeparator, string $expectedPath): void
     {
+        if ($withTrailingSeparator === null) {
+            $this->assertEquals($expectedPath, UrlFormatter::format($path));
+            return;
+        }
         $this->assertEquals($expectedPath, UrlFormatter::format($path, $withTrailingSeparator));
     }
 
@@ -32,15 +36,20 @@ class UrlFormatterTest extends MagentoTestCase
      * Test url format with exception.
      *
      * @param string $path
-     * @param bool $withTrailingSeparator
+     * @param bool|null $withTrailingSeparator
      *
      * @return void
      * @dataProvider formatExceptionDataProvider
      */
-    public function testFormatWithException(string $path, bool $withTrailingSeparator): void
+    public function testFormatWithException(string $path, ?bool $withTrailingSeparator): void
     {
         $this->expectException(TestFrameworkException::class);
         $this->expectExceptionMessage("Invalid url: $path\n");
+
+        if ($withTrailingSeparator === null) {
+            UrlFormatter::format($path);
+            return;
+        }
         UrlFormatter::format($path, $withTrailingSeparator);
     }
 
@@ -62,16 +71,16 @@ class UrlFormatterTest extends MagentoTestCase
         $url9 = 'http://www.google.com';
 
         return [
-            [$url1, false, $url1],
+            [$url1, null, $url2],
             [$url1, false, $url1],
             [$url1, true, $url2],
-            [$url2, false, $url1],
+            [$url2, null, $url2],
             [$url2, false, $url1],
             [$url2, true, $url2],
-            [$url3, false, $url3],
+            [$url3, null, $url4],
             [$url3, false, $url3],
             [$url3, true, $url4],
-            [$url4, false, $url3],
+            [$url4, null, $url4],
             [$url4, false, $url3],
             [$url4, true, $url4],
             [$url5, true, $url6],
@@ -91,7 +100,7 @@ class UrlFormatterTest extends MagentoTestCase
     public function formatExceptionDataProvider(): array
     {
         return [
-            ['', false]
+            ['', null]
         ];
     }
 }

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/UrlFormatterTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/Path/UrlFormatterTest.php
@@ -3,39 +3,41 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace tests\unit\Magento\FunctionalTestFramework\Util\Path;
 
-use tests\unit\Util\MagentoTestCase;
-use Magento\FunctionalTestingFramework\Util\Path\UrlFormatter;
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
+use Magento\FunctionalTestingFramework\Util\Path\UrlFormatter;
+use tests\unit\Util\MagentoTestCase;
 
 class UrlFormatterTest extends MagentoTestCase
 {
     /**
-     * Test url format
+     * Test url format.
      *
-     * @dataProvider formatDataProvider
      * @param string $path
-     * @param boolean $withTrailingSeparator
-     * @param mixed string|boolean $expectedPath
+     * @param bool $withTrailingSeparator
+     * @param string $expectedPath
+     *
      * @return void
-     * @throws TestFrameworkException
+     * @dataProvider formatDataProvider
      */
-    public function testFormat($path, $withTrailingSeparator, $expectedPath)
+    public function testFormat(string $path, bool $withTrailingSeparator, string $expectedPath): void
     {
         $this->assertEquals($expectedPath, UrlFormatter::format($path, $withTrailingSeparator));
     }
 
     /**
-     * Test url format with exception
+     * Test url format with exception.
      *
-     * @dataProvider formatExceptionDataProvider
      * @param string $path
-     * @param boolean $withTrailingSeparator
+     * @param bool $withTrailingSeparator
+     *
      * @return void
-     * @throws TestFrameworkException
+     * @dataProvider formatExceptionDataProvider
      */
-    public function testFormatWithException($path, $withTrailingSeparator)
+    public function testFormatWithException(string $path, bool $withTrailingSeparator): void
     {
         $this->expectException(TestFrameworkException::class);
         $this->expectExceptionMessage("Invalid url: $path\n");
@@ -43,11 +45,11 @@ class UrlFormatterTest extends MagentoTestCase
     }
 
     /**
-     * Data input
+     * Data input.
      *
      * @return array
      */
-    public function formatDataProvider()
+    public function formatDataProvider(): array
     {
         $url1 = 'http://magento.local/index.php';
         $url2 = $url1 . '/';
@@ -58,34 +60,38 @@ class UrlFormatterTest extends MagentoTestCase
         $url7 = 'http://127.0.0.1:8200';
         $url8 = 'wwøw.goåoøgle.coøm';
         $url9 = 'http://www.google.com';
+
         return [
-            [$url1, null, $url1],
+            [$url1, false, $url1],
             [$url1, false, $url1],
             [$url1, true, $url2],
-            [$url2, null, $url1],
+            [$url2, false, $url1],
             [$url2, false, $url1],
             [$url2, true, $url2],
-            [$url3, null, $url3],
+            [$url3, false, $url3],
             [$url3, false, $url3],
             [$url3, true, $url4],
-            [$url4, null, $url3],
+            [$url4, false, $url3],
             [$url4, false, $url3],
             [$url4, true, $url4],
             [$url5, true, $url6],
             [$url7, false, $url7],
             [$url8, false, $url9],
+            ['https://magento.local/path?', false, 'https://magento.local/path?'],
+            ['https://magento.local/path#', false, 'https://magento.local/path#'],
+            ['https://magento.local/path?#', false, 'https://magento.local/path?#']
         ];
     }
 
     /**
-     * Invalid data input
+     * Invalid data input.
      *
      * @return array
      */
-    public function formatExceptionDataProvider()
+    public function formatExceptionDataProvider(): array
     {
         return [
-            ['', null],
+            ['', false]
         ];
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Util/Path/FilePathFormatter.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Path/FilePathFormatter.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\FunctionalTestingFramework\Util\Path;
 
@@ -11,14 +12,15 @@ use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 class FilePathFormatter implements FormatterInterface
 {
     /**
-     * Return formatted full file path from input string, or false on error
+     * Return formatted full file path from input string, or false on error.
      *
      * @param string  $path
      * @param boolean $withTrailingSeparator
+     *
      * @return string
      * @throws TestFrameworkException
      */
-    public static function format($path, $withTrailingSeparator = true)
+    public static function format(string $path, bool $withTrailingSeparator = true): string
     {
         $validPath = realpath($path);
 

--- a/src/Magento/FunctionalTestingFramework/Util/Path/FormatterInterface.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Path/FormatterInterface.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\FunctionalTestingFramework\Util\Path;
 
@@ -11,12 +12,13 @@ use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 interface FormatterInterface
 {
     /**
-     * Return formatted path (file path, url, etc) from input string, or false on error
+     * Return formatted path (file path, url, etc) from input string, or false on error.
      *
      * @param string  $input
      * @param boolean $withTrailingSeparator
+     *
      * @return string
      * @throws TestFrameworkException
      */
-    public static function format($input, $withTrailingSeparator = true);
+    public static function format(string $input, bool $withTrailingSeparator = true): string;
 }

--- a/src/Magento/FunctionalTestingFramework/Util/Path/UrlFormatter.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Path/UrlFormatter.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\FunctionalTestingFramework\Util\Path;
 
@@ -11,14 +12,15 @@ use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 class UrlFormatter implements FormatterInterface
 {
     /**
-     * Return formatted url path from input string
+     * Return formatted url path from input string.
      *
      * @param string  $url
      * @param boolean $withTrailingSeparator
+     *
      * @return string
      * @throws TestFrameworkException
      */
-    public static function format($url, $withTrailingSeparator = true)
+    public static function format(string $url, bool $withTrailingSeparator = true): string
     {
         $sanitizedUrl = rtrim($url, '/');
 
@@ -47,12 +49,13 @@ class UrlFormatter implements FormatterInterface
     }
 
     /**
-     * Try to build missing url scheme and host
+     * Try to build missing url scheme and host.
      *
      * @param string $url
+     *
      * @return string
      */
-    private static function buildUrl($url)
+    private static function buildUrl(string $url): string
     {
         $urlParts = parse_url($url);
 
@@ -76,32 +79,42 @@ class UrlFormatter implements FormatterInterface
     /**
      * Returns url from $parts given, used with parse_url output for convenience.
      * This only exists because of deprecation of http_build_url, which does the exact same thing as the code below.
+     *
      * @param array $parts
+     *
      * @return string
      */
-    private static function merge(array $parts)
+    private static function merge(array $parts): string
     {
         $get = function ($key) use ($parts) {
-            return isset($parts[$key]) ? $parts[$key] : null;
+            return $parts[$key] ?? '';
         };
 
-        $pass      = $get('pass');
-        $user      = $get('user');
-        $userinfo  = $pass !== null ? "$user:$pass" : $user;
-        $port      = $get('port');
-        $scheme    = $get('scheme');
-        $query     = $get('query');
-        $fragment  = $get('fragment');
-        $authority =
-            ($userinfo !== null ? "$userinfo@" : '') .
-            $get('host') .
-            ($port ? ":$port" : '');
+        $pass = $get('pass');
+        $user = $get('user');
+        $userinfo = $pass !== '' ? "$user:$pass" : $user;
+        $port = $get('port');
+        $scheme = $get('scheme');
+        $query = $get('query');
+        $fragment = $get('fragment');
+        $authority = ($userinfo !== '' ? "$userinfo@" : '') . $get('host') . ($port ? ":$port" : '');
 
-        return
-            (strlen($scheme) ? "$scheme:" : '') .
-            (strlen($authority) ? "//$authority" : '') .
-            $get('path') .
-            (strlen($query) ? "?$query" : '') .
-            (strlen($fragment) ? "#$fragment" : '');
+        return str_replace(
+            [
+                '%scheme',
+                '%authority',
+                '%path',
+                '%query',
+                '%fragment'
+            ],
+            [
+                strlen($scheme) ? "$scheme:" : '',
+                strlen($authority) ? "//$authority" : '',
+                $get('path'),
+                strlen($query) ? "?$query" : '',
+                strlen($fragment) ? "#$fragment" : ''
+            ],
+            '%scheme%authority%path%query%fragment'
+        );
     }
 }


### PR DESCRIPTION
### Description
I've investigated the impact of the new changes in parse_url() function for PHP 8 on the current MFTF codebase.
**Reported change (from the official documentation):**

_parse_url() will now distinguish absent and empty queries and fragments:_
```
http://example.com/foo → query = null, fragment = null
http://example.com/foo? → query = "", fragment = null
http://example.com/foo# → query = null, fragment = ""
http://example.com/foo?# → query = "", fragment = ""
```
_Previously all cases resulted in query and fragment being null._

In the MFTF codebase this function used only in the `\Magento\FunctionalTestingFramework\Util\Path\UrlFormatter` class.

I've added two data sets to the `\tests\unit\Magento\FunctionalTestFramework\Util\Path\UrlFormatterTest::formatDataProvider` to cover cases when parsed URL has an empty query, an empty fragment or both of them.

**The result of testing for the PHP7.3:**
<img width="1742" alt="Screenshot 2021-08-16 at 15 48 16" src="https://user-images.githubusercontent.com/31848341/129566651-5711fdc2-574f-4dbf-bbb7-262098fcb8de.png">

**The result of testing for the PHP8.0:**
<img width="1742" alt="Screenshot 2021-08-16 at 15 50 19" src="https://user-images.githubusercontent.com/31848341/129566667-6a648878-8526-49ad-a3fe-d248f17928b7.png">


During this investigation I've found that the `\Magento\FunctionalTestingFramework\Util\Path\UrlFormatter` class is not strictly typed and has errors regarding strict typing:
<img width="1031" alt="Screenshot 2021-08-16 at 16 01 37" src="https://user-images.githubusercontent.com/31848341/129568290-27c01bc9-cbbc-4546-9463-a9051c5581c5.png">

### Investigation summary
I propose to extend the `UrlFormatterTest` with the new data sets. If the core team of the MFTF framework will consider those new datasets useful. If not, anyway, this also could be closed and taken into account only the result of this investigation regarding the related issue.

Also, I propose to make the `UrlFormatter` class strictly typed and fix strict type issues in the scope of this PR.

### Related Issues
1. magento/magento2/issues/33782: [MFTF] Investigate and fix code related to changes in parse_url() #33782

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests