### PR TITLE
Wait for cron process to finish properly

### DIFF
--- a/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
+++ b/src/Magento/FunctionalTestingFramework/Module/MagentoWebDriver.php
@@ -1033,6 +1033,10 @@ class MagentoWebDriver extends WebDriver
     {
         $cronGroups = array_filter($cronGroups);
 
+        if (isset($cronGroups[0]) && !isset($cronGroups[1])) {
+            $arguments .= ' --bootstrap=standaloneProcessStarted=1';
+        }
+
         $waitFor = $this->getCronWait($cronGroups);
 
         if ($waitFor) {


### PR DESCRIPTION
### Description
When running `bin/magento cron:run`, several background processes are spawned. The intent of the `<magentoCron />` XML node is to run certain cron groups to completion. However, as the actual processing may happen in a background process, the test-suite typically does not behave as expected. (This is a race condition; see https://github.com/magento/magento2/pull/37511 for further details.)

This pull request solves this race condition by using the internal 'bootstrap' argument to indicate that the cron process is already standalone. This means that no additional background processes will be run and the jobs complete in the foreground process. The test-suite will then wait for this process to terminate before proceeding. This is the desired behaviour.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/verification tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
 - [x] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests