### PR TITLE
Fix encoding issue when secret key contains plus sign

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -571,7 +571,7 @@ class MagentoWebDriver extends WebDriver
             $apiURL,
             [
                 'token' => WebApiAuth::getAdminToken(),
-                getenv('MAGENTO_CLI_COMMAND_PARAMETER') => $command,
+                getenv('MAGENTO_CLI_COMMAND_PARAMETER') => urlencode($command),
                 'arguments' => $arguments,
                 'timeout'   => $timeout,
             ],


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

If some of the `REMOTE_STORAGE_` options contain `+` sign inside value the tests running will fail as here https://github.com/magento-commerce/magento2-functional-testing-framework/blob/develop/etc/config/command.php#L15 urldecode will remove pluses `+` from command and `setup:config:set --remote-storage-driver=...` will fail with `Too many arguments, expected arguments "command"`.

I got this issue as the current `REMOTE_STORAGE_AWSS3_SECRET_KEY` value contains two + signs.
I tried, with single quotes or double quotes but they are ignored and option values in command passing without quotes. 

For example, I’ve set:

`REMOTE_STORAGE_AWSS3_ACCESS_KEY='AKIAAFIELSFN+FNM7S2T+VORAXPQ'`

command.php received:

`php bin/magento setup:config:set ...  --remote-storage-key=AKIAAFIELSFN+FNM7S2T+VORAXPQ`

and after urldecode will be

`php bin/magento setup:config:set ...  --remote-storage-key=AKIAAFIELSFN FNM7S2T VORAXPQ`


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests