### PR TITLE
Removing the `csharpru/vault-php-guzzle6-transport` not needed dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "codeception/module-webdriver": "^1.0",
         "composer/composer": "^1.9||^2.0",
         "csharpru/vault-php": "^4.2.1",
-        "csharpru/vault-php-guzzle6-transport": "^2.0",
+        "guzzlehttp/guzzle": "^7.3.0",
         "hoa/console": "~3.0",
         "monolog/monolog": "^2.3",
         "mustache/mustache": "~2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a03b6b0a4885e0049c74d187c70836c",
+    "content-hash": "edfa5cf6f951445f14be6d5deb535db3",
     "packages": [
         {
             "name": "allure-framework/allure-codeception",
@@ -1326,49 +1326,6 @@
             "time": "2021-05-21T06:39:35+00:00"
         },
         {
-            "name": "csharpru/vault-php-guzzle6-transport",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/CSharpRU/vault-php-guzzle6-transport.git",
-                "reference": "33c392120ac9f253b62b034e0e8ffbbdb3513bd8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/CSharpRU/vault-php-guzzle6-transport/zipball/33c392120ac9f253b62b034e0e8ffbbdb3513bd8",
-                "reference": "33c392120ac9f253b62b034e0e8ffbbdb3513bd8",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "~6.2",
-                "guzzlehttp/promises": "^1.3",
-                "guzzlehttp/psr7": "^1.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "VaultTransports\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Yaroslav Lukyanov",
-                    "email": "c_sharp@mail.ru"
-                }
-            ],
-            "description": "Guzzle6 transport for Vault PHP client",
-            "support": {
-                "issues": "https://github.com/CSharpRU/vault-php-guzzle6-transport/issues",
-                "source": "https://github.com/CSharpRU/vault-php-guzzle6-transport/tree/master"
-            },
-            "abandoned": true,
-            "time": "2019-03-10T06:17:37+00:00"
-        },
-        {
             "name": "doctrine/annotations",
             "version": "1.13.2",
             "source": {
@@ -1591,37 +1548,44 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.5",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
-                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17.0"
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
                 "psr/log": "^1.1"
             },
             "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5-dev"
+                    "dev-master": "7.3-dev"
                 }
             },
             "autoload": {
@@ -1641,6 +1605,11 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
@@ -1651,14 +1620,34 @@
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
             },
-            "time": "2020-06-16T21:01:06+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/SecretStorage/VaultStorage.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/SecretStorage/VaultStorage.php
@@ -6,12 +6,12 @@
 
 namespace Magento\FunctionalTestingFramework\DataGenerator\Handlers\SecretStorage;
 
+use GuzzleHttp\Client as GuzzleClient;
 use Magento\FunctionalTestingFramework\Config\MftfApplicationConfig;
 use Magento\FunctionalTestingFramework\DataGenerator\Handlers\CredentialStore;
 use Magento\FunctionalTestingFramework\Exceptions\TestFrameworkException;
 use Magento\FunctionalTestingFramework\Util\Logger\LoggingUtil;
 use Vault\Client;
-use VaultTransports\Guzzle6Transport;
 
 class VaultStorage extends BaseStorage
 {
@@ -78,8 +78,14 @@ class VaultStorage extends BaseStorage
     {
         parent::__construct();
         if (null === $this->client) {
-            // Creating the client using Guzzle6 Transport and passing a custom url
-            $this->client = new Client(new Guzzle6Transport(['base_uri' => $baseUrl]));
+            // client configuration and override http errors settings
+            $config = [
+                'timeout' => 15,
+                'base_uri' => $baseUrl,
+                'http_errors' => false
+            ];
+
+            $this->client = new Client(new GuzzleClient($config));
             $this->secretBasePath = $secretBasePath;
         }
         $this->readVaultTokenFromFileSystem();


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR aims to remove the dependency on Guzzle6transport, in order to be able to update the `guzzlehttp/guzzle` package to the latest `7.3.0` version. The current `csharpru/vault-php-guzzle6-transport` package's version, allows only `"guzzlehttp/guzzle": "~6.2"`.

### Fixed Issues (if relevant)
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests