### PR TITLE
Mftf 877 missed php variables

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriverDoctor.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriverDoctor.php
@@ -91,8 +91,8 @@ class MagentoWebDriverDoctor extends MagentoWebDriver
                 $this->capabilities,
                 $this->connectionTimeoutInMs,
                 $this->requestTimeoutInMs,
-                $this->httpProxy,
-                $this->httpProxyPort
+                $this->webdriverProxy,
+                $this->webdriverProxyPort
             );
             if (null !== $this->remoteWebDriver) {
                 return;


### PR DESCRIPTION
MagentoWebDriverDoctor uses wrong variables for webdriver_proxy definition.

### Description
Fixed variable names in MagentoWebDriverDoctor

### Fixed Issues (if relevant)
1. magento/magento2-functional-testing-framework#877: mftf doctor produces php notices because of missed variables2. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [x ] All automated tests passed successfully (all builds on Travis CI are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests