### PR TITLE
MFTF-33780: Changed loose comparisons into strict

### DIFF
--- a/dev/tests/static/Magento/Sniffs/NamingConventions/InterfaceNameSniff.php
+++ b/dev/tests/static/Magento/Sniffs/NamingConventions/InterfaceNameSniff.php
@@ -29,9 +29,9 @@ class InterfaceNameSniff implements Sniff
         $declarationLine = $tokens[$stackPtr]['line'];
         $suffixLength = strlen(self::INTERFACE_SUFFIX);
         // Find first T_STRING after 'interface' keyword in the line and verify it
-        while ($tokens[$stackPtr]['line'] == $declarationLine) {
-            if ($tokens[$stackPtr]['type'] == 'T_STRING') {
-                if (substr($tokens[$stackPtr]['content'], 0 - $suffixLength) != self::INTERFACE_SUFFIX) {
+        while ($tokens[$stackPtr]['line'] === $declarationLine) {
+            if ($tokens[$stackPtr]['type'] === 'T_STRING') {
+                if (substr($tokens[$stackPtr]['content'], 0 - $suffixLength) !== self::INTERFACE_SUFFIX) {
                     $sourceFile->addError(
                         'Interface should have name that ends with "Interface" suffix.',
                         $stackPtr,

--- a/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/DataGenerator/Persist/OperationDataArrayResolverTest.php
@@ -306,7 +306,7 @@ class OperationDataArrayResolverTest extends MagentoTestCase
         $callback = function ($name) {
             $entityDataObjectBuilder = new EntityDataObjectBuilder();
 
-            if ($name == 'childObject1') {
+            if ($name === 'childObject1') {
                 return $entityDataObjectBuilder
                     ->withName('childObject1')
                     ->withType('childType')
@@ -314,7 +314,7 @@ class OperationDataArrayResolverTest extends MagentoTestCase
                     ->build();
             };
 
-            if ($name == 'childObject2') {
+            if ($name === 'childObject2') {
                 return $entityDataObjectBuilder
                     ->withName('childObject2')
                     ->withType('childType')

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Suite/Handlers/SuiteObjectHandlerTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Suite/Handlers/SuiteObjectHandlerTest.php
@@ -113,11 +113,11 @@ class SuiteObjectHandlerTest extends MagentoTestCase
             ->will(
                 $this->returnCallback(
                     function ($clazz) use ($mockDataParser, $mockSuiteDataParser) {
-                        if ($clazz == TestDataParser::class) {
+                        if ($clazz === TestDataParser::class) {
                             return $mockDataParser;
                         }
 
-                        if ($clazz == SuiteDataParser::class) {
+                        if ($clazz === SuiteDataParser::class) {
                             return $mockSuiteDataParser;
                         }
 

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Suite/SuiteGeneratorTest.php
@@ -347,13 +347,13 @@ class SuiteGeneratorTest extends MagentoTestCase
                         $mockGroupClass,
                         $objectManager
                     ) {
-                        if ($class == TestDataParser::class) {
+                        if ($class === TestDataParser::class) {
                             return $mockDataParser;
                         }
-                        if ($class == SuiteDataParser::class) {
+                        if ($class === SuiteDataParser::class) {
                             return $mockSuiteDataParser;
                         }
-                        if ($class == GroupClassGenerator::class) {
+                        if ($class === GroupClassGenerator::class) {
                             return $mockGroupClass;
                         }
 

--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionGroupObjectTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Objects/ActionGroupObjectTest.php
@@ -61,7 +61,7 @@ class ActionGroupObjectTest extends MagentoTestCase
     public function testGetStepsWithCustomArgs(): void
     {
         $this->setEntityObjectHandlerReturn(function ($entityName) {
-            if ($entityName == "data2") {
+            if ($entityName === 'data2') {
                 return (new EntityDataObjectBuilder())->withDataFields(['field2' => 'testValue2'])->build();
             }
         });
@@ -128,7 +128,7 @@ class ActionGroupObjectTest extends MagentoTestCase
     public function testGetStepsWithNoFieldArg(): void
     {
         $this->setEntityObjectHandlerReturn(function ($entityName) {
-            if ($entityName == "data2") {
+            if ($entityName === 'data2') {
                 return (new EntityDataObjectBuilder())->withDataFields(['field2' => 'testValue2'])->build();
             }
         });
@@ -151,7 +151,7 @@ class ActionGroupObjectTest extends MagentoTestCase
     public function testGetStepsWithNoArgs(): void
     {
         $this->setEntityObjectHandlerReturn(function ($entityName) {
-            if ($entityName == "data1") {
+            if ($entityName === 'data1') {
                 return (new EntityDataObjectBuilder())->withDataFields(['field1' => 'testValue'])->build();
             }
         });
@@ -174,7 +174,7 @@ class ActionGroupObjectTest extends MagentoTestCase
     {
         // Mock Entity Object Handler
         $this->setEntityObjectHandlerReturn(function ($entityName) {
-            if ($entityName == "data2") {
+            if ($entityName === 'data2') {
                 return (new EntityDataObjectBuilder())->withDataFields(['field2' => 'testValue2'])->build();
             }
         });
@@ -216,7 +216,7 @@ class ActionGroupObjectTest extends MagentoTestCase
     {
         // Mock Entity Object Handler
         $this->setEntityObjectHandlerReturn(function ($entityName) {
-            if ($entityName == "data2") {
+            if ($entityName === 'data2') {
                 return (new EntityDataObjectBuilder())->withDataFields(['field2' => 'testValue2'])->build();
             }
         });

--- a/dev/tests/unit/Util/SuiteDataArrayBuilder.php
+++ b/dev/tests/unit/Util/SuiteDataArrayBuilder.php
@@ -181,7 +181,7 @@ class SuiteDataArrayBuilder
      */
     public function withAfterHook($afterHook = null)
     {
-        if ($afterHook == null) {
+        if ($afterHook === null) {
             $this->afterHook = [$this->testActionAfterName => [
                 ActionObjectExtractor::NODE_NAME => $this->testActionType,
                 ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testActionAfterName
@@ -202,7 +202,7 @@ class SuiteDataArrayBuilder
      */
     public function withBeforeHook($beforeHook = null)
     {
-        if ($beforeHook == null) {
+        if ($beforeHook === null) {
             $this->beforeHook = [$this->testActionBeforeName => [
                 ActionObjectExtractor::NODE_NAME => $this->testActionType,
                 ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testActionBeforeName

--- a/dev/tests/unit/Util/TestDataArrayBuilder.php
+++ b/dev/tests/unit/Util/TestDataArrayBuilder.php
@@ -109,7 +109,7 @@ class TestDataArrayBuilder
      */
     public function withAnnotations($annotations = null)
     {
-        if ($annotations == null) {
+        if ($annotations === null) {
             $this->annotations = ['group' => [['value' => 'test']]];
         } else {
             $this->annotations = $annotations;
@@ -126,7 +126,7 @@ class TestDataArrayBuilder
      */
     public function withBeforeHook($beforeHook = null)
     {
-        if ($beforeHook == null) {
+        if ($beforeHook === null) {
             $this->beforeHook = [$this->testActionBeforeName => [
                 ActionObjectExtractor::NODE_NAME => $this->testActionType,
                 ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testActionBeforeName
@@ -146,7 +146,7 @@ class TestDataArrayBuilder
      */
     public function withAfterHook($afterHook = null)
     {
-        if ($afterHook == null) {
+        if ($afterHook === null) {
             $this->afterHook = [$this->testActionAfterName => [
                     ActionObjectExtractor::NODE_NAME => $this->testActionType,
                     ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testActionAfterName
@@ -167,7 +167,7 @@ class TestDataArrayBuilder
      */
     public function withFailedHook($failedHook = null)
     {
-        if ($failedHook == null) {
+        if ($failedHook === null) {
             $this->failedHook = [$this->testActionFailedName => [
                 ActionObjectExtractor::NODE_NAME => $this->testActionType,
                 ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testActionFailedName
@@ -188,7 +188,7 @@ class TestDataArrayBuilder
      */
     public function withTestActions($actions = null)
     {
-        if ($actions == null) {
+        if ($actions === null) {
             $this->testActions = [$this->testTestActionName => [
                 ActionObjectExtractor::NODE_NAME => $this->testActionType,
                 ActionObjectExtractor::TEST_STEP_MERGE_KEY => $this->testTestActionName
@@ -207,7 +207,7 @@ class TestDataArrayBuilder
      */
     public function withFileName($filename = null)
     {
-        if ($filename == null) {
+        if ($filename === null) {
             $this->filename =
                 "/magento2-functional-testing-framework/dev/tests/verification/TestModule/Test/BasicFunctionalTest.xml";
         } else {

--- a/dev/tests/unit/Util/TestLoggingUtil.php
+++ b/dev/tests/unit/Util/TestLoggingUtil.php
@@ -40,7 +40,7 @@ class TestLoggingUtil extends TestCase
      */
     public static function getInstance(): TestLoggingUtil
     {
-        if (self::$instance == null) {
+        if (self::$instance === null) {
             self::$instance = new TestLoggingUtil();
         }
         return self::$instance;

--- a/dev/tests/verification/Tests/ResilientGenerationTest.php
+++ b/dev/tests/verification/Tests/ResilientGenerationTest.php
@@ -123,7 +123,7 @@ class ResilientGenerationTest extends MftfTestCase
         SuiteGenerator::getInstance()->generateAllSuites($testManifest);
 
         foreach (SuiteTestReferences::$data as $groupName => $expectedContents) {
-            if (substr($groupName, 0, 11) != 'NotGenerate') {
+            if (substr($groupName, 0, 11) !== 'NotGenerate') {
                 // Validate Yaml file updated
                 $yml = Yaml::parse(file_get_contents(self::CONFIG_YML_FILE));
                 $this->assertArrayHasKey($groupName, $yml['groups']);
@@ -175,7 +175,7 @@ class ResilientGenerationTest extends MftfTestCase
                 );
             }
 
-            if (substr($groupName, 0, 11) != 'NotGenerate') {
+            if (substr($groupName, 0, 11) !== 'NotGenerate') {
                 // Validate Yaml file updated
                 $yml = Yaml::parse(file_get_contents(self::CONFIG_YML_FILE));
                 $this->assertArrayHasKey($groupName, $yml['groups']);
@@ -199,7 +199,7 @@ class ResilientGenerationTest extends MftfTestCase
             }
 
             // Validate log message
-            if (substr($groupName, 0, 11) != 'NotGenerate'
+            if (substr($groupName, 0, 11) !== 'NotGenerate'
                 && !in_array($groupName, array_keys(self::$exceptionGrpLogs))) {
                 $type = 'info';
                 $message = '/suite generated/';

--- a/etc/config/command.php
+++ b/etc/config/command.php
@@ -18,7 +18,7 @@ if (!empty($_POST['token']) && !empty($_POST['command'])) {
 
     // Token returned will be null if the token we passed in is invalid
     $tokenFromMagento = $tokenModel->loadByToken($tokenPassedIn)->getToken();
-    if (!empty($tokenFromMagento) && ($tokenFromMagento == $tokenPassedIn)) {
+    if (!empty($tokenFromMagento) && ($tokenFromMagento === $tokenPassedIn)) {
         $php = PHP_BINDIR ? PHP_BINDIR . '/php' : 'php';
         $magentoBinary = $php . ' -f ../../../../bin/magento';
         $valid = validateCommand($magentoBinary, $command);
@@ -52,7 +52,7 @@ if (!empty($_POST['token']) && !empty($_POST['command'])) {
 
             $exitCode = $process->getExitCode();
 
-            if ($exitCode == 0 || $idleTimeout) {
+            if ($process->isSuccessful() || $idleTimeout) {
                 http_response_code(202);
             } else {
                 http_response_code(500);

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -63,7 +63,7 @@ class MagentoAllureAdapter extends AllureCodeception
      */
     private function getGroup()
     {
-        if ($this->options['groups'] != null) {
+        if ($this->options['groups'] !== null) {
             return $this->options['groups'][0];
         }
         return null;
@@ -79,7 +79,7 @@ class MagentoAllureAdapter extends AllureCodeception
     {
         $changeSuiteEvent = $suiteEvent;
 
-        if ($this->getGroup() != null) {
+        if ($this->getGroup() !== null) {
             $suite = $suiteEvent->getSuite();
             $suiteName = ($suite->getName()) . "\\" . $this->sanitizeGroupName($this->getGroup());
 
@@ -414,8 +414,8 @@ class MagentoAllureAdapter extends AllureCodeception
     private function formatAllureTestClassName($test)
     {
         if ($this->getGroup() !== null) {
-            foreach ($test->getLabels() as $name => $label) {
-                if ($label->getName() == 'testClass') {
+            foreach ($test->getLabels() as $label) {
+                if ($label->getName() === 'testClass') {
                     $originalTestClass = $this->sanitizeTestClassLabel($label->getValue());
                     call_user_func(\Closure::bind(
                         function () use ($label, $originalTestClass) {

--- a/src/Magento/FunctionalTestingFramework/Allure/AllureHelper.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/AllureHelper.php
@@ -50,7 +50,7 @@ class AllureHelper
         $rootStep = Allure::lifecycle()->getStepStorage()->getLast();
         $trueLastStep = array_last($rootStep->getSteps());
 
-        if ($trueLastStep == null) {
+        if ($trueLastStep === null) {
             // Nothing to attach to; do not fire off allure event
             return;
         }

--- a/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
+++ b/src/Magento/FunctionalTestingFramework/Codeception/Subscriber/Console.php
@@ -119,7 +119,7 @@ class Console extends \Codeception\Subscriber\Console
         }
 
         $metaStep = $e->getStep()->getMetaStep();
-        if ($metaStep and $this->metaStep != $metaStep) {
+        if ($metaStep and $this->metaStep !== $metaStep) {
             $this->message(' ' . $metaStep->getPrefix())
                 ->style('bold')
                 ->append($metaStep->__toString())
@@ -158,7 +158,7 @@ class Console extends \Codeception\Subscriber\Console
      */
     private function printStepKeys(Step $step)
     {
-        if ($step instanceof Comment and $step->__toString() == '') {
+        if ($step instanceof Comment and $step->__toString() === '') {
             return; // don't print empty comments
         }
 

--- a/src/Magento/FunctionalTestingFramework/Composer/ComposerInstall.php
+++ b/src/Magento/FunctionalTestingFramework/Composer/ComposerInstall.php
@@ -50,7 +50,7 @@ class ComposerInstall extends AbstractComposer
     {
         /** @var CompletePackageInterface $package */
         foreach ($this->getLocker()->getLockedRepository()->getPackages() as $package) {
-            if (($package->getName() == $packageName) && ($package->getType() == $packageType)) {
+            if (($package->getName() === $packageName) && ($package->getType() === $packageType)) {
                 return true;
             }
         }
@@ -67,7 +67,7 @@ class ComposerInstall extends AbstractComposer
         $packages = [];
         /** @var CompletePackageInterface $package */
         foreach ($this->getLocker()->getLockedRepository()->getPackages() as $package) {
-            if ($package->getType() == self::TEST_MODULE_PACKAGE_TYPE) {
+            if ($package->getType() === self::TEST_MODULE_PACKAGE_TYPE) {
                 $packages[$package->getName()] = [
                     self::PACKAGE_NAME => $package->getName(),
                     self::PACKAGE_TYPE => $package->getType(),

--- a/src/Magento/FunctionalTestingFramework/Composer/ComposerPackage.php
+++ b/src/Magento/FunctionalTestingFramework/Composer/ComposerPackage.php
@@ -116,7 +116,7 @@ class ComposerPackage extends AbstractComposer
      */
     public function isMftfTestPackage()
     {
-        return ($this->getType() == self::TEST_MODULE_PACKAGE_TYPE) ? true : false;
+        return $this->getType() === self::TEST_MODULE_PACKAGE_TYPE;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/Config/Converter.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Converter.php
@@ -91,7 +91,7 @@ class Converter implements \Magento\FunctionalTestingFramework\Config\ConverterI
 
         foreach ($elements as $element) {
             if ($element instanceof \DOMElement) {
-                if ($element->getAttribute('remove') == 'true') {
+                if ($element->getAttribute('remove') === 'true') {
                     // Remove element
                     continue;
                 }
@@ -119,7 +119,7 @@ class Converter implements \Magento\FunctionalTestingFramework\Config\ConverterI
                 } elseif (!empty($elementData)) {
                     $result[$element->nodeName][] = $elementData;
                 }
-            } elseif ($element->nodeType == XML_TEXT_NODE && trim($element->nodeValue) != '') {
+            } elseif ($element->nodeType === XML_TEXT_NODE && trim($element->nodeValue) !== '') {
                 return ['value' => $element->nodeValue];
             }
         }
@@ -156,9 +156,9 @@ class Converter implements \Magento\FunctionalTestingFramework\Config\ConverterI
     protected function isKeyAttribute(\DOMElement $element, \DOMAttr $attribute)
     {
         if (isset($this->idAttributes[$element->nodeName])) {
-            return $attribute->name == $this->idAttributes[$element->nodeName];
+            return $attribute->name === $this->idAttributes[$element->nodeName];
         } else {
-            return $attribute->name == self::NAME_ATTRIBUTE;
+            return $attribute->name === self::NAME_ATTRIBUTE;
         }
     }
 
@@ -174,7 +174,7 @@ class Converter implements \Magento\FunctionalTestingFramework\Config\ConverterI
         if ($element->hasAttributes()) {
             /** @var \DomAttr $attribute */
             foreach ($element->attributes as $attribute) {
-                if (trim($attribute->nodeValue) != '' && !$this->isKeyAttribute($element, $attribute)) {
+                if (trim($attribute->nodeValue) !== '' && !$this->isKeyAttribute($element, $attribute)) {
                     $attributes[$attribute->nodeName] = $this->castNumeric($attribute->nodeValue);
                 }
             }

--- a/src/Magento/FunctionalTestingFramework/Config/Converter/Dom/Flat.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Converter/Dom/Flat.php
@@ -41,7 +41,7 @@ class Flat
         $attributes = $node->attributes ?: [];
         /** @var \DOMNode $attribute */
         foreach ($attributes as $attribute) {
-            if ($attribute->nodeType == XML_ATTRIBUTE_NODE) {
+            if ($attribute->nodeType === XML_ATTRIBUTE_NODE) {
                 $result[$attribute->nodeName] = $attribute->nodeValue;
             }
         }
@@ -77,7 +77,7 @@ class Flat
         $value = [];
         /** @var \DOMNode $node */
         foreach ($source->childNodes as $node) {
-            if ($node->nodeType == XML_ELEMENT_NODE) {
+            if ($node->nodeType === XML_ELEMENT_NODE) {
                 $nodeName = $node->nodeName;
                 $nodePath = $basePath . '/' . $nodeName;
 
@@ -107,8 +107,8 @@ class Flat
                 } else {
                     $value[$nodeName] = $nodeData;
                 }
-            } elseif ($node->nodeType == XML_CDATA_SECTION_NODE
-                || ($node->nodeType == XML_TEXT_NODE && trim($node->nodeValue) != '')
+            } elseif ($node->nodeType === XML_CDATA_SECTION_NODE
+                || ($node->nodeType === XML_TEXT_NODE && trim($node->nodeValue) !== '')
             ) {
                 $value = $node->nodeValue;
                 break;

--- a/src/Magento/FunctionalTestingFramework/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Dom.php
@@ -207,7 +207,7 @@ class Dom
      */
     protected function isTextNode($node)
     {
-        return $node->childNodes->length == 1 && $node->childNodes->item(0) instanceof \DOMText;
+        return $node->childNodes->length === 1 && $node->childNodes->item(0) instanceof \DOMText;
     }
 
     /**
@@ -273,7 +273,7 @@ class Dom
         $node = null;
         if ($matchedNodes->length > 1) {
             throw new \Exception("More than one node matching the query: {$nodePath}");
-        } elseif ($matchedNodes->length == 1) {
+        } elseif ($matchedNodes->length === 1) {
             $node = $matchedNodes->item(0);
         }
         return $node;

--- a/src/Magento/FunctionalTestingFramework/Config/MftfApplicationConfig.php
+++ b/src/Magento/FunctionalTestingFramework/Config/MftfApplicationConfig.php
@@ -135,7 +135,7 @@ class MftfApplicationConfig
         $allowSkipped = false,
         $filters = []
     ) {
-        if (self::$MFTF_APPLICATION_CONTEXT == null) {
+        if (self::$MFTF_APPLICATION_CONTEXT === null) {
             self::$MFTF_APPLICATION_CONTEXT =
                 new MftfApplicationConfig(
                     $forceGenerate,
@@ -159,7 +159,7 @@ class MftfApplicationConfig
         // TODO explicitly set this with AcceptanceTester or MagentoWebDriver
         // during execution we cannot guarantee the use of the robofile so we return the default application config,
         // we don't want to set the application context in case the user explicitly does so at a later time.
-        if (self::$MFTF_APPLICATION_CONTEXT == null) {
+        if (self::$MFTF_APPLICATION_CONTEXT === null) {
             return new MftfApplicationConfig();
         }
 

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/Filesystem.php
@@ -159,7 +159,7 @@ class Filesystem implements \Magento\FunctionalTestingFramework\Config\ReaderInt
                 } else {
                     $configMerger->merge($content);
                 }
-                if (strcasecmp($debugLevel, MftfApplicationConfig::LEVEL_DEVELOPER) == 0) {
+                if (strcasecmp($debugLevel, MftfApplicationConfig::LEVEL_DEVELOPER) === 0) {
                     $this->validateSchema($configMerger, $fileList->getFilename());
                 }
             } catch (\Magento\FunctionalTestingFramework\Config\Dom\ValidationException $e) {

--- a/src/Magento/FunctionalTestingFramework/Config/Reader/MftfFilesystem.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader/MftfFilesystem.php
@@ -42,7 +42,7 @@ class MftfFilesystem extends \Magento\FunctionalTestingFramework\Config\Reader\F
                     $configMerger->merge($content, $fileList->getFilename(), $exceptionCollector);
                 }
                  // run per file validation with generate:tests -d
-                if (strcasecmp($debugLevel, MftfApplicationConfig::LEVEL_DEVELOPER) == 0) {
+                if (strcasecmp($debugLevel, MftfApplicationConfig::LEVEL_DEVELOPER) === 0) {
                     $this->validateSchema($configMerger, $fileList->getFilename());
                 }
             } catch (\Magento\FunctionalTestingFramework\Config\Dom\ValidationException $e) {
@@ -52,7 +52,7 @@ class MftfFilesystem extends \Magento\FunctionalTestingFramework\Config\Reader\F
         $exceptionCollector->throwException();
 
          //run validation on merged file with generate:tests
-        if (strcasecmp($debugLevel, MftfApplicationConfig::LEVEL_DEFAULT) == 0) {
+        if (strcasecmp($debugLevel, MftfApplicationConfig::LEVEL_DEFAULT) === 0) {
             $this->validateSchema($configMerger);
         }
 

--- a/src/Magento/FunctionalTestingFramework/Config/ValidationState.php
+++ b/src/Magento/FunctionalTestingFramework/Config/ValidationState.php
@@ -37,6 +37,6 @@ class ValidationState implements ValidationStateInterface
      */
     public function isValidationRequired()
     {
-        return $this->appMode == 'developer'; // @todo
+        return $this->appMode === 'developer'; // @todo
     }
 }

--- a/src/Magento/FunctionalTestingFramework/Console/DoctorCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/DoctorCommand.php
@@ -190,7 +190,7 @@ class DoctorCommand extends Command
 
         // Disable MagentoWebDriver to avoid conflicts
         foreach ($settings['modules']['enabled'] as $index => $module) {
-            if ($module == $magentoWebDriver) {
+            if ($module === $magentoWebDriver) {
                 unset($settings['modules']['enabled'][$index]);
                 break;
             }

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateDevUrnCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateDevUrnCommand.php
@@ -61,10 +61,10 @@ class GenerateDevUrnCommand extends Command
     {
         $miscXmlFilePath = $input->getArgument(self::IDE_FILE_PATH_ARGUMENT);
         $miscXmlFile = realpath($miscXmlFilePath);
-        $force = $input->getOption('force');
+        $force = (bool) $input->getOption('force');
 
         if ($miscXmlFile === false) {
-            if ($force == true) {
+            if ($force === true) {
                 // create file and refresh realpath
                 $xml = "<project version=\"4\"/>";
                 file_put_contents($miscXmlFilePath, $xml);

--- a/src/Magento/FunctionalTestingFramework/Console/GenerateTestsCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/GenerateTestsCommand.php
@@ -231,7 +231,8 @@ class GenerateTestsCommand extends BaseGenerateCommand
                     $message = "Unable to create test object {$test} from test configuration. " . $e->getMessage();
                     LoggingUtil::getInstance()->getLogger(self::class)->error($message);
                     if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                        && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                        && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE
+                    ) {
                         print($message);
                     }
                     GenerationErrorHandler::getInstance()->addError('test', $test, $message);

--- a/src/Magento/FunctionalTestingFramework/Console/RunManifestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunManifestCommand.php
@@ -86,7 +86,7 @@ class RunManifestCommand extends Command
                 continue;
             }
 
-            if ($line == count($manifestFile) - 1) {
+            if ($line === count($manifestFile) - 1) {
                 $this->runManifestLine($manifestFile[$line], $output, true);
             } else {
                 $this->runManifestLine($manifestFile[$line], $output);

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestCommand.php
@@ -156,7 +156,7 @@ class RunTestCommand extends BaseGenerateCommand
 
             if ($this->pauseEnabled()) {
                 $fullCommand = $codeceptionCommand . $testsDirectory . $testName . ' --verbose --steps --debug';
-                if ($i != count($tests) - 1) {
+                if ($i !== count($tests) - 1) {
                     $fullCommand .= self::CODECEPT_RUN_OPTION_NO_EXIT;
                 }
                 $this->returnCode = max($this->returnCode, $this->codeceptRunTest($fullCommand, $output));
@@ -195,7 +195,7 @@ class RunTestCommand extends BaseGenerateCommand
 
             $index += 1;
             if ($this->pauseEnabled()) {
-                if ($index != $count) {
+                if ($index !== $count) {
                     $fullCommand .= self::CODECEPT_RUN_OPTION_NO_EXIT;
                 }
                 $this->returnCode = max($this->returnCode, $this->codeceptRunTest($fullCommand, $output));

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestFailedCommand.php
@@ -108,7 +108,7 @@ class RunTestFailedCommand extends BaseGenerateCommand
         for ($i = 0; $i < count($testManifestList); $i++) {
             if ($this->pauseEnabled()) {
                 $codeceptionCommand = self::CODECEPT_RUN_FUNCTIONAL . $testManifestList[$i] . ' --debug ';
-                if ($i != count($testManifestList) - 1) {
+                if ($i !== count($testManifestList) - 1) {
                     $codeceptionCommand .= self::CODECEPT_RUN_OPTION_NO_EXIT;
                 }
                 $returnCode = $this->codeceptRunTest($codeceptionCommand, $output);
@@ -161,7 +161,7 @@ class RunTestFailedCommand extends BaseGenerateCommand
                     $testName = explode(":", $testInfo[count($testInfo) - 1])[1];
                     $suiteName = $testInfo[count($testInfo) - 2];
 
-                    if ($suiteName == self::DEFAULT_TEST_GROUP) {
+                    if ($suiteName === self::DEFAULT_TEST_GROUP) {
                         array_push($failedTestDetails['tests'], $testName);
                     } else {
                         $suiteName = $this->sanitizeSuiteName($suiteName);
@@ -195,7 +195,7 @@ class RunTestFailedCommand extends BaseGenerateCommand
     private function sanitizeSuiteName($suiteName)
     {
         $suiteNameArray = explode("_", $suiteName);
-        if (array_pop($suiteNameArray) == 'G') {
+        if (array_pop($suiteNameArray) === 'G') {
             if (is_numeric(array_pop($suiteNameArray))) {
                 $suiteName = implode("_", $suiteNameArray);
             }

--- a/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
+++ b/src/Magento/FunctionalTestingFramework/Console/RunTestGroupCommand.php
@@ -115,7 +115,7 @@ class RunTestGroupCommand extends BaseGenerateCommand
             $codeceptionCommandString = $commandString . ' -g ' . $groups[$i];
 
             if ($this->pauseEnabled()) {
-                if ($i != count($groups) - 1) {
+                if ($i !== count($groups) - 1) {
                     $codeceptionCommandString .= self::CODECEPT_RUN_OPTION_NO_EXIT;
                 }
                 $returnCodes[] = $this->codeceptRunTest($codeceptionCommandString, $output);
@@ -139,7 +139,7 @@ class RunTestGroupCommand extends BaseGenerateCommand
         $this->applyAllFailed();
 
         foreach ($returnCodes as $returnCode) {
-            if ($returnCode != 0) {
+            if ($returnCode !== 0) {
                 return $returnCode;
             }
             $exitCode = 0;

--- a/src/Magento/FunctionalTestingFramework/Data/Argument/Interpreter/ArrayType.php
+++ b/src/Magento/FunctionalTestingFramework/Data/Argument/Interpreter/ArrayType.php
@@ -98,7 +98,7 @@ class ArrayType implements InterpreterInterface
             $secondValue = intval($secondItem['sortOrder']);
         }
 
-        if ($firstValue == $secondValue) {
+        if ($firstValue === $secondValue) {
             // These keys reflect initial relative position of items.
             // Allows stable sort for items with equal 'sortOrder'
             return $firstItemKey < $secondItemKey ? -1 : 1;

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Config/Dom.php
@@ -84,7 +84,7 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
         $itemNodes = $dom->getElementsByTagName('item');
         /** @var \DOMElement $itemNode */
         foreach ($itemNodes as $itemKey => $itemNode) {
-            if ($itemNode->hasAttribute("name") == false) {
+            if ($itemNode->hasAttribute("name") === false) {
                 $itemNode->setAttribute("name", (string)$itemKey);
             }
         }

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/CredentialStore.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/CredentialStore.php
@@ -58,7 +58,7 @@ class CredentialStore
      */
     public static function getInstance()
     {
-        if (self::$INSTANCE == null) {
+        if (self::$INSTANCE === null) {
             self::$INSTANCE = new CredentialStore();
         }
 
@@ -162,13 +162,13 @@ class CredentialStore
         $exceptionMessage = "\n";
         foreach ($this->exceptionContexts->getErrors() as $type => $exceptions) {
             $exceptionMessage .= "\nException from ";
-            if ($type == self::ARRAY_KEY_FOR_FILE) {
+            if ($type === self::ARRAY_KEY_FOR_FILE) {
                 $exceptionMessage .= "File Storage: \n";
             }
-            if ($type == self::ARRAY_KEY_FOR_VAULT) {
+            if ($type === self::ARRAY_KEY_FOR_VAULT) {
                 $exceptionMessage .= "Vault Storage: \n";
             }
-            if ($type == self::ARRAY_KEY_FOR_AWS_SECRETS_MANAGER) {
+            if ($type === self::ARRAY_KEY_FOR_AWS_SECRETS_MANAGER) {
                 $exceptionMessage .= "AWS Secrets Manager Storage: \n";
             }
 

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/DataObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/DataObjectHandler.php
@@ -319,8 +319,8 @@ class DataObjectHandler implements ObjectHandlerInterface
      */
     private function extendDataObject($dataObject)
     {
-        if ($dataObject->getParentName() != null) {
-            if ($dataObject->getParentName() == $dataObject->getName()) {
+        if ($dataObject->getParentName() !== null) {
+            if ($dataObject->getParentName() === $dataObject->getName()) {
                 throw new TestFrameworkException("Mftf Data can not extend from itself: " . $dataObject->getName());
             }
             return $this->extendUtil->extendEntity($dataObject);

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/PersistedObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Handlers/PersistedObjectHandler.php
@@ -106,9 +106,9 @@ class PersistedObjectHandler
         
         $persistedObject->createEntity($storeCode);
 
-        if ($scope == self::TEST_SCOPE) {
+        if ($scope === self::TEST_SCOPE) {
             $this->testObjects[$key] = $persistedObject;
-        } elseif ($scope == self::HOOK_SCOPE) {
+        } elseif ($scope === self::HOOK_SCOPE) {
             $this->hookObjects[$key] = $persistedObject;
         } else {
             $this->suiteObjects[$key] = $persistedObject;
@@ -170,9 +170,9 @@ class PersistedObjectHandler
         );
         $persistedObject->getEntity($index, $storeCode);
 
-        if ($scope == self::TEST_SCOPE) {
+        if ($scope === self::TEST_SCOPE) {
             $this->testObjects[$key] = $persistedObject;
-        } elseif ($scope == self::HOOK_SCOPE) {
+        } elseif ($scope === self::HOOK_SCOPE) {
             $this->hookObjects[$key] = $persistedObject;
         } else {
             $this->suiteObjects[$key] = $persistedObject;
@@ -214,7 +214,7 @@ class PersistedObjectHandler
         // Assume TEST_SCOPE is default
         $entityArrays = [$this->testObjects, $this->hookObjects, $this->suiteObjects];
 
-        if ($scope == self::HOOK_SCOPE) {
+        if ($scope === self::HOOK_SCOPE) {
             $entityArrays[0] = $this->hookObjects;
             $entityArrays[1] = $this->testObjects;
         }

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Objects/EntityDataObject.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Objects/EntityDataObject.php
@@ -233,7 +233,7 @@ class EntityDataObject
                 $this->data[$name_lower],
                 $this->name . '.' . $name
             );
-            if (null === $uniquenessData || $uniquenessFormat == self::NO_UNIQUE_PROCESS) {
+            if (null === $uniquenessData || $uniquenessFormat === self::NO_UNIQUE_PROCESS) {
                 return $this->data[$name_lower];
             }
             return $this->formatUniqueData($name_lower, $uniquenessData, $uniquenessFormat);
@@ -276,7 +276,7 @@ class EntityDataObject
         switch ($uniqueDataFormat) {
             case self::SUITE_UNIQUE_VALUE:
                 $this->checkUniquenessFunctionExists(self::SUITE_UNIQUE_FUNCTION, $uniqueDataFormat);
-                if ($uniqueData == 'prefix') {
+                if ($uniqueData === 'prefix') {
                     return msqs($this->getName()) . $this->data[$name];
                 } else { // $uniData == 'suffix'
                     return $this->data[$name] . msqs($this->getName());
@@ -284,21 +284,21 @@ class EntityDataObject
                 break;
             case self::CEST_UNIQUE_VALUE:
                 $this->checkUniquenessFunctionExists(self::CEST_UNIQUE_FUNCTION, $uniqueDataFormat);
-                if ($uniqueData == 'prefix') {
+                if ($uniqueData === 'prefix') {
                     return msq($this->getName()) . $this->data[$name];
                 } else { // $uniqueData == 'suffix'
                     return $this->data[$name] . msq($this->getName());
                 }
                 break;
             case self::SUITE_UNIQUE_NOTATION:
-                if ($uniqueData == 'prefix') {
+                if ($uniqueData === 'prefix') {
                     return self::SUITE_UNIQUE_FUNCTION . '("' . $this->getName() . '")' . $this->data[$name];
                 } else { // $uniqueData == 'suffix'
                     return $this->data[$name] . self::SUITE_UNIQUE_FUNCTION . '("' . $this->getName() . '")';
                 }
                 break;
             case self::CEST_UNIQUE_NOTATION:
-                if ($uniqueData == 'prefix') {
+                if ($uniqueData === 'prefix') {
                     return self::CEST_UNIQUE_FUNCTION . '("' . $this->getName() . '")' . $this->data[$name];
                 } else { // $uniqueData == 'suffix'
                     return $this->data[$name] . self::CEST_UNIQUE_FUNCTION . '("' . $this->getName() . '")';
@@ -358,7 +358,7 @@ class EntityDataObject
         $groupedArray = [];
 
         foreach ($this->linkedEntities as $entityName => $entityType) {
-            if ($entityType == $type) {
+            if ($entityType === $type) {
                 $groupedArray[] = $entityName;
             }
         }

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Objects/OperationDefinitionObject.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Objects/OperationDefinitionObject.php
@@ -351,7 +351,7 @@ class OperationDefinitionObject
      */
     public function logDeprecated()
     {
-        if ($this->deprecated != null) {
+        if ($this->deprecated !== null) {
             LoggingUtil::getInstance()->getLogger(self::class)->deprecation(
                 $message = "The operation {$this->name} is deprecated.",
                 ["operationType" => $this->operation, "deprecatedMessage" => $this->deprecated],

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Persist/OperationDataArrayResolver.php
@@ -78,7 +78,7 @@ class OperationDataArrayResolver
         self::incrementSequence($entityObject->getName());
 
         foreach ($operationMetadata as $operationElement) {
-            if ($operationElement->getType() == OperationElementExtractor::OPERATION_OBJECT_OBJ_NAME) {
+            if ($operationElement->getType() === OperationElementExtractor::OPERATION_OBJECT_OBJ_NAME) {
                 $entityObj = $this->resolveOperationObjectAndEntityData($entityObject, $operationElement->getValue());
                 if (null === $entityObj && $operationElement->isRequired()) {
                     throw new \Exception(sprintf(
@@ -189,13 +189,13 @@ class OperationDataArrayResolver
             EntityDataObject::CEST_UNIQUE_VALUE
         );
 
-        if ($elementData == null && $entityObject->getVarReference($operationKey) != null) {
+        if ($elementData === null && $entityObject->getVarReference($operationKey) !== null) {
             list($type, $field) = explode(
                 DataObjectHandler::_SEPARATOR,
                 $entityObject->getVarReference($operationKey)
             );
 
-            if ($operationElementType == OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY) {
+            if ($operationElementType === OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY) {
                 $elementDatas = [];
                 $entities = $this->getDependentEntitiesOfType($type);
                 foreach ($entities as $entity) {
@@ -224,7 +224,7 @@ class OperationDataArrayResolver
         $entitiesOfType = [];
 
         foreach ($this->dependentEntities as $dependentEntity) {
-            if ($dependentEntity->getType() == $type) {
+            if ($dependentEntity->getType() === $type) {
                 $entitiesOfType[] = $dependentEntity;
             }
         }
@@ -244,7 +244,7 @@ class OperationDataArrayResolver
      */
     private function resolveOperationObjectAndEntityData($entityObject, $operationElementValue)
     {
-        if ($operationElementValue != $entityObject->getType()) {
+        if ($operationElementValue !== $entityObject->getType()) {
             // if we have a mismatch attempt to retrieve linked data and return just the last linkage
             // this enables overwriting of required entity fields
             $linkName = $entityObject->getLinkedEntitiesOfType($operationElementValue);
@@ -275,7 +275,7 @@ class OperationDataArrayResolver
         // in array case
         if (!is_array($operationElement->getValue())
             && !empty($operationElement->getNestedOperationElement($operationElement->getValue()))
-            && $operationElement->getType() == OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY
+            && $operationElement->getType() === OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY
         ) {
             $operationSubArray = $this->resolveOperationDataArray(
                 $linkedEntityObj,
@@ -403,7 +403,7 @@ class OperationDataArrayResolver
         // If data was defined at all, attempt to put it into operation data array
         // If data was not defined, and element is required, throw exception
         // If no data is defined, don't input defaults per primitive into operation data array
-        if ($elementData != null) {
+        if ($elementData !== null) {
             if (array_key_exists($operationElement->getKey(), $entityObject->getUniquenessData())) {
                 $uniqueData = $entityObject->getUniquenessDataByName($operationElement->getKey());
                 if ($uniqueData === 'suffix') {
@@ -449,7 +449,7 @@ class OperationDataArrayResolver
         $entityNamesOfType = $entityObject->getLinkedEntitiesOfType($operationElementType);
 
         // If an element is required by metadata, but was not provided in the entity, throw an exception
-        if ($operationElement->isRequired() && $entityNamesOfType == null) {
+        if ($operationElement->isRequired() && $entityNamesOfType === null) {
             throw new \Exception(sprintf(
                 self::EXCEPTION_REQUIRED_DATA,
                 $operationElement->getType(),
@@ -476,7 +476,7 @@ class OperationDataArrayResolver
                 }
             }
 
-            if ($operationElement->getType() == OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY) {
+            if ($operationElement->getType() === OperationDefinitionObjectHandler::ENTITY_OPERATION_ARRAY) {
                 $operationDataArray[$operationElement->getKey()][] = $operationDataSubArray;
             } else {
                 $operationDataArray[$operationElement->getKey()] = $operationDataSubArray;

--- a/src/Magento/FunctionalTestingFramework/DataGenerator/Util/DataExtensionUtil.php
+++ b/src/Magento/FunctionalTestingFramework/DataGenerator/Util/DataExtensionUtil.php
@@ -32,7 +32,7 @@ class DataExtensionUtil
     {
         // Check to see if the parent entity exists
         $parentEntity = DataObjectHandler::getInstance()->getObject($entityObject->getParentName());
-        if ($parentEntity == null) {
+        if ($parentEntity === null) {
             throw new XmlException(
                 "Parent Entity " .
                 $entityObject->getParentName() .

--- a/src/Magento/FunctionalTestingFramework/DataTransport/WebApiExecutor.php
+++ b/src/Magento/FunctionalTestingFramework/DataTransport/WebApiExecutor.php
@@ -135,7 +135,7 @@ class WebApiExecutor implements CurlInterface
     protected function getFormattedUrl($resource)
     {
         $urlResult = MftfGlobals::getWebApiBaseUrl();
-        if ($this->storeCode != null) {
+        if ($this->storeCode !== null) {
             $urlResult .= $this->storeCode . '/';
         }
         $urlResult .= trim($resource, '/');

--- a/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
+++ b/src/Magento/FunctionalTestingFramework/Extension/TestContextExtension.php
@@ -100,7 +100,7 @@ class TestContextExtension extends BaseExtension
         // check for errors in all test hooks and attach in allure
         if (!empty($testResultObject->errors())) {
             foreach ($testResultObject->errors() as $error) {
-                if ($error->failedTest()->getTestMethod() == $cest->getTestMethod()) {
+                if ($error->failedTest()->getTestMethod() === $cest->getTestMethod()) {
                     $this->attachExceptionToAllure($error->thrownException(), $cest->getTestMethod());
                 }
             }
@@ -109,7 +109,7 @@ class TestContextExtension extends BaseExtension
         // check for failures in all test hooks and attach in allure
         if (!empty($testResultObject->failures())) {
             foreach ($testResultObject->failures() as $failure) {
-                if ($failure->failedTest()->getTestMethod() == $cest->getTestMethod()) {
+                if ($failure->failedTest()->getTestMethod() === $cest->getTestMethod()) {
                     $this->attachExceptionToAllure($failure->thrownException(), $cest->getTestMethod());
                 }
             }
@@ -128,7 +128,7 @@ class TestContextExtension extends BaseExtension
     {
         foreach ($trace as $entry) {
             $traceClass = $entry["class"] ?? null;
-            if (strpos($traceClass, $class) != 0) {
+            if (strpos($traceClass, $class) !== 0) {
                 return $entry["function"];
             }
         }
@@ -257,7 +257,7 @@ class TestContextExtension extends BaseExtension
     protected function localizePath($path)
     {
         $root = realpath($this->getRootDir()) . DIRECTORY_SEPARATOR;
-        if (substr($path, 0, strlen($root)) == $root) {
+        if (substr($path, 0, strlen($root)) === $root) {
             return substr($path, strlen($root));
         }
         return $path;

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoAssert.php
@@ -36,7 +36,7 @@ class MagentoAssert extends \Codeception\Module
             $data = array_map('strtolower', $data);
         }
 
-        if ($sortOrder == "asc") {
+        if ($sortOrder === 'asc') {
             for ($i = 1; $i < $elementTotal; $i++) {
                 // $i >= $i-1
                 $this->assertLessThanOrEqual($data[$i], $data[$i-1], $message);

--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -222,7 +222,7 @@ class MagentoWebDriver extends WebDriver
     public function _getCurrentUri()
     {
         $url = $this->webDriver->getCurrentURL();
-        if ($url == 'about:blank') {
+        if ($url === 'about:blank') {
             throw new ModuleException($this, 'Current url is blank, no page was opened');
         }
 
@@ -509,7 +509,7 @@ class MagentoWebDriver extends WebDriver
      */
     public function mSetLocale(int $category, $locale)
     {
-        if (self::$localeAll[$category] == $locale) {
+        if (self::$localeAll[$category] === $locale) {
             return;
         }
         foreach (self::$localeAll as $c => $l) {
@@ -849,7 +849,7 @@ class MagentoWebDriver extends WebDriver
             }
         }
 
-        if ($this->current_test == null) {
+        if ($this->current_test === null) {
             throw new \RuntimeException("Suite condition failure: \n" . $fail->getMessage());
         }
 
@@ -869,7 +869,7 @@ class MagentoWebDriver extends WebDriver
     public function saveScreenshot()
     {
         $testDescription = "unknown." . uniqid();
-        if ($this->current_test != null) {
+        if ($this->current_test !== null) {
             $testDescription = Descriptor::getTestSignature($this->current_test);
         }
 

--- a/src/Magento/FunctionalTestingFramework/ObjectManager/Config/Mapper/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/ObjectManager/Config/Mapper/Dom.php
@@ -54,7 +54,7 @@ class Dom implements \Magento\FunctionalTestingFramework\Config\ConverterInterfa
         $output = [];
         /** @var \DOMNode $node */
         foreach ($config->documentElement->childNodes as $node) {
-            if ($node->nodeType != XML_ELEMENT_NODE) {
+            if ($node->nodeType !== XML_ELEMENT_NODE) {
                 continue;
             }
             switch ($node->nodeName) {
@@ -73,7 +73,7 @@ class Dom implements \Magento\FunctionalTestingFramework\Config\ConverterInterfa
                     if ($typeNodeShared) {
                         $typeData['shared'] = $this->booleanUtils->toBoolean($typeNodeShared->nodeValue);
                     }
-                    if ($node->nodeName == 'virtualType') {
+                    if ($node->nodeName === 'virtualType') {
                         $attributeType = $typeNodeAttributes->getNamedItem('type');
                         // attribute type is required for virtual type only in merged configuration
                         if ($attributeType) {
@@ -102,14 +102,14 @@ class Dom implements \Magento\FunctionalTestingFramework\Config\ConverterInterfa
 
         foreach ($node->childNodes as $typeChildNode) {
             /** @var \DOMNode $typeChildNode */
-            if ($typeChildNode->nodeType != XML_ELEMENT_NODE) {
+            if ($typeChildNode->nodeType !== XML_ELEMENT_NODE) {
                 continue;
             }
             switch ($typeChildNode->nodeName) {
                 case 'arguments':
                     /** @var \DOMNode $argumentNode */
                     foreach ($typeChildNode->childNodes as $argumentNode) {
-                        if ($argumentNode->nodeType != XML_ELEMENT_NODE) {
+                        if ($argumentNode->nodeType !== XML_ELEMENT_NODE) {
                             continue;
                         }
                         $argumentName = $argumentNode->attributes->getNamedItem('name')->nodeValue;

--- a/src/Magento/FunctionalTestingFramework/ObjectManager/Factory.php
+++ b/src/Magento/FunctionalTestingFramework/ObjectManager/Factory.php
@@ -84,7 +84,8 @@ class Factory extends \Magento\FunctionalTestingFramework\ObjectManager\Factory\
     {
         $type = get_class($object);
         $parameters = $this->classReader->getParameters($type, $method);
-        if ($parameters == null) {
+
+        if ($parameters === null) {
             return [];
         }
 
@@ -227,7 +228,8 @@ class Factory extends \Magento\FunctionalTestingFramework\ObjectManager\Factory\
     {
         $instanceType = $this->config->getInstanceType($requestedType);
         $parameters = $this->definitions->getParameters($instanceType);
-        if ($parameters == null) {
+
+        if ($parameters === null) {
             return new $instanceType();
         }
         if (isset($this->creationStack[$requestedType])) {

--- a/src/Magento/FunctionalTestingFramework/ObjectManager/Factory/Dynamic/Developer.php
+++ b/src/Magento/FunctionalTestingFramework/ObjectManager/Factory/Dynamic/Developer.php
@@ -178,7 +178,8 @@ class Developer implements \Magento\FunctionalTestingFramework\ObjectManager\Fac
     {
         $type = $this->config->getInstanceType($requestedType);
         $parameters = $this->definitions->getParameters($type);
-        if ($parameters == null) {
+
+        if ($parameters === null) {
             return new $type();
         }
         if (isset($this->creationStack[$requestedType])) {

--- a/src/Magento/FunctionalTestingFramework/Page/Handlers/PageObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Handlers/PageObjectHandler.php
@@ -66,7 +66,7 @@ class PageObjectHandler implements ObjectHandlerInterface
             $area = $pageData[self::AREA] ?? null;
             $url = $pageData[self::URL] ?? null;
 
-            if ($area == 'admin') {
+            if ($area === 'admin') {
                 $url = ltrim($url, "/");
             }
 

--- a/src/Magento/FunctionalTestingFramework/Page/Objects/ElementObject.php
+++ b/src/Magento/FunctionalTestingFramework/Page/Objects/ElementObject.php
@@ -75,9 +75,9 @@ class ElementObject
      */
     public function __construct($name, $type, $selector, $locatorFunction, $timeout, $parameterized, $deprecated = null)
     {
-        if ($selector != null && $locatorFunction != null) {
+        if ($selector !== null && $locatorFunction !== null) {
             throw new XmlException("Element '{$name}' cannot have both a selector and a locatorFunction.");
-        } elseif ($selector == null && $locatorFunction == null) {
+        } elseif ($selector === null && $locatorFunction === null) {
             throw new XmlException("Element '{$name}' must have either a selector or a locatorFunction.'");
         }
 
@@ -160,11 +160,11 @@ class ElementObject
      */
     public function getTimeout()
     {
-        if ($this->timeout == ElementObject::DEFAULT_TIMEOUT_SYMBOL) {
+        if ($this->timeout === ElementObject::DEFAULT_TIMEOUT_SYMBOL) {
             return null;
         }
 
-        return (int)$this->timeout;
+        return (int) $this->timeout;
     }
 
     /**

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/AnnotationsCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/AnnotationsCheck.php
@@ -173,8 +173,8 @@ class AnnotationsCheck implements StaticCheckInterface
         $skip = $annotations['skip'] ?? null;
         if ($skip !== null) {
             $validateSkipped = true;
-            if ((!isset($skip[0]) || strlen($skip[0]) == 0)
-                && (!isset($skip['issueId']) || strlen($skip['issueId']) == 0)) {
+            if ((!isset($skip[0]) || strlen($skip[0]) === 0)
+                && (!isset($skip['issueId']) || strlen($skip['issueId']) === 0)) {
                 $this->errors[][] = "Test {$test->getName()} is skipped but the issueId is empty.";
             }
         }

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/TestDependencyCheck.php
@@ -157,7 +157,7 @@ class TestDependencyCheck implements StaticCheckInterface
             $this->allEntities = [];
             $moduleName = $this->getModuleName($filePath);
             // Not a module, is either dev/tests/acceptance or loose folder with test materials
-            if ($moduleName == null) {
+            if ($moduleName === null) {
                 continue;
             }
 
@@ -219,7 +219,7 @@ class TestDependencyCheck implements StaticCheckInterface
         foreach ($modulesReferencedInTest as $entityName => $files) {
             $valid = false;
             foreach ($files as $module) {
-                if (array_key_exists($module, $moduleDependencies) || $module == $currentModule) {
+                if (array_key_exists($module, $moduleDependencies) || $module === $currentModule) {
                     $valid = true;
                     break;
                 }

--- a/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Generators/GroupClassGenerator.php
@@ -152,7 +152,7 @@ class GroupClassGenerator
             }
 
             // add these as vars to be created a class level in the template
-            if ($action->getType() == 'createData') {
+            if ($action->getType() === 'createData') {
                 $mustacheHookArray[self::MUSTACHE_VAR_TAG][] = [self::ENTITY_MERGE_KEY => $action->getStepKey()];
             }
 
@@ -213,7 +213,7 @@ class GroupClassGenerator
         $formattedStep = rtrim($formattedStep);
         foreach (self::REPLACEMENT_ACTIONS as $testAction => $replacement) {
             $testActionCall = "\${$actor}->{$testAction}";
-            if (substr($formattedStep, 0, strlen($testActionCall)) == $testActionCall) {
+            if (substr($formattedStep, 0, strlen($testActionCall)) === $testActionCall) {
                 $resultingStep = str_replace($testActionCall, $replacement, $formattedStep);
                 $actionEntries[] = ['action' => $resultingStep];
             } else {
@@ -278,7 +278,7 @@ class GroupClassGenerator
                 continue;
             }
 
-            if ($attribute[ActionObjectExtractor::NODE_NAME] == 'requiredEntity') {
+            if ($attribute[ActionObjectExtractor::NODE_NAME] === 'requiredEntity') {
                 $requiredEntities[] = [self::ENTITY_NAME_TAG => $attribute[TestGenerator::REQUIRED_ENTITY_REFERENCE]];
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Suite/Handlers/SuiteObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Handlers/SuiteObjectHandler.php
@@ -62,7 +62,7 @@ class SuiteObjectHandler implements ObjectHandlerInterface
      */
     public static function getInstance(): ObjectHandlerInterface
     {
-        if (self::$instance == null) {
+        if (self::$instance === null) {
             self::$instance = new SuiteObjectHandler();
             self::$instance->initSuiteData();
         }

--- a/src/Magento/FunctionalTestingFramework/Suite/SuiteGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/SuiteGenerator.php
@@ -206,7 +206,7 @@ class SuiteGenerator
             $this->appendEntriesToConfig($suiteName, $fullPath, $groupNamespace);
 
             if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
                 print("suite {$suiteName} generated\n");
             }
             LoggingUtil::getInstance()->getLogger(self::class)->info(
@@ -304,7 +304,7 @@ class SuiteGenerator
         } else {
             $suiteObject = SuiteObjectHandler::getInstance()->getObject($suiteName);
             // we have to handle the case when there is a custom configuration for an existing suite.
-            if (count($suiteObject->getTests()) != count($tests)) {
+            if (count($suiteObject->getTests()) !== count($tests)) {
                 return $this->generateGroupFile($suiteName, $tests, $suiteName);
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Suite/Util/SuiteObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Suite/Util/SuiteObjectExtractor.php
@@ -92,7 +92,7 @@ class SuiteObjectExtractor extends BaseObjectExtractor
                 $includeTests = $include['objects'] ?? [];
                 $stepError = $include['status'] ?? 0;
                 $includeMessage = '';
-                if ($stepError != 0) {
+                if ($stepError !== 0) {
                     $includeMessage = "ERROR: " . strval($stepError) . " test(s) not included for suite "
                         . $parsedSuite[self::NAME];
                 }
@@ -127,7 +127,8 @@ class SuiteObjectExtractor extends BaseObjectExtractor
                 if (!empty($includeMessage)) {
                     LoggingUtil::getInstance()->getLogger(self::class)->error($includeMessage);
                     if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                        && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                        && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE
+                    ) {
                         print($includeMessage);
                     }
 
@@ -145,7 +146,7 @@ class SuiteObjectExtractor extends BaseObjectExtractor
                     "Unable to parse suite " . $parsedSuite[self::NAME] . "\n" . $e->getMessage()
                 );
                 if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                    && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                    && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
                     print("ERROR: Unable to parse suite " . $parsedSuite[self::NAME] . "\n");
                 }
 
@@ -183,7 +184,7 @@ class SuiteObjectExtractor extends BaseObjectExtractor
     {
         //check if name used is using special char or the "default" reserved name
         NameValidationUtil::validateName($parsedSuite[self::NAME], 'Suite');
-        if ($parsedSuite[self::NAME] == 'default') {
+        if ($parsedSuite[self::NAME] === 'default') {
             throw new FastFailException("A Suite can not have the name \"default\"");
         }
 
@@ -235,7 +236,7 @@ class SuiteObjectExtractor extends BaseObjectExtractor
             $suiteHooks[TestObjectExtractor::TEST_AFTER_HOOK] = $hookObject;
         }
 
-        if (count($suiteHooks) == 1) {
+        if (count($suiteHooks) === 1) {
             throw new XmlException(sprintf(
                 "Suites that contain hooks must contain both a 'before' and an 'after' hook. Suite: \"%s\"",
                 $parsedSuite[self::NAME]
@@ -254,7 +255,7 @@ class SuiteObjectExtractor extends BaseObjectExtractor
      */
     private function isSuiteEmpty($suiteHooks, $includeTests, $excludeTests)
     {
-        $noHooks = count($suiteHooks) == 0 ||
+        $noHooks = count($suiteHooks) === 0 ||
             (
                 empty($suiteHooks['before']->getActions()) &&
                 empty($suiteHooks['after']->getActions())

--- a/src/Magento/FunctionalTestingFramework/Test/Config/Converter/Dom/Flat.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/Converter/Dom/Flat.php
@@ -77,7 +77,7 @@ class Flat implements ConverterInterface
         $value = [];
         /** @var \DOMNode $node */
         foreach ($source->childNodes as $node) {
-            if ($node->nodeType == XML_ELEMENT_NODE) {
+            if ($node->nodeType === XML_ELEMENT_NODE) {
                 $nodeName = $node->nodeName;
                 $nodePath = $basePath . '/' . $nodeName;
                 $arrayKeyAttribute = $this->arrayNodeConfig->getAssocArrayKeyAttribute($nodePath);
@@ -90,7 +90,7 @@ class Flat implements ConverterInterface
                     );
                 }
 
-                if ($nodeName == self::REMOVE_ACTION) {
+                if ($nodeName === self::REMOVE_ACTION) {
                     // Check to see if the test extends for this remove action
                     $parentHookExtends = in_array($node->parentNode->nodeName, self::TEST_HOOKS)
                         && !empty($node->parentNode->parentNode->getAttribute('extends'));
@@ -121,12 +121,12 @@ class Flat implements ConverterInterface
                 } else {
                     $value[$nodeName] = $nodeData;
                 }
-            } elseif ($node->nodeType == XML_CDATA_SECTION_NODE
-                || ($node->nodeType == XML_TEXT_NODE && trim($node->nodeValue) != '')
+            } elseif ($node->nodeType === XML_CDATA_SECTION_NODE
+                || ($node->nodeType === XML_TEXT_NODE && trim($node->nodeValue) !== '')
             ) {
                 $value = $node->nodeValue;
                 break;
-            } elseif ($node->nodeType == XML_COMMENT_NODE &&
+            } elseif ($node->nodeType === XML_COMMENT_NODE &&
                 in_array($node->parentNode->nodeName, self::VALID_COMMENT_PARENT)) {
                 $uniqid = uniqid($node->nodeName);
                 $value[$uniqid] = [
@@ -163,7 +163,7 @@ class Flat implements ConverterInterface
         $attributes = $node->attributes ?: [];
         /** @var \DOMNode $attribute */
         foreach ($attributes as $attribute) {
-            if ($attribute->nodeType == XML_ATTRIBUTE_NODE) {
+            if ($attribute->nodeType === XML_ATTRIBUTE_NODE) {
                 $result[$attribute->nodeName] = $attribute->nodeValue;
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Config/Dom.php
@@ -173,7 +173,7 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\MftfDom
         $childNodes = $testNode->childNodes;
         $previousStepKey = $insertKey;
         $actionInsertType = ActionObject::MERGE_ACTION_ORDER_AFTER;
-        if ($insertType == self::TEST_MERGE_POINTER_BEFORE) {
+        if ($insertType === self::TEST_MERGE_POINTER_BEFORE) {
             $actionInsertType = ActionObject::MERGE_ACTION_ORDER_BEFORE;
         }
         for ($i = 0; $i < $childNodes->length; $i++) {

--- a/src/Magento/FunctionalTestingFramework/Test/Handlers/ActionGroupObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Handlers/ActionGroupObjectHandler.php
@@ -151,9 +151,9 @@ class ActionGroupObjectHandler implements ObjectHandlerInterface
     private function extendActionGroup($actionGroupObject): ActionGroupObject
     {
         if ($actionGroupObject->getParentName() !== null) {
-            if ($actionGroupObject->getParentName() == $actionGroupObject->getName()) {
+            if ($actionGroupObject->getParentName() === $actionGroupObject->getName()) {
                 throw new TestFrameworkException(
-                    "Mftf Action Group can not extend from itself: " . $actionGroupObject->getName()
+                    'Mftf Action Group can not extend from itself: ' . $actionGroupObject->getName()
                 );
             }
             return $this->extendUtil->extendActionGroup($actionGroupObject);

--- a/src/Magento/FunctionalTestingFramework/Test/Handlers/TestObjectHandler.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Handlers/TestObjectHandler.php
@@ -124,7 +124,7 @@ class TestObjectHandler implements ObjectHandlerInterface
 
         if ($errCount > 0
             && MftfApplicationConfig::getConfig()->verboseEnabled()
-            && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+            && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
             print(
                 "ERROR: "
                 . strval($errCount)
@@ -173,7 +173,7 @@ class TestObjectHandler implements ObjectHandlerInterface
 
         if ($errCount > 0
             && MftfApplicationConfig::getConfig()->verboseEnabled()
-            && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+            && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
             print(
                 "ERROR: "
                 . strval($errCount)
@@ -248,7 +248,7 @@ class TestObjectHandler implements ObjectHandlerInterface
                     "Unable to parse test " . $testName . "\n" . $exception->getMessage()
                 );
                 if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                    && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                    && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
                     print("ERROR: Unable to parse test " . $testName . "\n");
                 }
                 GenerationErrorHandler::getInstance()->addError(
@@ -276,7 +276,7 @@ class TestObjectHandler implements ObjectHandlerInterface
     private function extendTest($testObject)
     {
         if ($testObject->getParentName() !== null) {
-            if ($testObject->getParentName() == $testObject->getName()) {
+            if ($testObject->getParentName() === $testObject->getName()) {
                 throw new TestFrameworkException(
                     "Mftf Test can not extend from itself: " . $testObject->getName()
                 );

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionGroupObject.php
@@ -239,7 +239,7 @@ class ActionGroupObject
                 $action->getStepKey() . ucfirst($actionReferenceKey),
                 $action->getType(),
                 array_replace_recursive($resolvedActionAttributes, $newActionAttributes),
-                $action->getLinkedAction() == null ? null : $action->getLinkedAction() . ucfirst($actionReferenceKey),
+                $action->getLinkedAction() === null ? null : $action->getLinkedAction() . ucfirst($actionReferenceKey),
                 $orderOffset,
                 [self::ACTION_GROUP_ORIGIN_NAME => $this->name,
                     self::ACTION_GROUP_ORIGIN_TEST_REF => $actionReferenceKey],
@@ -531,7 +531,7 @@ class ActionGroupObject
         $matchedArgument = array_filter(
             $argumentList,
             function ($e) use ($name) {
-                return $e->getName() == $name;
+                return $e->getName() === $name;
             }
         );
         if (isset(array_values($matchedArgument)[0])) {

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -290,7 +290,7 @@ class ActionObject
             $this->resolveUrlReference();
             $this->resolveDataInputReferences();
             $this->validateTimezoneAttribute();
-            if ($this->getType() == "deleteData") {
+            if ($this->getType() === "deleteData") {
                 $this->validateMutuallyExclusiveAttributes(self::DELETE_DATA_MUTUAL_EXCLUSIVE_ATTRIBUTES);
             }
         }
@@ -561,24 +561,24 @@ class ActionObject
                 continue;
             }
 
-            if ($obj == null) {
+            if ($obj === null) {
                 // keep initial values for subsequent logic
                 $replacement = null;
                 $parameterized = false;
-            } elseif (get_class($obj) == PageObject::class) {
+            } elseif (get_class($obj) === PageObject::class) {
                 if ($obj->getDeprecated() !== null) {
                     $this->deprecatedUsage[] = "DEPRECATED PAGE in Test: " . $match . ' ' . $obj->getDeprecated();
                 }
                 $this->validateUrlAreaAgainstActionType($obj);
                 $replacement = $obj->getUrl();
                 $parameterized = $obj->isParameterized();
-            } elseif (get_class($obj) == SectionObject::class) {
+            } elseif (get_class($obj) === SectionObject::class) {
                 if ($obj->getDeprecated() !== null) {
                     $this->deprecatedUsage[] = "DEPRECATED SECTION in Test: " . $match . ' ' . $obj->getDeprecated();
                 }
                 list(,$objField) = $this->stripAndSplitReference($match);
 
-                if ($obj->getElement($objField) == null) {
+                if ($obj->getElement($objField) === null) {
                     throw new TestReferenceException(
                         "Could not resolve entity reference \"{$inputString}\" "
                         . "in Action with stepKey \"{$this->getStepKey()}\"",
@@ -592,7 +592,7 @@ class ActionObject
                     $this->deprecatedUsage[] = "DEPRECATED ELEMENT in Test: " . $match . ' '
                         . $obj->getElement($objField)->getDeprecated();
                 }
-            } elseif (get_class($obj) == EntityDataObject::class) {
+            } elseif (get_class($obj) === EntityDataObject::class) {
                 if ($obj->getDeprecated() !== null) {
                     $this->deprecatedUsage[] = "DEPRECATED DATA ENTITY in Test: "
                         . $match . ' ' . $obj->getDeprecated();
@@ -638,7 +638,7 @@ class ActionObject
                 . implode("', '", $attributes) . "'",
                 ["type" => $this->getType(), "attributes" => $attributes]
             );
-        } elseif (count($matches) == 0) {
+        } elseif (count($matches) === 0) {
             throw new TestReferenceException(
                 "Actions of type '{$this->getType()}' must contain at least one attribute of types '"
                 . implode("', '", $attributes) . "'",
@@ -656,7 +656,7 @@ class ActionObject
      */
     private function validateUrlAreaAgainstActionType($obj)
     {
-        if ($obj->getArea() == 'external' &&
+        if ($obj->getArea() === 'external' &&
             in_array($this->getType(), self::EXTERNAL_URL_AREA_INVALID_ACTIONS)) {
             throw new TestReferenceException(
                 "Page of type 'external' is not compatible with action type '{$this->getType()}'",
@@ -697,7 +697,7 @@ class ActionObject
     {
         list(,$objField) = $this->stripAndSplitReference($match);
 
-        if (strpos($objField, '[') == true) {
+        if (strpos($objField, '[') === true) {
             // Access <array>...</array>
             $parts = explode('[', $objField);
             $name = $parts[0];
@@ -726,7 +726,7 @@ class ActionObject
         } else {
             $resolvedReplacement = $replacement;
         }
-        if (get_class($object) == PageObject::class && $object->getArea() == PageObject::ADMIN_AREA) {
+        if (get_class($object) === PageObject::class && $object->getArea() === PageObject::ADMIN_AREA) {
             $urlSegments = [
                 '{{_ENV.MAGENTO_BACKEND_BASE_URL}}',
                 '{{_ENV.MAGENTO_BACKEND_NAME}}',
@@ -794,7 +794,7 @@ class ActionObject
         if (count($matches) > count($parameters)) {
             if (is_array($parameters)) {
                 $parametersGiven = implode(",", $parameters);
-            } elseif ($parameters == null) {
+            } elseif ($parameters === null) {
                 $parametersGiven = "NONE";
             } else {
                 $parametersGiven = $parameters;
@@ -810,7 +810,7 @@ class ActionObject
                 $reference . ". Parameters Given: " . implode(", ", $parameters),
                 ["reference" => $reference, "parametersGiven" => $parameters]
             );
-        } elseif (count($matches) == 0) {
+        } elseif (count($matches) === 0) {
             throw new TestReferenceException(
                 "Parameter Resolution Failed: No parameter matches found in parameterized element with selector " .
                 $reference,

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/ActionObject.php
@@ -290,7 +290,7 @@ class ActionObject
             $this->resolveUrlReference();
             $this->resolveDataInputReferences();
             $this->validateTimezoneAttribute();
-            if ($this->getType() === "deleteData") {
+            if ($this->getType() === 'deleteData') {
                 $this->validateMutuallyExclusiveAttributes(self::DELETE_DATA_MUTUAL_EXCLUSIVE_ATTRIBUTES);
             }
         }
@@ -697,7 +697,7 @@ class ActionObject
     {
         list(,$objField) = $this->stripAndSplitReference($match);
 
-        if (strpos($objField, '[') === true) {
+        if (strpos($objField, '[') !== false) {
             // Access <array>...</array>
             $parts = explode('[', $objField);
             $name = $parts[0];

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -174,7 +174,7 @@ class TestObject
      */
     public function getCodeceptionName()
     {
-        if (strpos($this->name, 'Cest') && substr($this->name, -4) == 'Cest') {
+        if (strpos($this->name, 'Cest') && substr($this->name, -4) === 'Cest') {
             return $this->name;
         }
 

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionMergeUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionMergeUtil.php
@@ -170,10 +170,10 @@ class ActionMergeUtil
 
         foreach ($mergedSteps as $key => $mergedStep) {
             /**@var ActionObject $mergedStep**/
-            if ($mergedStep->getType() == ActionObjectExtractor::ACTION_GROUP_TAG) {
+            if ($mergedStep->getType() === ActionObjectExtractor::ACTION_GROUP_TAG) {
                 $actionGroupRef = $mergedStep->getCustomActionAttributes()[ActionObjectExtractor::ACTION_GROUP_REF];
                 $actionGroup = ActionGroupObjectHandler::getInstance()->getObject($actionGroupRef);
-                if ($actionGroup == null) {
+                if ($actionGroup === null) {
                     throw new TestReferenceException("Could not find ActionGroup by ref \"{$actionGroupRef}\"");
                 }
                 $args = $mergedStep->getCustomActionAttributes()[ActionObjectExtractor::ACTION_GROUP_ARGUMENTS] ?? null;

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ActionObjectExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ActionObjectExtractor.php
@@ -90,7 +90,7 @@ class ActionObjectExtractor extends BaseObjectExtractor
             $actions = $this->extractFieldActions($actionData, $actions);
             $actionAttributes = $this->extractFieldReferences($actionData, $actionAttributes);
 
-            if ($linkedAction['stepKey'] != null) {
+            if ($linkedAction['stepKey'] !== null) {
                 $stepKeyRefs[$linkedAction['stepKey']][] = $stepKey;
             }
 
@@ -157,7 +157,7 @@ class ActionObjectExtractor extends BaseObjectExtractor
 
         $actionAttributeArgData = [];
         foreach ($actionAttributeData as $attributeDataKey => $attributeDataValues) {
-            if ($attributeDataKey == self::ACTION_GROUP_REF) {
+            if ($attributeDataKey === self::ACTION_GROUP_REF) {
                 $actionAttributeArgData[self::ACTION_GROUP_REF] = $attributeDataValues;
                 continue;
             }
@@ -187,7 +187,7 @@ class ActionObjectExtractor extends BaseObjectExtractor
 
         $actionAttributeArgData = [];
         foreach ($actionAttributeData as $attributeDataKey => $attributeDataValues) {
-            if (isset($attributeDataValues['nodeName']) && $attributeDataValues['nodeName'] == 'argument') {
+            if (isset($attributeDataValues['nodeName']) && $attributeDataValues['nodeName'] === 'argument') {
                 if (isset($attributeDataValues['name'])
                     && in_array($attributeDataValues['name'], $reservedHelperVariableNames)) {
                     $message = 'Helper argument names ' . implode(',', $reservedHelperVariableNames);
@@ -225,7 +225,7 @@ class ActionObjectExtractor extends BaseObjectExtractor
         $fieldActions = [];
         foreach ($actionData as $type => $data) {
             // determine if field type is entity passed in
-            if (!is_array($data) || $data[self::NODE_NAME] != self::DATA_PERSISTENCE_CUSTOM_FIELD) {
+            if (!is_array($data) || $data[self::NODE_NAME] !== self::DATA_PERSISTENCE_CUSTOM_FIELD) {
                 continue;
             }
 
@@ -258,7 +258,8 @@ class ActionObjectExtractor extends BaseObjectExtractor
 
         $attributes = [];
         foreach ($actionAttributes as $attributeName => $attributeValue) {
-            if (!is_array($attributeValue) || $attributeValue[self::NODE_NAME] != self::DATA_PERSISTENCE_CUSTOM_FIELD) {
+            if (!is_array($attributeValue) ||
+                $attributeValue[self::NODE_NAME] !== self::DATA_PERSISTENCE_CUSTOM_FIELD) {
                 $attributes[$attributeName] = $attributeValue;
                 continue;
             }

--- a/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/AnnotationExtractor.php
@@ -77,14 +77,14 @@ class AnnotationExtractor extends BaseObjectExtractor
             }
             $annotationValues = [];
             // Only transform severity annotation
-            if ($annotationKey == "severity") {
+            if ($annotationKey === "severity") {
                 $annotationObjects[$annotationKey] = $this->transformAllureSeverityToMagento(
                     trim($annotationData[0][self::ANNOTATION_VALUE])
                 );
                 continue;
             }
 
-            if ($annotationKey == "skip") {
+            if ($annotationKey === "skip") {
                 $annotationData = $annotationData['issueId'];
                 if ($validateAnnotations) {
                     $this->validateSkippedIssues($annotationData, $filename);
@@ -182,7 +182,7 @@ class AnnotationExtractor extends BaseObjectExtractor
      */
     public function validateStoryTitleUniqueness()
     {
-        if (MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::EXECUTION_PHASE) {
+        if (MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::EXECUTION_PHASE) {
             return;
         }
 
@@ -197,7 +197,7 @@ class AnnotationExtractor extends BaseObjectExtractor
                 $message = "Story and Title annotation pairs is not unique in Tests {$tests}\n";
                 LoggingUtil::getInstance()->getLogger(self::class)->error($message);
                 if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                    && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                    && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
                     print('ERROR: ' . $message);
                 }
                 $testArray = explode(',', $tests);
@@ -220,7 +220,7 @@ class AnnotationExtractor extends BaseObjectExtractor
      */
     public function validateTestCaseIdTitleUniqueness()
     {
-        if (MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::EXECUTION_PHASE) {
+        if (MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::EXECUTION_PHASE) {
             return;
         }
 
@@ -235,7 +235,7 @@ class AnnotationExtractor extends BaseObjectExtractor
                 $message = "TestCaseId and Title pairs is not unique in Tests {$tests}\n";
                 LoggingUtil::getInstance()->getLogger(self::class)->error($message);
                 if (MftfApplicationConfig::getConfig()->verboseEnabled()
-                    && MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+                    && MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
                     print('ERROR: ' . $message);
                 }
                 $testArray = explode(',', $tests);

--- a/src/Magento/FunctionalTestingFramework/Test/Util/ObjectExtensionUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Util/ObjectExtensionUtil.php
@@ -98,7 +98,7 @@ class ObjectExtensionUtil
     {
         // Check to see if the parent action group exists
         $parentActionGroup = ActionGroupObjectHandler::getInstance()->getObject($actionGroupObject->getParentName());
-        if ($parentActionGroup == null) {
+        if ($parentActionGroup === null) {
             throw new XmlException(
                 "Parent Action Group " .
                 $actionGroupObject->getParentName() .
@@ -200,7 +200,7 @@ class ObjectExtensionUtil
 
         // remove actions merged that are of type 'remove'
         foreach ($actions as $actionName => $actionData) {
-            if ($actionData->getType() != "remove") {
+            if ($actionData->getType() !== 'remove') {
                 $cleanedActions[$actionName] = $actionData;
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Upgrade/UpdateAssertionSchema.php
+++ b/src/Magento/FunctionalTestingFramework/Upgrade/UpdateAssertionSchema.php
@@ -104,9 +104,9 @@ class UpdateAssertionSchema implements UpgradeInterface
                 $value = rtrim(ltrim($value, "'"), "'");
             }
             // If value is empty string (" " or ' '), trim again to become empty
-            if (str_replace(" ", "", $value) == "''") {
+            if (str_replace(" ", "", $value) === "''") {
                 $value = "";
-            } elseif (str_replace(" ", "", $value) == '""') {
+            } elseif (str_replace(" ", "", $value) === '""') {
                 $value = "";
             }
 
@@ -119,20 +119,20 @@ class UpdateAssertionSchema implements UpgradeInterface
             }
 
             // Store in subtype for child element creation
-            if ($type == "actual") {
+            if ($type === "actual") {
                 $subElements["actual"]["value"] = $value;
-            } elseif ($type == "actualType") {
+            } elseif ($type === "actualType") {
                 $subElements["actual"]["type"] = $value;
-            } elseif ($type == "expected" or $type == "expectedValue") {
+            } elseif ($type === "expected" or $type === "expectedValue") {
                 $subElements["expected"]["value"] = $value;
-            } elseif ($type == "expectedType") {
+            } elseif ($type === "expectedType") {
                 $subElements["expected"]["type"] = $value;
             }
         }
         $newString .= ">\n";
 
         // Assert type is very edge-cased, completely different schema
-        if ($assertType == 'assertElementContainsAttribute') {
+        if ($assertType === 'assertElementContainsAttribute') {
             // assertElementContainsAttribute type defaulted to string if not present
             if (!isset($subElements["expected"]['type'])) {
                 $subElements["expected"]['type'] = "string";

--- a/src/Magento/FunctionalTestingFramework/Util/ComposerModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ComposerModuleResolver.php
@@ -48,7 +48,7 @@ class ComposerModuleResolver
             return $this->installedTestModules;
         }
 
-        if (!file_exists($rootComposerFile) || basename($rootComposerFile, '.json') != 'composer') {
+        if (!file_exists($rootComposerFile) || basename($rootComposerFile, '.json') !== 'composer') {
             throw new TestFrameworkException("Invalid root composer json file: {$rootComposerFile}");
         }
 
@@ -168,7 +168,7 @@ class ComposerModuleResolver
                     self::findComposerJsonFilesAtDepth($dir, $depth-1)
                 );
             }
-        } elseif ($depth == 0) {
+        } elseif ($depth === 0) {
             $jsonFileList = glob($directory . $jsonPattern);
             if ($jsonFileList === false) {
                 $jsonFileList = [];

--- a/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ConfigSanitizerUtil.php
@@ -43,16 +43,16 @@ class ConfigSanitizerUtil
      */
     private static function sanitizeSeleniumEnvs($config)
     {
-        if ($config['protocol'] == '%SELENIUM_PROTOCOL%') {
+        if ($config['protocol'] === '%SELENIUM_PROTOCOL%') {
             $config['protocol'] = "http";
         }
-        if ($config['host'] == '%SELENIUM_HOST%') {
+        if ($config['host'] === '%SELENIUM_HOST%') {
             $config['host'] = "127.0.0.1";
         }
-        if ($config['port'] == '%SELENIUM_PORT%') {
+        if ($config['port'] === '%SELENIUM_PORT%') {
             $config['port'] = "4444";
         }
-        if ($config['path'] == '%SELENIUM_PATH%') {
+        if ($config['path'] === '%SELENIUM_PATH%') {
             $config['path'] = "/wd/hub";
         }
         return $config;

--- a/src/Magento/FunctionalTestingFramework/Util/Logger/LoggingUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Logger/LoggingUtil.php
@@ -66,7 +66,7 @@ class LoggingUtil
      */
     public function getLogger($className): MftfLogger
     {
-        if ($className == null) {
+        if ($className === null) {
             throw new TestFrameworkException("You must pass a class name to receive a logger");
         }
 

--- a/src/Magento/FunctionalTestingFramework/Util/ModulePathExtractor.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModulePathExtractor.php
@@ -72,7 +72,7 @@ class ModulePathExtractor
     private function splitKeyForParts($key)
     {
         $parts = explode(self::SPLIT_DELIMITER, $key);
-        return count($parts) == 2 ? $parts : [];
+        return count($parts) === 2 ? $parts : [];
     }
 
     /**
@@ -90,7 +90,7 @@ class ModulePathExtractor
         }
 
         foreach ($this->testModulePaths as $key => $value) {
-            if (substr($path, 0, strlen($value)) == $value) {
+            if (substr($path, 0, strlen($value)) === $value) {
                 return $key;
             }
         }

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver.php
@@ -156,7 +156,7 @@ class ModuleResolver
     {
         $objectManager = \Magento\FunctionalTestingFramework\ObjectManagerFactory::getObjectManager();
 
-        if (MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::UNIT_TEST_PHASE) {
+        if (MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::UNIT_TEST_PHASE) {
             $this->sequenceSorter = $objectManager->get(AlphabeticSequenceSorter::class);
         } else {
             $this->sequenceSorter = $objectManager->get(SequenceSorterInterface::class);
@@ -175,7 +175,7 @@ class ModuleResolver
             return $this->enabledModules;
         }
 
-        if (MftfApplicationConfig::getConfig()->getPhase() == MftfApplicationConfig::GENERATION_PHASE) {
+        if (MftfApplicationConfig::getConfig()->getPhase() === MftfApplicationConfig::GENERATION_PHASE) {
             $this->printMagentoVersionInfo();
         }
 
@@ -338,8 +338,8 @@ class ModuleResolver
         // Filter array by enabled modules
         foreach ($objectArray as $path => $modules) {
             if (!array_diff($modules, $filterArray)
-                || (count($modules) == 1 && isset($this->knownDirectories[$modules[0]]))) {
-                if (count($modules) == 1) {
+                || (count($modules) === 1 && isset($this->knownDirectories[$modules[0]]))) {
+                if (count($modules) === 1) {
                     $oneToOneArray[$path] = $modules[0];
                 } else {
                     $oneToManyArray[$path] = $modules;

--- a/src/Magento/FunctionalTestingFramework/Util/ModuleResolver/ModuleResolverService.php
+++ b/src/Magento/FunctionalTestingFramework/Util/ModuleResolver/ModuleResolverService.php
@@ -162,11 +162,11 @@ class ModuleResolverService
      */
     private static function globRelevantWrapper(string $testPath, string $pattern): array
     {
-        if ($pattern == "") {
+        if ($pattern === '') {
             return glob($testPath . '*' . DIRECTORY_SEPARATOR . '*' . $pattern);
         }
 
-        $subDirectory = "*" . DIRECTORY_SEPARATOR;
+        $subDirectory = '*' . DIRECTORY_SEPARATOR;
         $directories = glob($testPath . $subDirectory . $pattern, GLOB_ONLYDIR);
 
         foreach (glob($testPath . $subDirectory, GLOB_ONLYDIR) as $dir) {

--- a/src/Magento/FunctionalTestingFramework/Util/Script/ScriptUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Script/ScriptUtil.php
@@ -273,7 +273,7 @@ class ScriptUtil
      */
     public function findEntity($name)
     {
-        if ($name == '_ENV' || $name == '_CREDS') {
+        if ($name === '_ENV' || $name === '_CREDS') {
             return null;
         }
 

--- a/src/Magento/FunctionalTestingFramework/Util/Sorter/ParallelGroupSorter.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Sorter/ParallelGroupSorter.php
@@ -37,7 +37,7 @@ class ParallelGroupSorter
     public function getTestsGroupedBySize($suiteConfiguration, $testNameToSize, $time)
     {
         // we must have the lines argument in order to create the test groups
-        if ($time == 0) {
+        if ($time === 0) {
             throw new FastFailException(
                 "Please provide the argument '--time' to the robo command in order to".
                 " generate grouped tests manifests for a parallel execution"
@@ -139,7 +139,7 @@ class ParallelGroupSorter
         $ceilSuiteGroupNumber = ceil($maxSuiteTime / $minGroupTime);
         $ceilSuiteGroupTime = max(ceil($maxSuiteTime / $ceilSuiteGroupNumber), $minGroupTime);
         $floorSuiteGroupNumber = floor($maxSuiteTime / $minGroupTime);
-        if ($floorSuiteGroupNumber != 0) {
+        if ($floorSuiteGroupNumber !== 0) {
             $floorSuiteGroupTime = max(ceil($maxSuiteTime / $floorSuiteGroupNumber), $minGroupTime);
         }
 
@@ -148,7 +148,7 @@ class ParallelGroupSorter
         $ceilSuiteGroupTotal = array_sum($ceilSuiteNameToGroupCount);
         $ceilTestGroupTotal = $groupTotal - $ceilSuiteGroupTotal;
 
-        if ($ceilTestGroupTotal == 0) {
+        if ($ceilTestGroupTotal === 0) {
             $ceilTestGroupTime = 0;
         } else {
             $ceilTestGroupTime = ceil(array_sum($testNameToSize) / $ceilTestGroupTotal);
@@ -157,7 +157,7 @@ class ParallelGroupSorter
         // Set suite group total to ceiling
         $suiteNameToGroupCount = $ceilSuiteNameToGroupCount;
 
-        if (isset($floorSuiteGroupTime) && $ceilSuiteGroupTime != $floorSuiteGroupTime) {
+        if (isset($floorSuiteGroupTime) && $ceilSuiteGroupTime !== $floorSuiteGroupTime) {
             // Calculate test group time for floor
             $floorSuiteNameToGroupCount = $this->getSuiteGroupCountFromGroupTime(
                 $suiteNameToTestSize,
@@ -165,7 +165,7 @@ class ParallelGroupSorter
             );
             $floorSuiteGroupTotal = array_sum($floorSuiteNameToGroupCount);
             $floorTestGroupTotal = $groupTotal - $floorSuiteGroupTotal;
-            if ($floorTestGroupTotal == 0) {
+            if ($floorTestGroupTotal === 0) {
                 $floorTestGroupTime = 0;
             } else {
                 $floorTestGroupTime = ceil(array_sum($testNameToSize) / $floorTestGroupTotal);
@@ -243,7 +243,7 @@ class ParallelGroupSorter
         $groups = [];
         foreach ($suiteNameToTestSize as $suiteName => $suiteTests) {
             $suiteCnt = $suiteNameToGroupCount[$suiteName];
-            if ($suiteCnt == 1) {
+            if ($suiteCnt === 1) {
                 $groups[][$suiteName] = array_sum($suiteTests);
                 $this->addSuiteToConfig($suiteName, null, $suiteTests);
             } elseif ($suiteCnt > 1) {
@@ -457,7 +457,7 @@ class ParallelGroupSorter
      */
     private function addSuiteToConfig($originalSuiteName, $newSuiteName, $tests)
     {
-        if ($newSuiteName == null) {
+        if ($newSuiteName === null) {
             $this->suiteConfig[$originalSuiteName] = array_keys($tests);
             return;
         }

--- a/src/Magento/FunctionalTestingFramework/Util/Sorter/ParallelGroupSorter.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Sorter/ParallelGroupSorter.php
@@ -146,7 +146,7 @@ class ParallelGroupSorter
         // Calculate test group time for ceiling
         $ceilSuiteNameToGroupCount = $this->getSuiteGroupCountFromGroupTime($suiteNameToTestSize, $ceilSuiteGroupTime);
         $ceilSuiteGroupTotal = array_sum($ceilSuiteNameToGroupCount);
-        $ceilTestGroupTotal = $groupTotal - $ceilSuiteGroupTotal;
+        $ceilTestGroupTotal = (int) $groupTotal - (int) $ceilSuiteGroupTotal;
 
         if ($ceilTestGroupTotal === 0) {
             $ceilTestGroupTime = 0;

--- a/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
+++ b/src/Magento/FunctionalTestingFramework/Util/TestGenerator.php
@@ -371,7 +371,7 @@ class TestGenerator
                 $this->debug("<comment>Finish creating test: " . $test->getCodeceptionName() . "</comment>" . PHP_EOL);
 
                 // Write to manifest here if manifest is not null
-                if ($testManifest != null) {
+                if ($testManifest !== null) {
                     $testManifest->addTest($test);
                 }
             } catch (FastFailException $e) {
@@ -460,7 +460,7 @@ class TestGenerator
 
         foreach ($annotationsObject as $annotationType => $annotationName) {
             //Remove conditional and output useCaseId upon completion of MQE-588
-            if ($annotationType == "useCaseId") {
+            if ($annotationType === 'useCaseId') {
                 continue;
             }
             if (!$isMethod) {
@@ -752,7 +752,7 @@ class TestGenerator
                 $time = $time ?? ActionObject::getDefaultWaitTimeout();
             }
 
-            if (isset($customActionAttributes['parameterArray']) && $actionObject->getType() != 'pressKey') {
+            if (isset($customActionAttributes['parameterArray']) && $actionObject->getType() !== 'pressKey') {
                 // validate the param array is in the correct format
                 $this->validateParameterArray($customActionAttributes['parameterArray']);
 
@@ -799,7 +799,7 @@ class TestGenerator
                     $function = trim($function, '"');
                 }
                 // turn $javaVariable => \$javaVariable but not {$mftfVariable}
-                if ($actionObject->getType() == "executeJS") {
+                if ($actionObject->getType() === "executeJS") {
                     $function = preg_replace('/(?<!{)(\$[A-Za-z._]+)(?![A-z.]*+\$)/', '\\\\$1', $function);
                 }
             }
@@ -905,7 +905,7 @@ class TestGenerator
 
                     $requiredEntityKeys = [];
                     foreach ($actionObject->getCustomActionAttributes() as $actionAttribute) {
-                        if (is_array($actionAttribute) && $actionAttribute['nodeName'] == 'requiredEntity') {
+                        if (is_array($actionAttribute) && $actionAttribute['nodeName'] === 'requiredEntity') {
                             //append ActionGroup if provided
                             $requiredEntityActionGroup = $actionAttribute['actionGroup'] ?? null;
                             $requiredEntityKeys[] = $actionAttribute['createDataKey'] . $requiredEntityActionGroup;
@@ -977,7 +977,7 @@ class TestGenerator
                     // Build array of requiredEntities
                     $requiredEntityKeys = [];
                     foreach ($actionObject->getCustomActionAttributes() as $actionAttribute) {
-                        if (is_array($actionAttribute) && $actionAttribute['nodeName'] == 'requiredEntity') {
+                        if (is_array($actionAttribute) && $actionAttribute['nodeName'] === 'requiredEntity') {
                             //append ActionGroup if provided
                             $requiredEntityActionGroup = $actionAttribute['actionGroup'] ?? null;
                             $requiredEntityKeys[] = $actionAttribute['createDataKey'] . $requiredEntityActionGroup;
@@ -1012,7 +1012,7 @@ class TestGenerator
                     // Build array of requiredEntities
                     $requiredEntityKeys = [];
                     foreach ($actionObject->getCustomActionAttributes() as $actionAttribute) {
-                        if (is_array($actionAttribute) && $actionAttribute['nodeName'] == 'requiredEntity') {
+                        if (is_array($actionAttribute) && $actionAttribute['nodeName'] === 'requiredEntity') {
                             $requiredEntityActionGroup = $actionAttribute['actionGroup'] ?? null;
                             $requiredEntityKeys[] = $actionAttribute['createDataKey'] . $requiredEntityActionGroup;
                         }
@@ -1587,7 +1587,7 @@ class TestGenerator
             $replacement = null;
             $delimiter = '$';
             $variable = $this->stripAndSplitReference($match, $delimiter);
-            if (count($variable) != 2) {
+            if (count($variable) !== 2) {
                 throw new \Exception(
                     "Invalid Persisted Entity Reference: {$match}.
                 Test persisted entity references must follow {$delimiter}entityStepKey.field{$delimiter} format."
@@ -1639,7 +1639,7 @@ class TestGenerator
      */
     private function resolveStepKeyReferences($input, $actionGroupOrigin, $matchAll = false)
     {
-        if ($actionGroupOrigin == null) {
+        if ($actionGroupOrigin === null) {
             return $input;
         }
         $output = $input;
@@ -1701,7 +1701,7 @@ class TestGenerator
         foreach ($allArguments as $argument) {
             $argument = trim($argument);
 
-            if ($argument[0] == self::ARRAY_WRAP_OPEN) {
+            if ($argument[0] === self::ARRAY_WRAP_OPEN) {
                 $replacement = $this->wrapParameterArray($this->addUniquenessToParamArray($argument));
             } elseif (is_numeric($argument)) {
                 $replacement = $argument;
@@ -1948,7 +1948,7 @@ class TestGenerator
      */
     private function wrapWithDoubleQuotes($input)
     {
-        if ($input == null) {
+        if ($input === null) {
             return '';
         }
         //Only replace &quot; with \" so that it doesn't break outer string.

--- a/src/Magento/FunctionalTestingFramework/Util/Validation/DuplicateNodeValidationUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Validation/DuplicateNodeValidationUtil.php
@@ -65,10 +65,10 @@ class DuplicateNodeValidationUtil
 
         $withoutDuplicates = array_unique($keyValues);
 
-        if (count($withoutDuplicates) != count($keyValues)) {
+        if (count($withoutDuplicates) !== count($keyValues)) {
             $duplicates = array_diff_assoc($keyValues, $withoutDuplicates);
             $keyError = "";
-            foreach ($duplicates as $duplicateKey => $duplicateValue) {
+            foreach ($duplicates as $duplicateValue) {
                 $keyError .= "\t{$this->uniqueKey}: {$duplicateValue} is used more than once.";
                 if ($parentKey !== null) {
                     $keyError .=" (Parent: {$parentKey})";

--- a/src/Magento/FunctionalTestingFramework/Util/Validation/SingleNodePerFileValidationUtil.php
+++ b/src/Magento/FunctionalTestingFramework/Util/Validation/SingleNodePerFileValidationUtil.php
@@ -43,7 +43,7 @@ class SingleNodePerFileValidationUtil
     {
         $tagNodes = $dom->getElementsByTagName($tag);
         $count = $tagNodes->length;
-        if ($count == 1) {
+        if ($count === 1) {
             return;
         }
 


### PR DESCRIPTION
### Description
In this PR loose comparison operators were changed to the strict comparison operators.
These changes apply to the next comparison operators:

1. == changed to ===
2. != changed to !==

**Reason of those changes:**
With the PHP RFC updates often changes rules of loose comparison operators interpretation. So, for each MFTF codebase update to the new PHP version, if there is any update in the loose comparison operators interpretation, we must check every line of code where such operators are used to clarify if those changes applies to our codebase. A lot easier to replace loose operators with the strict ones to eliminate such problems in the future.

**This PR doesn’t cover operations that perform non-strict comparisons with the next parts:**

- functions: in_array(), array_search() and array_keys() (without declaring strict types)
- sorting functions: sort(), rsort(), asort(), arsort() and array_multisort() (with $sort_flags set to SORT_REGULAR, which is the default) 

Those cases would be considered only if any build fails on them.

**I've run all Magento 2 MFTF tests for the CE, EE, B2B repositories on the current branch:**
<img width="1225" alt="Screenshot 2021-08-20 at 01 58 27" src="https://user-images.githubusercontent.com/31848341/130216410-0d4dd917-1f92-48f8-bec4-59e3e6de686e.png">
<img width="1225" alt="Screenshot 2021-08-20 at 01 57 36" src="https://user-images.githubusercontent.com/31848341/130216419-cd3b8bc4-a7ff-4e22-9149-f13ff702e7ad.png">

**All tests passed successfully:**
<img width="1339" alt="Screenshot 2021-08-20 at 12 58 42" src="https://user-images.githubusercontent.com/31848341/130216530-84ff075d-7acd-4cdf-ba0f-dfd55581feab.png">

https://github.com/magento/magento2/pull/33866

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/33780: [MFTF] Investigate and fix code affected by saner string to number comparisons #33780

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests