### PR TITLE
The `squizlabs/php_codesniffer` composer dependency has been updated to version 3.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpmd/phpmd": "^2.8.0",
         "phpunit/phpunit": "^9.0",
         "sebastian/phpcpd": "~6.0.0",
-        "squizlabs/php_codesniffer": "~3.5.4"
+        "squizlabs/php_codesniffer": "~3.6.0"
     },
     "autoload": {
         "files": ["src/Magento/FunctionalTestingFramework/_bootstrap.php"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb8347aab3be241fe1517983f3fc044c",
+    "content-hash": "56d4fb53d9dbda3444499d2fce97e9fc",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",
@@ -8001,16 +8001,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -8053,7 +8053,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This pull request (PR) provides updating the `squizlabs/php_codesniffer` composer dependency to version 3.6.0 (latest).

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2#33832

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests