### PR TITLE
PHP 8 support - fix code related to changes in CURL

### DIFF
--- a/src/Magento/FunctionalTestingFramework/DataTransport/Protocol/CurlTransport.php
+++ b/src/Magento/FunctionalTestingFramework/DataTransport/Protocol/CurlTransport.php
@@ -132,18 +132,18 @@ class CurlTransport implements CurlInterface
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_COOKIEFILE => '',
-            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_HTTPHEADER => is_object($headers) ? (array) $headers : $headers,
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_SSL_VERIFYHOST => false,
         ];
         switch ($method) {
             case CurlInterface::POST:
                 $options[CURLOPT_POST] = true;
-                $options[CURLOPT_POSTFIELDS] = $body;
+                $options[CURLOPT_POSTFIELDS] = is_object($body) ? (array) $body : $body;
                 break;
             case CurlInterface::PUT:
                 $options[CURLOPT_CUSTOMREQUEST] = self::PUT;
-                $options[CURLOPT_POSTFIELDS] = $body;
+                $options[CURLOPT_POSTFIELDS] = is_object($body) ? (array) $body : $body;
                 break;
             case CurlInterface::DELETE:
                 $options[CURLOPT_CUSTOMREQUEST] = self::DELETE;
@@ -189,7 +189,10 @@ class CurlTransport implements CurlInterface
      */
     public function close()
     {
-        curl_close($this->getResource());
+        if (version_compare(PHP_VERSION, '8.0') < 0) {
+            // this function no longer has an effect in PHP 8.0, but it's required in earlier versions
+            curl_close($this->getResource());
+        }
         $this->resource = null;
     }
 
@@ -271,7 +274,11 @@ class CurlTransport implements CurlInterface
             $result[$key] = curl_multi_getcontent($handle);
             curl_multi_remove_handle($multiHandle, $handle);
         }
-        curl_multi_close($multiHandle);
+        if (version_compare(PHP_VERSION, '8.0') < 0) {
+            // this function no longer has an effect in PHP 8.0, but it's required in earlier versions
+            curl_multi_close($multiHandle);
+        }
+
         return $result;
     }
 

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -72,7 +72,10 @@ class TestContextExtension extends BaseExtension
                 CURLOPT_URL => getenv('MAGENTO_BASE_URL') . "/test.php?test=" . $this->currentTest,
             ]);
             curl_exec($cURLConnection);
-            curl_close($cURLConnection);
+            if (version_compare(PHP_VERSION, '8.0') < 0) {
+                // this function no longer has an effect in PHP 8.0, but it's required in earlier versions
+                curl_close($cURLConnection);
+            }
         }
 
         PersistedObjectHandler::getInstance()->clearHookObjects();


### PR DESCRIPTION
### Description
Fixed fragments of code related to changes in Curl in PHP 8 (where it was necessary) according to the document:
https://www.php.net/manual/en/migration80.incompatible.php

### Fixed Issues (if relevant)
1. magento/magento2#33781: [MFTF] Investigate and fix code related to changes in CURL

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests