### PR TITLE
Removes duplicate 'before' opening tag in MFTF CSS selectors example

### DIFF
--- a/docs/test-prep.md
+++ b/docs/test-prep.md
@@ -130,7 +130,6 @@ In this example `AdminProductFormSection` refers to the `<section>` in the XML f
             <group value="alex" />
         </annotations>
         <before>
-        <before>
             <!-- Login to Admin panel -->
             <amOnPage url="admin" stepKey="openAdminPanelPage" />
             <fillField selector="#username" userInput="admin" stepKey="fillLoginField" />


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Removes duplicate opening <before> tag in extracting CSS selectors example of MFTF test prep docs.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. No related issue

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [X] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests