### PR TITLE
Fixed PHP 8.2 deprecation warnings: 'creation of dynamic property'.

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Util/UnusedEntityCheckTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Util/UnusedEntityCheckTest.php
@@ -42,11 +42,11 @@ class UnusedEntityCheckTest extends MagentoTestCase
 
     public function testUnusedActiongroupFilesReturnedWhenActionXmlFilesAreNotEmpty()
     {
-        $this->scriptUtil = new ScriptUtil();
+        $scriptUtil = new ScriptUtil();
         $unusedEntityCheck = new UnusedEntityCheck();
         $domDocument = new \DOMDocument();
-        $modulePaths = $this->scriptUtil->getAllModulePaths();
-        $actionGroupXmlFiles = $this->scriptUtil->getModuleXmlFilesByScope($modulePaths, "ActionGroup");
+        $modulePaths = $scriptUtil->getAllModulePaths();
+        $actionGroupXmlFiles = $scriptUtil->getModuleXmlFilesByScope($modulePaths, "ActionGroup");
         $actionGroupFiles = ['DeprecationCheckActionGroup' =>
             '/verification/DeprecationCheckModule/ActionGroup/DeprecationCheckActionGroup.xml',
             'ActionGroupWithMultiplePausesActionGroup'=>
@@ -82,9 +82,9 @@ class UnusedEntityCheckTest extends MagentoTestCase
     public function testUnusedSectionFilesReturnedWhenSectionXmlFilesAreNotEmpty()
     {
         $unusedEntityCheck = new UnusedEntityCheck();
-        $this->scriptUtil = new ScriptUtil();
-        $modulePaths = $this->scriptUtil->getAllModulePaths();
-        $sectionXmlFiles = $this->scriptUtil->getModuleXmlFilesByScope($modulePaths, "Section");
+        $scriptUtil = new ScriptUtil();
+        $modulePaths = $scriptUtil->getAllModulePaths();
+        $sectionXmlFiles = $scriptUtil->getModuleXmlFilesByScope($modulePaths, "Section");
 
         $domDocument = new \DOMDocument();
         $section = [
@@ -119,9 +119,9 @@ class UnusedEntityCheckTest extends MagentoTestCase
     {
         $unusedEntityCheck = new UnusedEntityCheck();
         $domDocument = new \DOMDocument();
-        $this->scriptUtil = new ScriptUtil();
-        $modulePaths = $this->scriptUtil->getAllModulePaths();
-        $pageXmlFiles = $this->scriptUtil->getModuleXmlFilesByScope($modulePaths, "Page");
+        $scriptUtil = new ScriptUtil();
+        $modulePaths = $scriptUtil->getAllModulePaths();
+        $pageXmlFiles = $scriptUtil->getModuleXmlFilesByScope($modulePaths, "Page");
         $page = [
             'DeprecationCheckPage' => '/verification/DeprecationCheckModule/Page/DeprecationCheckPage.xml',
             'DeprecatedPage' => '/verification/TestModule/Page/DeprecatedPage.xml',
@@ -164,9 +164,9 @@ class UnusedEntityCheckTest extends MagentoTestCase
     {
         $unusedEntityCheck = new UnusedEntityCheck();
         $domDocument = new \DOMDocument();
-        $this->scriptUtil = new ScriptUtil();
-        $modulePaths = $this->scriptUtil->getAllModulePaths();
-        $dataXmlFiles = $this->scriptUtil->getModuleXmlFilesByScope($modulePaths, "Data");
+        $scriptUtil = new ScriptUtil();
+        $modulePaths = $scriptUtil->getAllModulePaths();
+        $dataXmlFiles = $scriptUtil->getModuleXmlFilesByScope($modulePaths, "Data");
         $data = [
             "simpleData" =>
             [

--- a/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
+++ b/src/Magento/FunctionalTestingFramework/Allure/Adapter/MagentoAllureAdapter.php
@@ -42,6 +42,12 @@ use Codeception\Event\TestEvent;
 class MagentoAllureAdapter extends AllureCodeception
 {
     const STEP_PASSED = "passed";
+
+    /**
+     * @var array
+     */
+    private $options = [];
+
     /**
      * Test files cache.
      *
@@ -184,7 +190,6 @@ class MagentoAllureAdapter extends AllureCodeception
         // Strip control characters so that report generation does not fail
         $stepName = preg_replace('/[[:cntrl:]]/', '', $stepName);
 
-        $this->emptyStep = false;
         $this->getLifecycle()->fire(new StepStartedEvent($stepName));
     }
 

--- a/src/Magento/FunctionalTestingFramework/Config/Reader.php
+++ b/src/Magento/FunctionalTestingFramework/Config/Reader.php
@@ -48,9 +48,9 @@ class Reader extends \Magento\FunctionalTestingFramework\Config\Reader\Filesyste
         $this->fileName = $fileName;
         $this->idAttributes = array_replace($this->idAttributes, $idAttributes);
         $this->schemaFile = $schemaLocator->getSchema();
-        $this->isValidated = $validationState->isValidated();
-        $this->perFileSchema = $schemaLocator->getPerFileSchema() &&
-        $this->isValidated ? $schemaLocator->getPerFileSchema() : null;
+        $isValidated = $validationState->isValidated();
+        $this->perFileSchema = $schemaLocator->getPerFileSchema() && $isValidated ?
+            $schemaLocator->getPerFileSchema() : null;
         $this->domDocumentClass = $domDocumentClass;
         $this->defaultScope = $defaultScope;
     }

--- a/src/Magento/FunctionalTestingFramework/ObjectManager/Config/Reader/Dom.php
+++ b/src/Magento/FunctionalTestingFramework/ObjectManager/Config/Reader/Dom.php
@@ -65,6 +65,6 @@ class Dom extends \Magento\FunctionalTestingFramework\Config\Reader\Filesystem
      */
     protected function _createConfigMerger($mergerClass, $initialContents)
     {
-        return new $mergerClass($initialContents, $this->_idAttributes, self::TYPE_ATTRIBUTE, $this->_perFileSchema);
+        return new $mergerClass($initialContents, $this->idAttributes, self::TYPE_ATTRIBUTE, $this->perFileSchema);
     }
 }

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/CreatedDataFromOutsideActionGroupCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/CreatedDataFromOutsideActionGroupCheck.php
@@ -61,6 +61,11 @@ class CreatedDataFromOutsideActionGroupCheck implements StaticCheckInterface
     private $scriptUtil;
 
     /**
+     * @var array
+     */
+    private $actionGroupXmlFile = [];
+
+    /**
      * Checks test dependencies, determined by references in tests versus the dependencies listed in the Magento module
      *
      * @param InputInterface $input

--- a/src/Magento/FunctionalTestingFramework/StaticCheck/UnusedEntityCheck.php
+++ b/src/Magento/FunctionalTestingFramework/StaticCheck/UnusedEntityCheck.php
@@ -38,6 +38,16 @@ class UnusedEntityCheck implements StaticCheckInterface
     private $scriptUtil;
 
     /**
+     * @var array
+     */
+    private $errors = [];
+
+    /**
+     * @var string
+     */
+    private $output = '';
+
+    /**
      * Checks test dependencies, determined by references in tests versus the dependencies listed in the Magento module
      *
      * @param  InputInterface $input
@@ -625,7 +635,7 @@ class UnusedEntityCheck implements StaticCheckInterface
     /**
      * Return output
      *
-     * @return array
+     * @return string
      */
     public function getOutput()
     {

--- a/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
+++ b/src/Magento/FunctionalTestingFramework/Test/Objects/TestObject.php
@@ -337,7 +337,7 @@ class TestObject
      */
     public function getCustomData()
     {
-        return $this->customData;
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Description
This fixes most PHP 8.2 deprecated usages of 'creation of dynamic property': https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties

The phpstan tool is able to find these problems:

```
$ /path/to/phpstan analyse --level=0 src | grep 'Access to an undefined property'
  66     Access to an undefined property Magento\FunctionalTestingFramework\Allure\Adapter\MagentoAllureAdapter::$options.
  67     Access to an undefined property Magento\FunctionalTestingFramework\Allure\Adapter\MagentoAllureAdapter::$options.
  187    Access to an undefined property Magento\FunctionalTestingFramework\Allure\Adapter\MagentoAllureAdapter::$emptyStep.
  51     Access to an undefined property Magento\FunctionalTestingFramework\Config\Reader::$isValidated.
  68     Access to an undefined property Magento\FunctionalTestingFramework\ObjectManager\Config\Reader\Dom::$_idAttributes.
  68     Access to an undefined property Magento\FunctionalTestingFramework\ObjectManager\Config\Reader\Dom::$_perFileSchema.
  75     Access to an undefined property Magento\FunctionalTestingFramework\StaticCheck\CreatedDataFromOutsideActionGroupCheck::$actionGroupXmlFile.
  133    Access to an undefined property Magento\FunctionalTestingFramework\StaticCheck\CreatedDataFromOutsideActionGroupCheck::$actionGroupXmlFile.
  49     Access to an undefined property Magento\FunctionalTestingFramework\StaticCheck\UnusedEntityCheck::$errors.
  50     Access to an undefined property Magento\FunctionalTestingFramework\StaticCheck\UnusedEntityCheck::$output.
  622    Access to an undefined property Magento\FunctionalTestingFramework\StaticCheck\UnusedEntityCheck::$errors.
  632    Access to an undefined property Magento\FunctionalTestingFramework\StaticCheck\UnusedEntityCheck::$output.
  340    Access to an undefined property Magento\FunctionalTestingFramework\Test\Objects\TestObject::$customData.

$ /path/to/phpstan analyse --level=0 dev | grep 'Access to an undefined property'
  45     Access to an undefined property tests\unit\Magento\FunctionalTestFramework\Util\UnusedEntityCheckTest::$scriptUtil.
  85     Access to an undefined property tests\unit\Magento\FunctionalTestFramework\Util\UnusedEntityCheckTest::$scriptUtil.
  122    Access to an undefined property tests\unit\Magento\FunctionalTestFramework\Util\UnusedEntityCheckTest::$scriptUtil.
  167    Access to an undefined property tests\unit\Magento\FunctionalTestFramework\Util\UnusedEntityCheckTest::$scriptUtil.
```

Since I'm not familiar with this MFTF tool, please review all changes carefully.

### Fixed Issues (if relevant)
1. https://github.com/magento/adobe-commerce-beta/issues/61

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests